### PR TITLE
Fix iframes not showing properly on staging

### DIFF
--- a/cms/settings.py
+++ b/cms/settings.py
@@ -459,6 +459,7 @@ TINYMCE_DEFAULT_CONFIG = {
     "paste_retain_style_properties": "all",
     "paste_remove_styles": False,
     "paste_merge_formats": True,
+    "sandbox_iframes": False,
 }
 
 # settings that are related with UX/appearance

--- a/files/admin.py
+++ b/files/admin.py
@@ -135,21 +135,15 @@ class MediaLanguageAdmin(admin.ModelAdmin):
 class PageAdminForm(forms.ModelForm):
     description = forms.CharField(widget=TinyMCE())
 
+    def clean_description(self):
+        content = self.cleaned_data['description']
+        # Add sandbox attribute to all iframes
+        content = content.replace('<iframe ', '<iframe sandbox="allow-scripts allow-same-origin allow-presentation" ')
+        return content
+
     class Meta:
         model = Page
         fields = "__all__"
-
-    def clean_description(self):
-        # Get the raw content from the description field
-        content = self.cleaned_data.get('description', '')
-
-        # Remove the <div class="custom-page-wrapper"> wrapper
-        content = re.sub(r'<div class="custom-page-wrapper">', '', content)
-        content = re.sub(r'</div>', '', content)
-
-        # Return the cleaned content
-        return content
-
 
 class PageAdmin(admin.ModelAdmin):
     form = PageAdminForm


### PR DESCRIPTION
- Added `sandbox` attribute to iframes within the TinyMCE editor to enhance security. The sandbox attribute restricts iframe capabilities, mitigating potential security risks.
- Set `sandbox_iframes` to `False` in TinyMCE config to prevent TinyMCE from automatically adding sandbox attributes. This allows manual control over iframe sandboxing.
- Modified PageAdminForm to automatically add the sandbox attribute to all iframes. The sandbox attribute includes "allow-scripts", "allow-same-origin", and "allow-presentation" permissions.

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- Please link to the issue here: -->
Fixes #(issue)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
