### PR TITLE
Update site.html for Light Theme

### DIFF
--- a/templates/config/installation/site.html
+++ b/templates/config/installation/site.html
@@ -5,7 +5,7 @@ MediaCMS.site = {
     api: '{{FRONTEND_HOST}}/api/v1',
     topmessage: '{{TOP_MESSAGE}}',
     theme: {
-        mode: 'dark',    // Valid values: 'light', 'dark'.
+        mode: 'light',    // Valid values: 'light', 'dark'.
         switch: {
             position: 'sidebar',    // Valid values: 'header', 'sidebar'.
         },


### PR DESCRIPTION
For better Cinemata.org branding, and to popularise the Light Theme, which looks cool, too. I'm making the default theme to Light.

## Description
Makes the default look of CinemataCMS as Light Theme post-installation

## Related Issue
None. 

## Motivation and Context
For better Cinemata.org branding, and to popularise the Light Theme, which looks cool, too. I'm making the default theme to Light.


## How Has This Been Tested?
This has been tested weeks back in an Ubuntu VM running on a Mac 15.2.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
