### PR TITLE
Fix: Admin-Added Languages Appear in Frontend via Language Serializer

### DIFF
--- a/files/models.py
+++ b/files/models.py
@@ -27,6 +27,9 @@ from . import helpers, lists
 from .methods import is_mediacms_editor, is_mediacms_manager, notify_users, is_media_allowed_type
 from .stop_words import STOP_WORDS
 
+#
+from .language import Language
+
 logger = logging.getLogger(__name__)
 
 RE_TIMECODE = re.compile(r"(\d+:\d+:\d+.\d+)")
@@ -136,13 +139,13 @@ class Media(models.Model):
 
     description = models.TextField("More Information and Credits", blank=True)
     summary = models.TextField("Synopsis", help_text="Maximum 60 words")
-    media_language = models.CharField(
-        max_length=5,
-        blank=True,
-        null=True,
-        default="en",
-        choices=lists.video_languages,
-        db_index=True,
+    media_language = models.ForeignKey(
+    Language,
+    on_delete=models.SET_NULL,
+    null=True,
+    blank=True,
+    related_name="media_items",
+    verbose_name="Media Language",
     )
     media_country = models.CharField(
         max_length=5,

--- a/files/serializers.py
+++ b/files/serializers.py
@@ -6,6 +6,7 @@ from .models import (
     EncodeProfile,
     HomepagePopup,
     IndexPageFeatured,
+    Language,
     Media,
     MediaCountry,
     MediaLanguage,
@@ -25,6 +26,8 @@ class MediaSerializer(serializers.ModelSerializer):
     thumbnail_url = serializers.SerializerMethodField()
     author_profile = serializers.SerializerMethodField()
     author_thumbnail = serializers.SerializerMethodField()
+    media_language_info = LanguageSerializer(source="media_language", read_only=True)
+
 
     def get_url(self, obj):
         return self.context["request"].build_absolute_uri(obj.get_absolute_url())
@@ -94,10 +97,16 @@ class MediaSerializer(serializers.ModelSerializer):
             "year_produced",
         )
 
+class LanguageSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Language
+        fields = ["code", "title"]
 
 class SingleMediaSerializer(serializers.ModelSerializer):
     user = serializers.ReadOnlyField(source="user.username")
     url = serializers.SerializerMethodField()
+    media_language_info = LanguageSerializer(source="media_language", read_only=True)
+
 
     def get_url(self, obj):
         return self.context["request"].build_absolute_uri(obj.get_absolute_url())

--- a/fixtures/apac_languages.json
+++ b/fixtures/apac_languages.json
@@ -1,0 +1,218 @@
+[
+  {
+    "model": "files.language",
+    "pk": 1,
+    "fields": {
+      "code": "en",
+      "title": "English"
+    }
+  },
+  {
+    "model": "files.language", 
+    "pk": 2,
+    "fields": {
+      "code": "zh",
+      "title": "Chinese (Simplified)"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 3, 
+    "fields": {
+      "code": "zh-TW",
+      "title": "Chinese (Traditional)"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 4,
+    "fields": {
+      "code": "ja",
+      "title": "Japanese"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 5,
+    "fields": {
+      "code": "ko", 
+      "title": "Korean"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 6,
+    "fields": {
+      "code": "th",
+      "title": "Thai"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 7,
+    "fields": {
+      "code": "vi",
+      "title": "Vietnamese"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 8,
+    "fields": {
+      "code": "id",
+      "title": "Indonesian"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 9,
+    "fields": {
+      "code": "ms",
+      "title": "Malay"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 10,
+    "fields": {
+      "code": "tl",
+      "title": "Filipino"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 11,
+    "fields": {
+      "code": "hi",
+      "title": "Hindi"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 12,
+    "fields": {
+      "code": "ta",
+      "title": "Tamil"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 13,
+    "fields": {
+      "code": "bn",
+      "title": "Bengali"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 14,
+    "fields": {
+      "code": "ur",
+      "title": "Urdu"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 15,
+    "fields": {
+      "code": "pa",
+      "title": "Punjabi"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 16,
+    "fields": {
+      "code": "te",
+      "title": "Telugu"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 17,
+    "fields": {
+      "code": "kn",
+      "title": "Kannada"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 18,
+    "fields": {
+      "code": "ml",
+      "title": "Malayalam"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 19,
+    "fields": {
+      "code": "gu",
+      "title": "Gujarati"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 20,
+    "fields": {
+      "code": "mr",
+      "title": "Marathi"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 21,
+    "fields": {
+      "code": "ne",
+      "title": "Nepali"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 22,
+    "fields": {
+      "code": "si",
+      "title": "Sinhala"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 23,
+    "fields": {
+      "code": "my",
+      "title": "Myanmar (Burmese)"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 24,
+    "fields": {
+      "code": "km",
+      "title": "Khmer"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 25,
+    "fields": {
+      "code": "lo",
+      "title": "Lao"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 26,
+    "fields": {
+      "code": "automatic",
+      "title": "Automatic Detection"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 27,
+    "fields": {
+      "code": "automatic-translation",
+      "title": "Auto-detect & Translate to English"
+    }
+  }
+]


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- Please link to the issue here: -->
Fixes #90 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Changes Made
- Added LanguageSerializer to expose media_language_info in API.

- Included media_language_info field in both MediaSerializer and SingleMediaSerializer.

- Used source="media_language" with read_only=True to properly serialize related ForeignKey data.

- Language model (Language) is used instead of deprecated lists.video_languages.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

🛠 Backend Functional
- Can load 27 languages via fixture apac_languages.json

- media_language_info shows { "code": ..., "title": ... } format

- No duplicate language error when re-loading fixture

- Language dropdown shows updated list in admin + upload form

🌐 Frontend Display
- Language dropdown appears in upload form

- Filtering by language in sidebar works

- Language shows correctly on Media Page

- Whisper detection and auto-translate languages selectable

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
