### PR TITLE
Add TranscriptionRequest Admin Interface for Whisper Re-transcription

### DIFF
--- a/docs/technical/media-processing/whisper-speech-reconition.md
+++ b/docs/technical/media-processing/whisper-speech-reconition.md
@@ -4,6 +4,51 @@ This explains how Whisper is integrated to transcribe the audio for subtitle gen
 
 ---
 
+## Admin Management
+
+### Re-running Failed Transcriptions
+
+To re-run Whisper transcription when it fails or needs updating:
+
+**Step 1: Delete Existing Subtitles First**
+Before deleting transcription requests, remove any existing subtitles:
+
+**Option A - Via Edit Media Interface:**
+1. Go to Edit Media page for your video
+2. Click "Edit Subtitle" 
+3. Delete existing subtitle files
+4. Look for "Auto-detect & Translate to English" subtitles and delete them
+
+**Option B - Via Django Admin:**
+1. Go to `/admin/files/subtitle/`
+2. Find subtitles for your media
+3. Delete the subtitle records
+
+**Step 2: Delete Transcription Requests**
+1. Go to `/admin/files/transcriptionrequest/`
+2. Find the failed transcription request(s)
+3. Select the checkbox(es) next to the requests
+4. Choose "Delete requests (enable retranscoding)" from the Actions dropdown
+5. Click "Go"
+6. You'll see a success message confirming deletion
+
+**Step 3: Retry Transcription**
+1. Go back to the Edit Media page
+2. The "Translate to English" checkbox should now be unchecked
+3. Check the transcription option you want and save
+4. Whisper will start processing again
+
+### TranscriptionRequest Admin Interface
+
+The admin interface provides:
+- **List View**: Media title, date, language, country, translation status
+- **Search**: Filter by media title
+- **Filters**: Translation status and date
+- **Bulk Actions**: Delete multiple requests at once
+- **Status Monitoring**: See all transcription requests in one place
+
+---
+
 ## Model Configuration
 
 CinemataCMS uses the **ggml-base.bin** model by default for optimal memory efficiency and broad compatibility. This model provides good transcription quality while using approximately 1GB of RAM.
@@ -153,6 +198,7 @@ ls -la /path/to/whisper.cpp/models/ggml-*.bin
 ### Manual Recovery
 - **Clear Stuck Tasks**: Restart Celery workers if tasks get stuck
 - **Model Switching**: Change to smaller model for memory-constrained systems
+- **Admin Interface**: Use `/admin/files/transcriptionrequest/` to manage failed requests
 
 ### Logging
 All transcription attempts are logged with:
@@ -196,5 +242,6 @@ whisper_cmd_conf = [
 - **File Storage**: VTT files stored in Django media storage
 - **User Notifications**: Integrated with CinemataCMS notification system
 - **API Integration**: Results accessible via Media API endpoints
+- **Admin Management**: Full admin interface for transcription request management
 
 For additional troubleshooting and advanced configuration, see the [Whisper.cpp Integration Fix Documentation](../technical/whisper-cpp-integration-fix.md).

--- a/files/admin.py
+++ b/files/admin.py
@@ -206,6 +206,14 @@ class TranscriptionRequestAdmin(admin.ModelAdmin):
         """Allow retranscoding by deleting transcription requests"""
         count = queryset.count()
         media_titles = [req.media.title for req in queryset if req.media]
+        
+        # Reset the Media model fields to allow retranscoding
+        for req in queryset:
+            if req.media:
+                req.media.allow_whisper_transcribe = False
+                req.media.allow_whisper_transcribe_and_translate = False
+                req.media.save(update_fields=['allow_whisper_transcribe', 'allow_whisper_transcribe_and_translate'])
+
         queryset.delete()
         
         if count == 1:


### PR DESCRIPTION
Resolves #106

## Description
Adds Django admin interface for managing Whisper transcription requests, enabling administrators to view, monitor, and re-run failed transcriptions without using Django shell commands.

## Problem Solved
- No way to view or manage transcription requests through admin interface
- Failed transcriptions required manual Django shell commands to reset
- No visibility into transcription status across media

## Changes Made

### Files Modified
- `files/admin.py` - Added TranscriptionRequestAdmin class

### Features Implemented
- **Admin Interface**: List display with Media Title, Add Date, Language, Country, Translation Status
- **Search and Filtering**: By media title, translation status, and date
- **Custom Display Methods**: Human-readable media title, language, and country names
- **Smart Bulk Actions**: Delete action that resets Media model fields and removes default Django delete
- **UI Fix**: Checkbox states properly reset after transcription request deletion

## Technical Implementation

### Admin Configuration
```python
class TranscriptionRequestAdmin(admin.ModelAdmin):
    list_display = ['media_title', 'add_date', 'language', 'country', 'translate_to_english']
    search_fields = ['media__title']
    list_filter = ['translate_to_english', 'add_date']
    readonly_fields = ['add_date']
    ordering = ['-add_date']
    actions = ['delete_selected_requests']
```

### Key Innovation
The custom delete action performs two operations:
1. Resets Media model fields (`allow_whisper_transcribe`, `allow_whisper_transcribe_and_translate`)
2. Deletes TranscriptionRequest records

This ensures the frontend Edit Media interface properly reflects the deletion.

## Testing
- **Environment**: Ubuntu 22.04, Python 3.10.12 with UV
- **Verified**: Admin interface access, display methods, bulk deletion, re-transcription flow
- **Confirmed**: UI properly updates after deletion, success messages work correctly

## User Experience
**Before**: 7-step manual process using Django shell
**After**: 4-step process through admin interface with automatic field resets

## Checklist
- [x] Code follows project style guidelines
- [x] Feature works as described in issue
- [x] No breaking changes to existing functionality
- [x] Comprehensive testing performed
- [x] Admin interface follows Django best practices