### PR TITLE
feat: Add USE_ROUNDED_CORNERS configuration option

### DIFF
--- a/cms/context_processors.py
+++ b/cms/context_processors.py
@@ -1,0 +1,7 @@
+from django.conf import settings
+
+def ui_settings(request):
+    """Add UI settings to template context"""
+    return {
+        'USE_ROUNDED_CORNERS': getattr(settings, 'USE_ROUNDED_CORNERS', True),
+    }

--- a/cms/settings.py
+++ b/cms/settings.py
@@ -77,6 +77,7 @@ TEMPLATES = [
                 "django.template.context_processors.media",
                 "django.contrib.messages.context_processors.messages",
                 "files.context_processors.stuff",
+                'cms.context_processors.ui_settings',
             ],
         },
     },
@@ -470,6 +471,9 @@ TINYMCE_DEFAULT_CONFIG = {
 # settings that are related with UX/appearance
 # whether a featured item appears enlarged with player on index page
 VIDEO_PLAYER_FEATURED_VIDEO_ON_INDEX_PAGE = False
+
+# Video UI/UX settings
+USE_ROUNDED_CORNERS = True  # Default: rounded corners enabled
 
 # allow option to override the default admin url
 DJANGO_ADMIN_URL = "admin/"

--- a/frontend/src/static/css/styles.scss
+++ b/frontend/src/static/css/styles.scss
@@ -1266,3 +1266,4 @@ input#authenticator_secret {
 .media-title-banner .media-actions .media-views {
 	margin-left: 0;
 }
+

--- a/templates/cms/user.html
+++ b/templates/cms/user.html
@@ -16,7 +16,28 @@
 {% block topimports %}
 <link href="{% static "css/profile-home.css" %}" rel="preload" as="style">
 <link href="{% static "css/profile-home.css" %}" rel="stylesheet">
-{%endblock topimports %}
+
+<!-- Admin user media: bottom corners only (fixes EDIT MEDIA button overlay) -->
+{% if USE_ROUNDED_CORNERS %}
+<style>
+    /* Use maximum CSS specificity to override existing styles */
+    body #page-profile-home .item-thumb,
+    body #page-profile-home .item.video-item {
+        border-radius: 0 0 6px 6px !important;
+        overflow: hidden !important;
+        -webkit-border-radius: 0 0 6px 6px !important; /* Safari fallback */
+    }
+
+    @media (max-width: 480px) {
+        body #page-profile-home .item-thumb,
+        body #page-profile-home .item.video-item {
+            border-radius: 0 !important;
+        }
+    }
+</style>
+{% endif %}
+
+{% endblock topimports %}
 
 {% block innercontent %}
 {% if user %}{% else %}

--- a/templates/root.html
+++ b/templates/root.html
@@ -23,8 +23,46 @@
 
         {% include "config/index.html" %}
 
-    {% endblock head %}
+         <!-- Rounded corners CSS (inline approach) -->
+        {% if USE_ROUNDED_CORNERS %}
+        <style>
+            /* Rounded Corners for Videos - CinematCMS */
+            .item-thumb,
+            a.item-thumb,
+            .item.video-item,
+            .item-content,
+            .video-js,
+            .video-player {
+                border-radius: 6px !important;
+                overflow: hidden;
+            }
 
+            @media (max-width: 767px) {
+                .item-thumb,
+                a.item-thumb,
+                .item.video-item,
+                .video-js,
+                .video-player {
+                    border-radius: 0 !important;
+                }
+            }
+        </style>
+        {% endif %}
+        
+        <!-- Rounded corners conditional override -->
+        {% if not USE_ROUNDED_CORNERS %}
+        <style>
+            .item-thumb,
+            a.item-thumb,
+            .item.video-item,
+            .item-content,
+            .video-js,
+            .video-player {
+                border-radius: 0 !important;
+            }
+        </style>
+        {% endif %}
+    {% endblock head %}
 </head>
 
 <body>


### PR DESCRIPTION
- Add USE_ROUNDED_CORNERS setting to control video element styling
- Create context processor to pass UI settings to templates
- Implement inline CSS approach for rounded corners on video elements
- Add responsive design (no rounded corners on mobile)
- Default: enabled (6px border radius on desktop)
- Can be disabled by setting USE_ROUNDED_CORNERS = False in local_settings.py

Uses inline CSS method following MediaCMS implementation pattern.

## Description
This replicates a feature from MediaCMS that was not integrated into CinemataCMS. Implementing it would be a good way to give a slightly new look to Cinemata. 

## Related Issue
<!--- Please link to the issue here: -->
Fixes #110 110

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested on Ubuntu 22.0.4 using Chrome, Brave and Firefox. 

## Screenshots (if appropriate):

<img width="2553" height="1486" alt="Screenshot from 2025-07-10 17-29-56" src="https://github.com/user-attachments/assets/2fb70fde-387f-4a8a-a864-906b1f586792" />
<img width="2553" height="1486" alt="Screenshot from 2025-07-10 17-29-45" src="https://github.com/user-attachments/assets/a49803ef-28ee-4541-9b55-8604edc16838" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
