### PR TITLE
Fix: Reduce TinyMCE content width for improved readability

### DIFF
--- a/frontend/src/static/css/_extra.css
+++ b/frontend/src/static/css/_extra.css
@@ -1958,7 +1958,7 @@ body.dark_theme .manage-users-item .mi-name > a {
     padding-right: 8px !important; */
     padding-top: 32px !important;
     padding-bottom: 64px !important;
-    width: 1366px;
+    width: 800px;
     /* width: 1448px; */
     max-width: 100%;
 }

--- a/static/css/_extra.css
+++ b/static/css/_extra.css
@@ -1,1 +1,3433 @@
-body{--body-bg-color:#f8ffff!important;--body-text-color:#000!important;--default-logo-height:50px!important;--header-height:90px!important;--default-theme-color:#1a3f61!important;--default-brand-color:#e7a27b!important;--header-bg-color:#122536!important;--sidebar-bg-color:#dfeff4!important;--sidebar-nav-border-color:#d5e9ee!important;--nav-menu-active-item-bg-color:#cbdde5!important;--default-item-width:372px!important;--default-max-item-width:372px!important;--default-max-row-items:4!important;--default-item-margin-right-width:27px!important;--default-item-margin-bottom-width:27px!important;--item-title-line-height:20px!important;--default-horizontal-item-margin-bottom-width:29px!important;--horizontal-item-title-line-height:20px;--sidebar-nav-item-icon-color:#1a3f61!important;--sidebar-nav-item-icon-color-active:#7bbbbf!important;--header-popup-menu-icon-color:#869ea5!important}body.dark_theme{--body-text-color:#fff!important;--body-bg-color:#101a24!important;--default-theme-color:#659ba0!important;--default-brand-color:#e7a27b!important;--header-bg-color:#122536!important;--sidebar-bg-color:#0f2230!important;--sidebar-nav-border-color:#182b39!important;--nav-menu-active-item-bg-color:#163652!important;--nav-menu-item-hover-bg-color:#163652!important;--sidebar-nav-item-icon-color:#026691!important;--media-actions-more-options-popup-bg-color:#0b3145!important;--popup-bg-color:#0b3145!important;--header-popup-menu-icon-color:#bad8dd!important;--media-actions-share-copy-field-border-color:#0f1a25!important;--media-actions-share-copy-field-bg-color:#101a24!important;--share-embed-inner-textarea-text-color:hsla(0,0%,100%,.88)!important;--share-embed-inner-textarea-border-color:#0f1a25!important;--share-embed-inner-textarea-bg-color:#101a24!important;--input-border-color:#0f1a25!important;--input-bg-color:#101a24!important;--add-media-page-tmplt-uploader-bg-color:#0b3145!important}html body{font-family:Amulya,Arial,sans-serif}html body .h1,html body .h2,html body .h3,html body .h4,html body .h5,html body .h6,html body h1,html body h2,html body h3,html body h4,html body h5,html body h6{font-family:Facultad,Arial,sans-serif}a{color:#3385a6}body.dark_theme a{color:#659ba0}body.dark_theme .top-message--text a{color:#fff}body .auto-play-header .checkbox-switcher-wrap{width:30px}body .auto-play-header .checkbox-switcher-wrap .checkbox-switcher{height:20px}body .auto-play-header .checkbox-switcher-wrap .checkbox-switcher input[type=checkbox]:after{height:14px;width:14px}body .auto-play-header .checkbox-switcher-wrap .checkbox-switcher input[type=checkbox]:checked:after{background:var(--body-bg-color)}body .auto-play-header .checkbox-switcher{height:14px}body .auto-play-header .checkbox-switcher input[type=checkbox]:before{background:rgba(186,216,221,.4);border-radius:99em}body .auto-play-header .checkbox-switcher input[type=checkbox]:checked:before{background:#bad8dd}body .auto-play-header .checkbox-switcher input[type=checkbox]:after{background:var(--body-bg-color);box-shadow:none;height:14px;left:3px;top:3px;width:14px}body .auto-play-header .checkbox-switcher input[type=checkbox]:checked:after{box-shadow:none;left:50%;margin-left:-2px}body .popup .nav-menu li a,body .popup .nav-menu li button{font-weight:500}body .popup .nav-menu li a,body .popup .nav-menu li a:focus,body .popup .nav-menu li a:hover,body .popup .nav-menu li button,body .popup .nav-menu li button:focus,body .popup .nav-menu li button:hover{color:#323333}body.dark_theme .popup .nav-menu li a,body.dark_theme .popup .nav-menu li a:focus,body.dark_theme .popup .nav-menu li a:hover,body.dark_theme .popup .nav-menu li button,body.dark_theme .popup .nav-menu li button:focus,body.dark_theme .popup .nav-menu li button:hover{color:#fff}body .popup .nav-menu .menu-item-icon{color:var(--header-popup-menu-icon-color)}body.dark_theme .user-menu-top-link{color:#fff}body .media-title-banner .media-actions>*>.more-options .popup-fullscreen .popup-main>div,body .media-title-banner .media-actions>*>.save .popup-fullscreen .popup-main>div,body .media-title-banner .media-actions>*>.share .popup-fullscreen .popup-main>div,body .media-title-banner .media-actions>*>.video-downloads .popup-fullscreen .popup-main>div{background-color:var(--popup-bg-color)}body .share-options .circle-icon-button{background:var(--media-actions-share-copy-field-bg-color)}body .share-embed .on-right-top-inner .circle-icon-button{background:var(--popup-bg-color)}body .media-title-banner .media-actions>*>.download a,body .media-title-banner .media-actions>*>.save,body .media-title-banner .media-actions>*>.share{color:#869ea5}body.dark_theme .media-title-banner .media-actions>*>.download a,body.dark_theme .media-title-banner .media-actions>*>.save,body.dark_theme .media-title-banner .media-actions>*>.share{color:#bad8dd}header.page-header:before{background-image:url(../images/ripple_white.svg);background-repeat:no-repeat;background-size:contain;content:"";display:block;height:140px;left:282px;opacity:.5;position:absolute;top:-67px;width:140px}header.page-header .mobile-search-toggle{padding-right:16px}header.page-header .page-header-left div>.circle-icon-button,header.page-header .page-header-right div>.circle-icon-button{background-color:hsla(0,0%,100%,0);color:#fff}@media screen and (min-width:640px) and (max-width:1023px){body .page-header-left{max-width:88%}}header.page-header .on-logo-right{color:#bad8dd;font-size:14px;font-weight:500;padding-left:20px;padding-right:0;padding-top:9px}@media (max-width:767px){header.page-header .on-logo-right{display:none!important}}header.page-header.mobile-search-field .on-logo-right{display:none}header.page-header .search-field-wrap{margin-left:567px;width:39.5833333333%;width:30%}@media (min-width:1024px){header.page-header .search-field-wrap{margin-left:567px;width:30%}}@media (min-width:1366px){header.page-header .search-field-wrap{width:39.5833333333%}}@media (min-width:1580px){header.page-header .search-field-wrap{margin-left:36.1681372184%;width:39.5833333333%}}header.page-header.mobile-search-field .search-field-wrap{margin-left:0;width:auto}header.page-header .search-field-wrap input[type=text]{background:#102c40;border-color:#102c40;-moz-border-radius:99em;-webkit-border-radius:99em;border-radius:99em;border-width:1px;color:#fff;font-size:16px;line-height:2.55;padding-left:47px;padding-right:20px}header.page-header .search-field-wrap input[type=text]:focus{border-color:#223647;box-shadow:0 0 2px 0 rgba(0,0,0,.1);color:#bad8dd}header.page-header .search-field-wrap input[type=text]::-webkit-input-placeholder{color:#87a2aa}header.page-header .search-field-wrap input[type=text]::-moz-placeholder{color:#87a2aa}header.page-header .search-field-wrap input[type=text]:-ms-input-placeholder{color:#87a2aa}header.page-header .search-field-wrap input[type=text]:-moz-placeholder{color:#87a2aa}header.page-header .search-field-wrap button[type=submit]{background:none;-moz-border-radius:0 1px 1px 0;-webkit-border-radius:0 1px 1px 0;border-radius:0 1px 1px 0;border-width:0;color:#fff;left:20px;right:auto;width:18px}header.page-header .mobile-search-toggle .material-icons:after,header.page-header .search-field-wrap button[type=submit] .material-icons:after{display:none}header.page-header .mobile-search-toggle .material-icons,header.page-header .search-field-wrap button[type=submit] .material-icons{background-image:url(../images/icons/search-icon.svg);background-repeat:no-repeat;background-size:contain;height:18px;line-height:1;margin:0;padding:0;width:18px}header.page-header .search-field-wrap .text-field-wrap{padding-left:0;padding-right:0}header.page-header .search-field-wrap .text-field-wrap .popup{border:0;right:0}header.page-header .search-predictions-list{background-color:#1a3f61;padding-bottom:4px;padding-top:4px}header.page-header .search-predictions-item{background-color:#1a3f61;border-bottom:2px solid #224667;color:#fff;cursor:pointer;font-weight:500;padding:0}header.page-header .search-predictions-item span{display:block;padding:12px 24px}header.page-header .search-predictions-item:focus span{background-color:#224667}header.page-header .search-predictions-item:last-child{border:0}header.page-header .page-header-right{padding-right:0}.logo a:focus span:before{border-color:hsla(0,0%,100%,.88)!important}.page-header-right .button-link.register-link,.page-header-right .button-link.sign-in{background-color:#ed7c30;color:#fff;font-weight:700;height:50px;line-height:50px;margin:0 24px 0 0;padding:0 30px;text-transform:none}body .nav-menu li.link-item{position:relative}body .nav-menu li.link-item .menu-item-icon{color:var(--sidebar-nav-item-icon-color)}body .nav-menu li.link-item.active .menu-item-icon{color:var(--sidebar-nav-item-icon-color-active)}body .nav-menu li.link-item.active:before{background-color:#ed7c30;bottom:0;content:"";left:0;position:absolute;top:0;width:4px}body.dark_theme .nav-menu li.link-item a{color:#bad8dd}@media (min-width:1024px){.page-sidebar-inner .nav-menu:first-child ul li:first-child{display:none}}.nav-menu nav .menu-item-icon{margin-left:4px;margin-right:16px}.nav-menu nav .menu-item-icon .material-icons{font-size:1.2em}body .media-info-content .media-author-banner+.media-content-banner{max-width:1152px;width:100%}body .media-info-content .media-author-banner+.media-content-banner .media-content-banner-inner,body .media-info-content .media-content-banner .media-content-banner-inner{max-width:100%}.media-content-description p,.media-content-description ul{margin:0}.comments-list .comment{max-width:1152px;width:100%}ul.social-media-links{border-color:var(--sidebar-nav-border-color);border-style:solid;border-width:1px 0;display:table;list-style:none;margin:0;padding:16px 32px;position:relative;text-align:center;width:100%}ul.social-media-links li{display:table-cell}ul.social-media-links li a{border:1px solid #bbd9de;border-radius:99em;display:block;height:36px;line-height:40px;margin:0 auto;overflow:hidden;position:relative;text-align:center;width:36px}body.dark_theme ul.social-media-links li a{border-color:rgba(186,216,221,.4)}.copyright-wrap,body.dark_theme ul.social-media-links li a img.in-light-mode{display:inline-block}.copyright-wrap{background-color:#112a40;border-radius:.75em;margin:0 auto;padding:10px 0;width:170px}.copyright-notice{line-height:1;margin:0 0 8px;position:relative;width:100%}.copyright-notice p{line-height:1.2857;margin:0 0 16px;padding:0 24px;text-align:center}.copyright-notice a{display:table;margin:0 auto}.copyright-notice a span{display:table-cell}.copyright-notice a img{display:block;max-width:125px}.copyright-notice img.em-dark{display:none}body .page-sidebar .social-media-links{border-bottom:0}body .page-sidebar .sidebar-theme-switcher{border:0;bottom:132px;float:none;left:0;padding:24px 0 4px;position:static}body .page-sidebar.fixed-bottom .sidebar-theme-switcher{position:absolute}body .sidebar-theme-switcher .theme-icon{bottom:0;display:block;line-height:40px;opacity:.3;padding:0;pointer-events:none;position:absolute;text-align:center;top:0;width:84px!important;z-index:1}body .sidebar-theme-switcher .theme-icon .material-icons:after{display:none}body .sidebar-theme-switcher .theme-icon .material-icons{background-position:50%;background-repeat:no-repeat;background-size:20px;height:100%;transform:none;width:100%;z-index:1}body .sidebar-theme-switcher .theme-icon{opacity:1;right:4px}body .sidebar-theme-switcher .theme-icon .material-icons{background-image:url(../images/icons/moon.png)}body .sidebar-theme-switcher .theme-icon.active .material-icons{background-image:url(../images/icons/moon-active.png)}body .sidebar-theme-switcher .theme-icon:first-child{left:4px;right:auto}body .sidebar-theme-switcher .theme-icon:first-child .material-icons{background-image:url(../images/icons/sun.png)}body .sidebar-theme-switcher .theme-icon:first-child.active .material-icons{background-image:url(../images/icons/sun-active.png)}body .sidebar-theme-switcher .sidebar-theme-switcher-inner{display:block;margin:0 auto;padding:0;position:relative;width:170px}body .sidebar-theme-switcher .sidebar-theme-switcher-inner>*{width:170px}body .sidebar-theme-switcher .checkbox-switcher{height:40px}body .sidebar-theme-switcher .checkbox-switcher input[type=checkbox]:before{background:#112a40;border-radius:99em}body .sidebar-theme-switcher .checkbox-switcher input[type=checkbox]:after{background:#ed7c30;border-radius:99em;box-shadow:none;height:32px;left:4px;top:4px;width:84px}body .sidebar-theme-switcher .checkbox-switcher input[type=checkbox]:checked:after{background:#ed7c30;box-shadow:none;left:100%;margin-left:-88px}body .page-sidebar .page-sidebar-bottom{color:inherit;font-size:1em;padding-left:0;padding-right:0;text-align:center}body .page-sidebar .page-sidebar-bottom a{color:inherit}body .page-sidebar-bottom-content{color:#fff;display:block;font-size:.785714em;padding:0}body .page-sidebar .page-sidebar-bottom .page-sidebar-bottom-content a{color:inherit;font-style:italic;text-decoration:none}body .page-sidebar .page-sidebar-bottom .page-sidebar-bottom-content a:hover{color:inherit!important;text-decoration:underline}ul.sidebar-bottom-menu{display:inline-block;line-height:1;list-style:none;margin:20px 0 0;text-align:center;width:auto}ul.sidebar-bottom-menu li{display:block;float:left;padding:0 4px;position:relative;width:auto}ul.sidebar-bottom-menu li a{float:left;font-size:12px;font-style:normal;padding:0 4px;text-transform:uppercase}ul.sidebar-extra-menu{display:inline-block;line-height:1;list-style:none;margin:20px 0 0;text-align:center;width:auto}ul.sidebar-extra-menu li{display:block;float:left;padding:0 4px;position:relative;width:auto}ul.sidebar-extra-menu li a{float:left;font-size:12px;font-style:normal;padding:0 4px;text-transform:uppercase}body.dark_theme ul.sidebar-bottom-menu li a,body.dark_theme ul.sidebar-bottom-menu li a:active,body.dark_theme ul.sidebar-bottom-menu li a:hover{color:#bad8dd!important}body.dark_theme ul.sidebar-bottom-menu li a:active,body.dark_theme ul.sidebar-bottom-menu li a:hover{text-decoration:underline}body.dark_theme ul.sidebar-extra-menu li a,body.dark_theme ul.sidebar-extra-menu li a:active,body.dark_theme ul.sidebar-extra-menu li a:hover{color:#bad8dd!important}body.dark_theme ul.sidebar-extra-menu li a:active,body.dark_theme ul.sidebar-extra-menu li a:hover{text-decoration:underline}body .items-list-header h2,body .media-list-header h2{font-family:Facultad,Arial,sans-serif;font-size:30px;line-height:32px;padding:12px 0 8px}body .hover-overlay-title .item .item-content-link{align-content:flex-end;display:flex;flex-wrap:wrap;padding:24px 19px}body .hover-overlay-title .item h3{display:block;font-family:Facultad,Arial,sans-serif;font-size:26px;line-height:1;padding:0;text-align:left;width:100%}body .hover-overlay-title .item h3 span{display:inline-block;overflow:visible;position:relative}body .hover-overlay-title .item h3 span:after{background-image:url(../images/icons/taxonomy-item-title-arrow.svg);background-position:50%;background-repeat:no-repeat;background-size:contain;content:"";display:none;height:29px;margin-left:14px;margin-top:-1px;vertical-align:middle;width:21px}body .hover-overlay-title .item .item-meta{padding-top:16px;text-align:left;width:100%;z-index:1}body .hover-overlay-title .item .item-meta .item-media-count{background-color:#7bbbbf;border-radius:2em;color:#fff;display:inline-block;font-size:12px;font-weight:500;line-height:1;padding:8px 16px}body .hover-overlay-title .item .item-content-link:before{background:#0f1a25;opacity:.6}body .hover-overlay-title .item .item-content-link:hover:before{background:#0f1a25;opacity:.8}body .hover-overlay-title .item .item-content-link:after{background:none;border:1px solid #026690;bottom:0;left:0;opacity:.6;right:0;top:0}body .hover-overlay-title .item .item-content-link:hover:after{background:none;border-color:#7bbbbf;opacity:.8}body .hover-overlay-title .item .item-content-link:hover h3{color:#fff}body .hover-overlay-title .item .item-content-link:hover h3 span:after{display:inline-block}body .hover-overlay-title .item .item-content-link:hover .item-meta{display:block}@media (min-width:580px){.media-list-wrapper.items-list-ver{padding:0}.media-list-wrapper.items-list-ver .media-list-row{max-width:100%}}body .empty-channel-media .button-link{background-color:#ed7c30;border-color:#ed7c30}body .profile-page-header .profile-nav ul li a{text-transform:capitalize}body a.item-edit-link{background-color:#ed7c30;color:#fff}body .media-list-wrapper{max-width:calc(var( --item-margin-right-width, var(--default-item-margin-right-width) ) + var( --item-width, var(--default-item-width) )*4)}body .profile-page-header .delete-profile-wrap>button,body .profile-page-header a.edit-channel,body .profile-page-header a.edit-profile{background-color:#ed7c30}@media (min-width:600px) and (max-width:802px){body .media-list-wrapper.items-list-ver .media-list-row,body .profile-page-header .profile-info,body .profile-page-header .profile-nav .profile-nav-inner{padding-left:var( --item-margin-right-width,var(--default-item-margin-right-width) );width:100%}body .media-list-wrapper.items-list-ver .media-list-row .item,body .profile-page-header .profile-info .item,body .profile-page-header .profile-nav .profile-nav-inner .item{display:inline-block;max-width:50%}}@media (min-width:803px){body .media-list-wrapper.items-list-ver .media-list-row,body .profile-page-header .profile-info,body .profile-page-header .profile-nav .profile-nav-inner{padding-left:var( --item-margin-right-width,var(--default-item-margin-right-width) );width:771px}}@media (min-width:1175px){body .media-list-wrapper.items-list-ver .media-list-row,body .profile-page-header .profile-info,body .profile-page-header .profile-nav .profile-nav-inner{width:calc(var( --item-margin-right-width, var(--default-item-margin-right-width) ) + var( --item-width, var(--default-item-width) )*3)}}@media (min-width:1547px){body .media-list-wrapper.items-list-ver .media-list-row,body .profile-page-header .profile-info,body .profile-page-header .profile-nav .profile-nav-inner{max-width:calc(var( --item-margin-right-width, var(--default-item-margin-right-width) ) + var( --item-width, var(--default-item-width) )*4);width:calc(var( --item-margin-right-width, var(--default-item-margin-right-width) ) + var( --item-width, var(--default-item-width) )*4)}}@media (min-width:600px) and (max-width:1046px){body.visible-sidebar .media-list-wrapper.items-list-ver .media-list-row,body.visible-sidebar .profile-page-header .profile-info,body.visible-sidebar .profile-page-header .profile-nav .profile-nav-inner{padding-left:var( --item-margin-right-width,var(--default-item-margin-right-width) );width:100%}body .media-list-wrapper.items-list-ver .media-list-row .item,body .profile-page-header .profile-info .item,body .profile-page-header .profile-nav .profile-nav-inner .item{display:inline-block;max-width:50%}}@media (min-width:1047px){body.visible-sidebar .media-list-wrapper.items-list-ver .media-list-row,body.visible-sidebar .profile-page-header .profile-info,body.visible-sidebar .profile-page-header .profile-nav .profile-nav-inner{max-width:calc(var( --item-margin-right-width, var(--default-item-margin-right-width) ) + var( --item-width, var(--default-item-width) )*2);padding-left:var( --item-margin-right-width,var(--default-item-margin-right-width) );width:calc(var( --item-margin-right-width, var(--default-item-margin-right-width) ) + var( --item-width, var(--default-item-width) )*2)}}@media (min-width:1419px){body.visible-sidebar .media-list-wrapper.items-list-ver .media-list-row,body.visible-sidebar .profile-page-header .profile-info,body.visible-sidebar .profile-page-header .profile-nav .profile-nav-inner{max-width:calc(var( --item-margin-right-width, var(--default-item-margin-right-width) ) + var( --item-width, var(--default-item-width) )*3);width:calc(var( --item-margin-right-width, var(--default-item-margin-right-width) ) + var( --item-width, var(--default-item-width) )*3)}}@media (min-width:1791px){body.visible-sidebar .media-list-wrapper.items-list-ver .media-list-row,body.visible-sidebar .profile-page-header .profile-info,body.visible-sidebar .profile-page-header .profile-nav .profile-nav-inner{max-width:1547px;max-width:calc(var( --item-margin-right-width, var(--default-item-margin-right-width) ) + var( --item-width, var(--default-item-width) )*4);width:1547px;width:calc(var( --item-margin-right-width, var(--default-item-margin-right-width) ) + var( --item-width, var(--default-item-width) )*4)}}@media (max-width:619px) and (max-width:709px){body .profile-page-header .profile-nav.fixed-nav .profile-nav{padding-left:1em}}@media (max-width:619px) and (max-width:768px){body .profile-page-header .profile-nav.fixed-nav .profile-nav{padding-left:1.5em}}@media (min-width:580px){body .items-list-outer.list-inline.list-slider .next-slide,body .items-list-outer.list-inline.list-slider .previous-slide{padding-top:calc(var(--default-item-width)*.28125)}body .items-list-outer.list-inline.list-slider .previous-slide{left:-20px}body .items-list-outer.list-inline.list-slider .next-slide{right:calc(-20px + var(--default-item-margin-right-width))}}body .item-main h3{display:inline-block;font-size:18px;letter-spacing:.2px;line-height:20px;margin:17px 0 10px!important}body .item-meta{color:#869ea5;font-family:inherit;font-size:12px;font-weight:500}body .item-author{margin-bottom:2px}body .item-author a,body .item-author a:active,body .item-author a:hover{color:var(--default-brand-color)}body .item-content h3 span{background-color:var(--body-bg-color)}body.dark_theme .item-content h3 a{color:#fff}body .items-list-ver .feat-first-item .item:first-child .item-content h3 span,body .items-list-ver .feat-first-item .item:first-child .item-description,body .items-list-ver .feat-first-item .item:first-child .item-description div{display:block;max-height:unset;-webkit-line-clamp:unset;-webkit-box-orient:unset}body .items-list-ver .feat-first-item .item:first-child .item-description div{text-overflow:unset}body .items-list-ver .feat-first-item .item:first-child{max-width:100%;width:100%}body .items-list-ver .feat-first-item .item:first-child .item-content{background-color:#dfeff4}body.dark_theme .items-list-ver .feat-first-item .item:first-child .item-content{background-color:#0b3144}body .items-list-ver .feat-first-item .item:first-child .item-main{padding:8px 24px 80px}body .items-list-ver .feat-first-item .item:first-child .item-main h3{color:#000;margin:35px 0 0;max-height:unset}body.dark_theme .items-list-ver .feat-first-item .item:first-child .item-main h3{color:#fff}body .items-list-ver .feat-first-item .item:first-child .item-main h3 span{background-color:#dfeff4;font-family:Facultad,Arial,sans-serif;font-size:22px;line-height:27px}body.dark_theme .items-list-ver .feat-first-item .item:first-child .item-main h3 span{background-color:#0b3144}body .items-list-ver .feat-first-item .item:first-child .item-main .item-description{color:#000;line-height:21px;margin:12px 0 32px}body .items-list-ver .feat-first-item .item:first-child .item-main .item-description div{font-size:14.5px;line-height:22.5px}body.dark_theme .items-list-ver .feat-first-item .item:first-child .item-main .item-description{color:#bad8dd}body .items-list-ver .feat-first-item .item:first-child .item-main .item-meta{bottom:32px;font-size:14px;left:24px;position:absolute;right:24px;width:auto}@media (min-width:600px){body .items-list-ver .feat-first-item .item:first-child .item-main{padding:12px 32px 80px}body .items-list-ver .feat-first-item .item:first-child .item-main .item-meta{left:32px;right:32px}}@media (min-width:1175px){body:not(.visible-sidebar) .items-list-ver .feat-first-item .item:first-child .item-player-wrapper{padding-bottom:33.5%;width:60%}body:not(.visible-sidebar) .items-list-ver .feat-first-item .item:first-child .item-main{bottom:32px;padding:0 40px;position:absolute;right:0;top:32px;width:40%}body:not(.visible-sidebar) .items-list-ver .feat-first-item .item:first-child .item-main h3 span{font-size:24px;line-height:32px}body:not(.visible-sidebar) .items-list-ver .feat-first-item .item:first-child .item-main .item-description{margin:24px 0 0}body:not(.visible-sidebar) .items-list-ver .feat-first-item .item:first-child .item-main .item-meta{bottom:0;left:40px;right:40px}body:not(.visible-sidebar) .items-list-ver .feat-first-item .item:first-child .item-main .item-description,body:not(.visible-sidebar) .items-list-ver .feat-first-item .item:first-child .item-main .item-description>*{display:-webkit-box;max-height:135px;-webkit-line-clamp:6;-webkit-box-orient:vertical;overflow:hidden;text-overflow:ellipsis}}@media (min-width:1547px){body:not(.visible-sidebar) .items-list-ver .feat-first-item .item:first-child .item-player-wrapper{padding-bottom:36.5%;width:65%}body:not(.visible-sidebar) .items-list-ver .feat-first-item .item:first-child .item-main{bottom:40px;padding:0 50px;top:40px;width:35%}body:not(.visible-sidebar) .items-list-ver .feat-first-item .item:first-child .item-main h3 span{font-size:24px;line-height:29.5px}body:not(.visible-sidebar) .items-list-ver .feat-first-item .item:first-child .item-main .item-meta{left:50px;right:50px}body:not(.visible-sidebar) .items-list-ver .feat-first-item .item:first-child .item-main .item-description,body:not(.visible-sidebar) .items-list-ver .feat-first-item .item:first-child .item-main .item-description>*{display:-webkit-box;max-height:293px;-webkit-line-clamp:13;-webkit-box-orient:vertical;overflow:hidden;text-overflow:ellipsis}}@media (min-width:1419px){body .items-list-ver .feat-first-item .item:first-child .item-player-wrapper{padding-bottom:33.5%;width:60%}body .items-list-ver .feat-first-item .item:first-child .item-main{bottom:32px;padding:0 40px;position:absolute;right:0;top:32px;width:40%}body .items-list-ver .feat-first-item .item:first-child .item-main h3 span{font-size:24px;line-height:32px}body .items-list-ver .feat-first-item .item:first-child .item-main .item-description{margin:24px 0 0}body .items-list-ver .feat-first-item .item:first-child .item-main .item-meta{bottom:0;left:40px;right:40px}body .items-list-ver .feat-first-item .item:first-child .item-main .item-description,body .items-list-ver .feat-first-item .item:first-child .item-main .item-description>*{display:-webkit-box;max-height:135px;-webkit-line-clamp:6;-webkit-box-orient:vertical;overflow:hidden;text-overflow:ellipsis}}@media (min-width:1791px){body .items-list-ver .feat-first-item .item:first-child .item-player-wrapper{padding-bottom:36.5%;width:65%}body .items-list-ver .feat-first-item .item:first-child .item-main{bottom:40px;padding:0 50px;top:40px;width:35%}body .items-list-ver .feat-first-item .item:first-child .item-main h3 span{font-size:24px;line-height:29.5px}body .items-list-ver .feat-first-item .item:first-child .item-main .item-meta{left:50px;right:50px}body .items-list-ver .feat-first-item .item:first-child .item-main .item-description,body .items-list-ver .feat-first-item .item:first-child .item-main .item-description>*{display:-webkit-box;max-height:293px;-webkit-line-clamp:12;-webkit-box-orient:vertical;overflow:hidden;text-overflow:ellipsis}}body .items-list-ver .feat-first-item .item{clear:none!important;margin-bottom:var(--default-item-margin-bottom-width)!important;min-height:0!important}#page-search .media-list-header h2{font-family:Facultad,Arial,sans-serif;font-size:21px;line-height:32px}body.dark_theme #page-search .media-list-header h2{color:#fff;opacity:.5}body #page-search .items-list-hor .media-list-header{padding-right:144px}@media (max-width:389px){body #page-search .items-list-hor .item .item-thumb{padding-bottom:69%}}@media (min-width:390px){body #page-search .items-list-hor .item{margin-bottom:27px}body #page-search .items-list-hor .item .item-thumb{height:100.05px;width:145px}body #page-search .items-list-hor .item-content{max-height:unset;padding-left:145px}body #page-search .items-list-hor .item-main h3{margin:10px 0!important}}@media (min-width:600px){body #page-search .items-list-hor .item .item-thumb{height:200px;max-height:200px;padding-bottom:0;width:290px}body #page-search .items-list-hor .item-content{min-height:200px;padding-left:290px}body.dark_theme #page-search .items-list-hor .item-main{padding-left:21px}}@media (min-width:1366px){body #page-search .items-list-hor .item{display:inline-block;max-width:50%;padding-right:16px;width:50%}body #page-search .items-list-hor .item:nth-child(2n){padding-left:16px;padding-right:0}}body #page-search .items-list-hor .item-main h3{font-size:18px}body #page-search .items-list-hor .item-main .item-meta{color:#869ea5}body #page-search .items-list-hor .item-main .item-author{display:block;margin-bottom:2px}body #page-search .items-list-hor .item-main .item-author a,body #page-search .items-list-hor .item-main .item-author a:active,body #page-search .items-list-hor .item-main .item-author a:hover{color:var(--default-brand-color)}body #page-search .items-list-hor .item-main .item-views:before{display:none}body.dark_theme #page-search .items-list-hor .item-main .item-description{color:#fff;font-weight:500;margin-bottom:0;margin-top:27px}body.dark_theme #page-search .items-list-hor .item-main .item-description,body.dark_theme #page-search .items-list-hor .item-main .item-description div{-webkit-line-clamp:3;max-height:54px}body .mi-filters-toggle{background-color:#1a3f61;top:34px}body .mi-filters-toggle button{color:#fff;height:36px;line-height:36px;margin:0;opacity:.75!important;padding:0 14px}body .mi-filters-toggle button.active,body .mi-filters-toggle button:hover{color:#fff!important;opacity:1!important}body .mi-filters-row-inner .mi-filter-options>* button{color:#869ea5!important;font-weight:500;opacity:1!important}body .mi-filters-row-inner .mi-filter-options>* button:hover,body .mi-filters-row-inner .mi-filter-options>.active button{color:inherit!important}body.dark_theme .mi-filters-row-inner .mi-filter-options>* button:hover,body.dark_theme .mi-filters-row-inner .mi-filter-options>.active button{color:#fff!important}@media (max-width:767px){body .mi-filters-row-inner .mi-filter.mi-filter-license{padding-left:0}}body .video-js.vjs-mediacms .vjs-big-play-button{border-radius:99em;font-size:5.5em;height:100px;line-height:100px;margin-left:-50px;margin-top:-50px;width:100px}.user-action-form-inner .editorial-pocicy-notice{border:1px solid var(--user-action-form-inner-title-border-bottom-color);-moz-border-radius:1px;-webkit-border-radius:1px;border-radius:1px;display:block;padding:16px;text-align:center}body.dark_theme .manage-media-item .mi-title>a,body.dark_theme .manage-users-item .mi-name>a{color:inherit;font-weight:400}.export-csv .media-list-row{min-height:0;padding:16px 0 0;text-align:right}@media (max-width:1365px){.export-csv{max-width:100%}.export-csv .media-list-row{padding:16px 24px 0}}@media (max-width:709px){.export-csv .media-list-row{padding:16px 16px 0}}.export-csv a{background-color:#1a3f61;color:#fff!important;display:inline-block;line-height:1.125;padding:1em 2em;text-decoration:none}.media-uploader-wrap .pre-upload-msg{font-weight:500}.media-uploader-wrap .pre-upload-msg a{text-decoration:none}.media-uploader-wrap .pre-upload-msg a:hover{text-decoration:underline}.custom-page-wrapper ol,.custom-page-wrapper p,.custom-page-wrapper ul{font-size:1em}.page-main-inner .custom-page-wrapper{display:block;margin:0 auto;max-width:100%;padding-bottom:64px!important;padding-top:32px!important;width:1366px}.in-dark-mode{display:none}body.dark_theme .in-dark-mode{display:initial}body.dark_theme .in-light-mode{display:none}body .page-main-inner .custom-page-wrapper{color:#323333}body.dark_theme .page-main-inner .custom-page-wrapper{color:#cfd1d3}.page-main-inner .custom-page-wrapper p,.page-main-inner .custom-page-wrapper ul li{font-family:Amulya,Arial,Helvetica,sans-serif;font-size:16px;font-weight:500;letter-spacing:0;line-height:1.5;word-wrap:break-word;overflow-wrap:break-word;&:not(:last-child){margin-bottom:30px}}.page-main-inner .custom-page-wrapper ul li{margin-left:0;padding-left:0}.page-main-inner .custom-page-wrapper ul{list-style-position:outside;margin-left:20px;padding-left:0}.page-main-inner .custom-page-wrapper iframe,.page-main-inner .custom-page-wrapper img{display:block;height:auto;margin-left:auto;margin-right:auto;max-width:100%}.page-main-inner .custom-page-wrapper iframe{aspect-ratio:16/9}.page-main-inner .custom-page-wrapper a{text-decoration:underline;word-wrap:break-word;overflow-wrap:break-word}.page-main-inner .custom-page-wrapper a:hover{text-decoration:none}.page-main-inner .custom-page-wrapper h1{color:#000;display:block;font-family:Facultad,Arial,Helvetica,sans-serif;font-size:32px;line-height:1.2;padding-bottom:10px;position:relative;word-wrap:break-word;overflow-wrap:break-word}.page-main-inner .custom-page-wrapper h2{font-size:24px;line-height:1.2}.page-main-inner .custom-page-wrapper h2,.page-main-inner .custom-page-wrapper h3{color:#000;display:block;font-family:Facultad,Arial,sans-serif;letter-spacing:.01;padding-bottom:10px;position:relative;word-wrap:break-word;overflow-wrap:break-word}.page-main-inner .custom-page-wrapper h3{font-size:18px;line-height:1.5}body.dark_theme .page-main-inner .custom-page-wrapper h1,body.dark_theme .page-main-inner .custom-page-wrapper h2,body.dark_theme .page-main-inner .custom-page-wrapper h3{color:#fff}.page-main-inner .custom-page-wrapper h1:after,.page-main-inner .custom-page-wrapper h2:after{background-color:#e7a27b;bottom:0;content:"";display:block;height:3px;left:0;position:absolute;width:50px}.page-main-inner .custom-page-wrapper .emphasis,.page-main-inner .custom-page-wrapper .emphasis-large{color:#026690}body.dark_theme .page-main-inner .custom-page-wrapper .emphasis,body.dark_theme .page-main-inner .custom-page-wrapper .emphasis-large{color:#7bbbbf}.page-main-inner .custom-page-wrapper .emphasis-large{font-family:Facultad,Arial,sans-serif;font-size:24px;line-height:32px}.page-main-inner .custom-page-wrapper .emphasis-large strong,.page-main-inner .custom-page-wrapper em strong{font-weight:500}.page-main-inner .custom-page-wrapper ul.tick-list{list-style:none}.page-main-inner .custom-page-wrapper ul.tick-list li{padding-left:26px;position:relative}.page-main-inner .custom-page-wrapper ul.tick-list li:before{background-image:url(../images/icons/tick.svg);background-position:50%;background-repeat:no-repeat;background-size:contain;color:#7bbbbf;content:"";display:block;height:16px;left:0;line-height:1;position:absolute;top:4px;width:16px}.page-main-inner .custom-page-wrapper .box{background-color:#ebf7f9;color:#000;display:inline-block;padding:30px;width:100%}body.dark_theme .page-main-inner .custom-page-wrapper .box{background-color:#0b3145;color:#fff}.page-main-inner .custom-page-wrapper .box img.fl{margin-bottom:0;margin-right:57px}.page-main-inner .custom-page-wrapper ul.box-list{display:inline-block;list-style:none;margin-bottom:0;position:relative;width:100%}.page-main-inner .custom-page-wrapper ul.box-list li{float:left;margin-bottom:40px;padding-left:0;position:relative}.page-main-inner .custom-page-wrapper ul.box-list li:before{display:none}.page-main-inner .custom-page-wrapper ul.box-list li>*{background-color:#ebf7f9;color:#000;display:block;margin:0 20px;padding:30px}body.dark_theme .page-main-inner .custom-page-wrapper ul.box-list li>*{background-color:#0b3145;color:#fff}.page-main-inner .custom-page-wrapper ul.box-list li>* .board-member{display:block;font-family:Facultad,Arial,sans-serif;font-size:24px;font-weight:500}.page-main-inner .custom-page-wrapper ul.box-list-half li{width:50%}.page-main-inner .custom-page-wrapper ul.box-list-half li:nth-child(odd){clear:left}.page-main-inner .custom-page-wrapper ul.box-list-half li:nth-child(odd) span{margin-left:0}.page-main-inner .custom-page-wrapper ul.box-list-half li:nth-child(2n) span{margin-right:0}.page-main-inner .custom-page-wrapper ul.box-list-third li{width:33.333333%}.page-main-inner .custom-page-wrapper ul.box-list-third li:nth-child(3n+1){clear:left}.page-main-inner .custom-page-wrapper ul.box-list-third li:nth-child(3n+1) span{margin-left:0}.page-main-inner .custom-page-wrapper ul.box-list-third li:nth-child(3n) span{margin-right:0}@media screen and (max-width:1023px){.page-main-inner .custom-page-wrapper ul.box-list li,.page-main-inner .custom-page-wrapper ul.box-list li>*{margin-left:0!important;margin-right:0!important;width:100%}}.page-main-inner .custom-page-wrapper .box-list .box-icon-title{background-position:0 0;background-repeat:no-repeat;background-size:contain;display:inline-block;font-size:18px;font-weight:500;margin-bottom:16px;padding-left:60px;width:100%}.page-main-inner .custom-page-wrapper .box-list .box-icon-title.open-tech{background-image:url(../images/icons/open_technology.svg)}.page-main-inner .custom-page-wrapper .box-list .box-icon-title.video4change{background-image:url(../images/icons/video4change.svg)}.page-main-inner .custom-page-wrapper .box-list .box-icon-title.research{background-image:url(../images/icons/research.svg)}.page-main-inner .custom-page-wrapper .box-list .box-icon-title.skills-build{background-image:url(../images/icons/skill_building.svg)}.page-main-inner .custom-page-wrapper .box-list .box-icon-title a{color:inherit;text-decoration:underline}.page-main-inner .custom-page-wrapper .box-list .box-icon-title a:hover{text-decoration:none}.page-sidebar li.nav-item-about-us .material-icons,.page-sidebar li.nav-item-categories .material-icons,.page-sidebar li.nav-item-contact-us .material-icons,.page-sidebar li.nav-item-countries .material-icons,.page-sidebar li.nav-item-editorial-policy .material-icons,.page-sidebar li.nav-item-featured .material-icons,.page-sidebar li.nav-item-history .material-icons,.page-sidebar li.nav-item-languages .material-icons,.page-sidebar li.nav-item-latest .material-icons,.page-sidebar li.nav-item-manage-comments .material-icons,.page-sidebar li.nav-item-manage-media .material-icons,.page-sidebar li.nav-item-manage-users .material-icons,.page-sidebar li.nav-item-my-playlists .material-icons,.page-sidebar li.nav-item-playlist .material-icons,.page-sidebar li.nav-item-recommended .material-icons,.page-sidebar li.nav-item-topics .material-icons,.page-sidebar li.nav-item-upload-media .material-icons{background-position:50%;background-repeat:no-repeat;background-size:contain;height:16px;width:16px}.page-sidebar li.nav-item-about-us .material-icons:after,.page-sidebar li.nav-item-categories .material-icons:after,.page-sidebar li.nav-item-contact-us .material-icons:after,.page-sidebar li.nav-item-countries .material-icons:after,.page-sidebar li.nav-item-editorial-policy .material-icons:after,.page-sidebar li.nav-item-featured .material-icons:after,.page-sidebar li.nav-item-history .material-icons:after,.page-sidebar li.nav-item-languages .material-icons:after,.page-sidebar li.nav-item-latest .material-icons:after,.page-sidebar li.nav-item-manage-comments .material-icons:after,.page-sidebar li.nav-item-manage-media .material-icons:after,.page-sidebar li.nav-item-manage-users .material-icons:after,.page-sidebar li.nav-item-my-playlists .material-icons:after,.page-sidebar li.nav-item-playlist .material-icons:after,.page-sidebar li.nav-item-recommended .material-icons:after,.page-sidebar li.nav-item-topics .material-icons:after,.page-sidebar li.nav-item-upload-media .material-icons:after{display:none}.page-sidebar li.material-icons{color:#1a3f61}.page-sidebar li.active .material-icons,.page-sidebar li:hover .material-icons{color:#7bbbbf}.page-sidebar li.nav-item-featured .material-icons{background-image:url(../images/icons/light-mode/default/Featured_light_active.svg)}.page-sidebar li.active.nav-item-featured .material-icons,.page-sidebar li:hover.nav-item-featured .material-icons{background-image:url(../images/icons/light-mode/active/Featured_light_hover_selected.svg)}.page-sidebar li.nav-item-recommended .material-icons{background-image:url(../images/icons/light-mode/default/Trending_light_active.svg)}.page-sidebar li.active.nav-item-recommended .material-icons,.page-sidebar li:hover.nav-item-recommended .material-icons{background-image:url(../images/icons/light-mode/active/Trending_light_hover_selected.svg)}.page-sidebar li.nav-item-latest .material-icons{background-image:url(../images/icons/light-mode/default/Recent\ Uploads_light_active.svg)}.page-sidebar li.active.nav-item-latest .material-icons,.page-sidebar li:hover.nav-item-latest .material-icons{background-image:url(../images/icons/light-mode/active/Recent\ Uploads_light_hover_selected.svg)}.page-sidebar li.nav-item-categories .material-icons{background-image:url(../images/icons/light-mode/default/Categories_light_active.svg)}.page-sidebar li.active.nav-item-categories .material-icons,.page-sidebar li:hover.nav-item-categories .material-icons{background-image:url(../images/icons/light-mode/active/Categories_light_hover_selected.svg)}.page-sidebar li.nav-item-topics .material-icons{background-image:url(../images/icons/light-mode/default/Topics_light_active.svg)}.page-sidebar li.active.nav-item-topics .material-icons,.page-sidebar li:hover.nav-item-topics .material-icons{background-image:url(../images/icons/light-mode/active/Topics_light_hover_selected.svg)}.page-sidebar li.nav-item-languages .material-icons{background-image:url(../images/icons/light-mode/default/Languages_light_active.svg)}.page-sidebar li.active.nav-item-languages .material-icons,.page-sidebar li:hover.nav-item-languages .material-icons{background-image:url(../images/icons/light-mode/active/Languages_light_hover_selected.svg)}.page-sidebar li.nav-item-countries .material-icons{background-image:url(../images/icons/light-mode/default/Countries_light_active.svg)}.page-sidebar li.active.nav-item-countries .material-icons,.page-sidebar li:hover.nav-item-countries .material-icons{background-image:url(../images/icons/light-mode/active/Countries_light_hover_selected.svg)}.page-sidebar li.nav-item-playlist .material-icons{background-image:url(../images/icons/light-mode/default/Playlists_light_active.svg)}.page-sidebar li.active.nav-item-playlist .material-icons,.page-sidebar li:hover.nav-item-playlist .material-icons{background-image:url(../images/icons/light-mode/active/Playlists_light_hover_selected.svg)}.page-sidebar li.nav-item-upload-media .material-icons{background-image:url(../images/icons/light-mode/default/Upload\ Media_light_active.svg)}.page-sidebar li.active.nav-item-upload-media .material-icons,.page-sidebar li:hover.nav-item-upload-media .material-icons{background-image:url(../images/icons/light-mode/active/Upload\ Media_light_hover_selected.svg)}.page-sidebar li.nav-item-my-playlists .material-icons{background-image:url(../images/icons/light-mode/default/My\ Playlists_light_active.svg)}.page-sidebar li.active.nav-item-my-playlists .material-icons,.page-sidebar li:hover.nav-item-my-playlists .material-icons{background-image:url(../images/icons/light-mode/active/My\ Playlists_light_hover_selected.svg)}.page-sidebar li.nav-item-history .material-icons{background-image:url(../images/icons/light-mode/default/My\ History_light_active.svg)}.page-sidebar li.active.nav-item-history .material-icons,.page-sidebar li:hover.nav-item-history .material-icons{background-image:url(../images/icons/light-mode/active/My\ History_light_hover_selected.svg)}.page-sidebar li.nav-item-about-us .material-icons{background-image:url(../images/icons/light-mode/default/About\ Us_light_active.svg)}.page-sidebar li.active.nav-item-about-us .material-icons,.page-sidebar li:hover.nav-item-about-us .material-icons{background-image:url(../images/icons/light-mode/active/About\ Us_light_hover_selected.svg)}.page-sidebar li.nav-item-editorial-policy .material-icons{background-image:url(../images/icons/light-mode/default/Editorial\ Policy_light_active.svg)}.page-sidebar li.active.nav-item-editorial-policy .material-icons,.page-sidebar li:hover.nav-item-editorial-policy .material-icons{background-image:url(../images/icons/light-mode/active/Editorial\ Policy_light_hover_selected.svg)}.page-sidebar li.nav-item-contact-us .material-icons{background-image:url(../images/icons/light-mode/default/Contact_light_active.svg)}.page-sidebar li.active.nav-item-contact-us .material-icons,.page-sidebar li:hover.nav-item-contact-us .material-icons{background-image:url(../images/icons/light-mode/active/Contact_light_hover_selected.svg)}.page-sidebar li.nav-item-manage-comments .material-icons,.page-sidebar li.nav-item-manage-media .material-icons,.page-sidebar li.nav-item-manage-users .material-icons{background-image:url(../images/icons/light-mode/default/Manage_light_active.svg)}.page-sidebar li.active.nav-item-manage-comments .material-icons,.page-sidebar li.active.nav-item-manage-media .material-icons,.page-sidebar li.active.nav-item-manage-users .material-icons,.page-sidebar li:hover.nav-item-manage-comments .material-icons,.page-sidebar li:hover.nav-item-manage-media .material-icons,.page-sidebar li:hover.nav-item-manage-users .material-icons{background-image:url(../images/icons/light-mode/active/Manage_light_hover_selected.svg)}body.dark_theme .page-sidebar li.material-icons{color:#026691}body.dark_theme .page-sidebar li.active .material-icons,body.dark_theme .page-sidebar li:hover .material-icons{color:#7bbbbf}body.dark_theme .page-sidebar li.nav-item-featured .material-icons{background-image:url(../images/icons/dark-mode/default/Featured_dark_active.svg)}body.dark_theme .page-sidebar li.active.nav-item-featured .material-icons,body.dark_theme .page-sidebar li:hover.nav-item-featured .material-icons{background-image:url(../images/icons/dark-mode/active/Featured_dark_hover_selected.svg)}body.dark_theme .page-sidebar li.nav-item-recommended .material-icons{background-image:url(../images/icons/dark-mode/default/Trending_dark_active.svg)}body.dark_theme .page-sidebar li.active.nav-item-recommended .material-icons,body.dark_theme .page-sidebar li:hover.nav-item-recommended .material-icons{background-image:url(../images/icons/dark-mode/active/Trending_dark_hover_selected.svg)}body.dark_theme .page-sidebar li.nav-item-latest .material-icons{background-image:url(../images/icons/dark-mode/default/Recent\ Uploads_dark_active.svg)}body.dark_theme .page-sidebar li.active.nav-item-latest .material-icons,body.dark_theme .page-sidebar li:hover.nav-item-latest .material-icons{background-image:url(../images/icons/dark-mode/active/Recent\ Uploads_dark_hover_selected.svg)}body.dark_theme .page-sidebar li.nav-item-categories .material-icons{background-image:url(../images/icons/dark-mode/default/Categories_dark_active.svg)}body.dark_theme .page-sidebar li.active.nav-item-categories .material-icons,body.dark_theme .page-sidebar li:hover.nav-item-categories .material-icons{background-image:url(../images/icons/dark-mode/active/Categories_dark_hover_selected.svg)}body.dark_theme .page-sidebar li.nav-item-topics .material-icons{background-image:url(../images/icons/dark-mode/default/Topics_dark_active.svg)}body.dark_theme .page-sidebar li.active.nav-item-topics .material-icons,body.dark_theme .page-sidebar li:hover.nav-item-topics .material-icons{background-image:url(../images/icons/dark-mode/active/Topics_dark_hover_selected.svg)}body.dark_theme .page-sidebar li.nav-item-languages .material-icons{background-image:url(../images/icons/dark-mode/default/Languages_dark_active.svg)}body.dark_theme .page-sidebar li.active.nav-item-languages .material-icons,body.dark_theme .page-sidebar li:hover.nav-item-languages .material-icons{background-image:url(../images/icons/dark-mode/active/Languages_dark_hover_selected.svg)}body.dark_theme .page-sidebar li.nav-item-countries .material-icons{background-image:url(../images/icons/dark-mode/default/Countries_dark_active.svg)}body.dark_theme .page-sidebar li.active.nav-item-countries .material-icons,body.dark_theme .page-sidebar li:hover.nav-item-countries .material-icons{background-image:url(../images/icons/dark-mode/active/Countries_dark_hover_selected.svg)}body.dark_theme .page-sidebar li.nav-item-playlist .material-icons{background-image:url(../images/icons/dark-mode/default/Playlists_dark_active.svg)}body.dark_theme .page-sidebar li.active.nav-item-playlist .material-icons,body.dark_theme .page-sidebar li:hover.nav-item-playlist .material-icons{background-image:url(../images/icons/dark-mode/active/Playlists_dark_hover_selected.svg)}body.dark_theme .page-sidebar li.nav-item-upload-media .material-icons{background-image:url(../images/icons/dark-mode/default/Upload\ Media_dark_active.svg)}body.dark_theme .page-sidebar li.active.nav-item-upload-media .material-icons,body.dark_theme .page-sidebar li:hover.nav-item-upload-media .material-icons{background-image:url(../images/icons/dark-mode/active/Upload\ Media_dark_hover_selected.svg)}body.dark_theme .page-sidebar li.nav-item-my-playlists .material-icons{background-image:url(../images/icons/dark-mode/default/My\ Playlists_dark_active.svg)}body.dark_theme .page-sidebar li.active.nav-item-my-playlists .material-icons,body.dark_theme .page-sidebar li:hover.nav-item-my-playlists .material-icons{background-image:url(../images/icons/dark-mode/active/My\ Playlists_dark_hover_selected.svg)}body.dark_theme .page-sidebar li.nav-item-history .material-icons{background-image:url(../images/icons/dark-mode/default/My\ History_dark_active.svg)}body.dark_theme .page-sidebar li.active.nav-item-history .material-icons,body.dark_theme .page-sidebar li:hover.nav-item-history .material-icons{background-image:url(../images/icons/dark-mode/active/My\ History_dark_hover_selected.svg)}body.dark_theme .page-sidebar li.nav-item-about-us .material-icons{background-image:url(../images/icons/dark-mode/default/About\ Us_dark_active.svg)}body.dark_theme .page-sidebar li.active.nav-item-about-us .material-icons,body.dark_theme .page-sidebar li:hover.nav-item-about-us .material-icons{background-image:url(../images/icons/dark-mode/active/About\ Us_dark_hover_selected.svg)}body.dark_theme .page-sidebar li.nav-item-editorial-policy .material-icons{background-image:url(../images/icons/dark-mode/default/Editorial\ Policy_dark_active.svg)}body.dark_theme .page-sidebar li.active.nav-item-editorial-policy .material-icons,body.dark_theme .page-sidebar li:hover.nav-item-editorial-policy .material-icons{background-image:url(../images/icons/dark-mode/active/Editorial\ Policy_dark_hover_selected.svg)}body.dark_theme .page-sidebar li.nav-item-contact-us .material-icons{background-image:url(../images/icons/dark-mode/default/Contact_dark_active.svg)}body.dark_theme .page-sidebar li.active.nav-item-contact-us .material-icons,body.dark_theme .page-sidebar li:hover.nav-item-contact-us .material-icons{background-image:url(../images/icons/dark-mode/active/Contact_dark_hover_selected.svg)}body.dark_theme .page-sidebar li.nav-item-manage-comments .material-icons,body.dark_theme .page-sidebar li.nav-item-manage-media .material-icons,body.dark_theme .page-sidebar li.nav-item-manage-users .material-icons{background-image:url(../images/icons/dark-mode/default/Manage_dark_active.svg)}body.dark_theme .page-sidebar li.active.nav-item-manage-comments .material-icons,body.dark_theme .page-sidebar li.active.nav-item-manage-media .material-icons,body.dark_theme .page-sidebar li.active.nav-item-manage-users .material-icons,body.dark_theme .page-sidebar li:hover.nav-item-manage-comments .material-icons,body.dark_theme .page-sidebar li:hover.nav-item-manage-media .material-icons,body.dark_theme .page-sidebar li:hover.nav-item-manage-users .material-icons{background-image:url(../images/icons/dark-mode/active/Manage_dark_hover_selected.svg)}body .media-title-banner h1{font-family:Facultad,Arial,sans-serif;font-size:26px;line-height:32px;margin-bottom:8px}body.dark_theme .media-title-banner h1{color:#fff}body .media-content-description,body .media-content-description p,body .media-content-summary{font-weight:500;line-height:21px}body.dark_theme .thumbnail,body.dark_theme .thumbnail.circle-icon-button{background-color:#bad8dd;color:var(--body-bg-color)}body .media-info-content .media-author-banner .author-banner-name{font-size:16px;line-height:21px}body.dark_theme .media-info-content .media-author-banner .author-banner-name{color:#fff}body .media-content-field-label h4,body .media-info-content .media-author-banner,body .media-title-banner .media-views .author-banner-date{font-size:14px;font-weight:500;line-height:21px}body.dark_theme .media-content-field-label h4,body.dark_theme .media-info-content .media-author-banner,body.dark_theme .media-title-banner .media-views{color:hsla(0,0%,100%,.4)}body .media-year-produced{color:#1a3f61}body.dark_theme .media-content-field-content a,body.dark_theme .media-year-produced{color:#7bbbbf}body.dark_theme button.load-more{color:#bad8dd}body .media-author-actions a{color:#fff}body .viewer-sidebar .auto-play-header .auto-play-option label,body .viewer-sidebar .auto-play-header .next-label{font-size:15px;font-weight:500;line-height:1;text-transform:uppercase}body.dark_theme .viewer-sidebar .auto-play-header .auto-play-option label{color:hsla(0,0%,100%,.5)}@media screen and (min-width:1008px){body .viewer-sidebar .auto-play-header{margin-bottom:32px;margin-top:24px}}body .viewer-sidebar .auto-play .item{margin-bottom:40px;padding-bottom:40px}@media screen and (min-width:390px){body .viewer-sidebar .item-main{padding-left:12px!important}body .sliding-sidebar .viewer-sidebar .item-main h3,body .viewer-sidebar .item-main h3,body .visible-sidebar .viewer-sidebar .item-main h3{margin-top:0!important}}body .sliding-sidebar .viewer-sidebar .item-main h3,body .viewer-sidebar .item-main h3,body .visible-sidebar .viewer-sidebar .item-main h3{font-size:18px!important;line-height:24px!important;margin-bottom:12px!important}@media screen and (min-width:390px){body .viewer-sidebar .item-main span{max-height:42px}}body .viewer-sidebar .item-author{margin-bottom:6px}body .viewer-sidebar .item-author span,body .viewer-sidebar .item-views{font-size:12px!important;font-weight:500!important}body .viewer-sidebar .item-meta{color:#869ea5}body.dark_theme .viewer-sidebar .item-meta{color:#bad8dd}body .viewer-sidebar .item-author span{color:var(--default-brand-color)}@media screen and (min-width:1217px) and (max-width:1439px){body .viewer-wide .viewer-container,body .viewer-wide .viewer-info{width:65%}body .viewer-wide .viewer-sidebar{width:35%}}@media screen and (min-width:1440px) and (max-width:1919px){body .viewer-wide .viewer-container,body .viewer-wide .viewer-info{width:70%}body .viewer-wide .viewer-sidebar{width:30%}}@media screen and (min-width:390px){body .items-list-hor .item-main h3 span{max-height:calc(3 + var(--horizontal-item-title-line-height));-webkit-line-clamp:3}}body .author-banner-date,body .media-actions .download>a,body .media-actions .like>button,body .media-actions .media-views,body .media-actions .more-options>span>button,body .media-actions .save>button,body .media-actions .share>button,body .media-actions .video-downloads>button,body .media-country{color:#323333;font-size:14px!important}body .media-title-banner .media-actions>div>div>.circle-icon-button,body .media-title-banner .media-actions>div>div>button{color:#323333}body.dark_theme .author-banner-date,body.dark_theme .media-actions .download>a,body.dark_theme .media-actions .like>button,body.dark_theme .media-actions .media-views,body.dark_theme .media-actions .more-options>span>button,body.dark_theme .media-actions .save>button,body.dark_theme .media-actions .share>button,body.dark_theme .media-actions .video-downloads>button,body.dark_theme .media-country{color:#bad8dd}body .media-actions .download>a .circle-icon-button>*,body .media-actions .like>button .circle-icon-button>*,body .media-actions .save>button .circle-icon-button>*,body .media-actions .share>button .circle-icon-button>*,body .media-actions .video-downloads>button .circle-icon-button>*{background:none!important}body .media-actions .download>a .material-icons,body .media-actions .like>button .material-icons,body .media-actions .save>button .material-icons,body .media-actions .share>button .material-icons,body .media-actions .video-downloads>button .material-icons{background-position:50%;background-repeat:no-repeat;background-size:contain;height:20px;width:20px}body .media-actions .download>a .material-icons:after,body .media-actions .like:before,body .media-actions .like>button .material-icons:after,body .media-actions .save>button .material-icons:after,body .media-actions .share>button .material-icons:after,body .media-actions .video-downloads>button .material-icons:after{display:none}body .media-actions .like>button .material-icons{background-image:url(../images/icons/light-mode/default/Like_light_active.svg)}body .media-actions .like>button:active .material-icons,body .media-actions .like>button:focus .material-icons{background-image:url(../images/icons/light-mode/active/Like_light_hover_selected.svg)}body.dark_theme .media-actions .like>button .material-icons{background-image:url(../images/icons/dark-mode/default/Like_dark_active.svg)}body.dark_theme .media-actions .like>button:active .material-icons,body.dark_theme .media-actions .like>button:focus .material-icons{background-image:url(../images/icons/dark-mode/active/Like_dark_hover_selected.svg)}body .media-actions .share>button .material-icons{background-image:url(../images/icons/light-mode/default/Share_light_active.svg)}body .media-actions .share>button:active .material-icons,body .media-actions .share>button:focus .material-icons{background-image:url(../images/icons/light-mode/active/Share_light_hover_selected.svg)}body.dark_theme .media-actions .share>button .material-icons{background-image:url(../images/icons/dark-mode/default/Share_dark_active.svg)}body.dark_theme .media-actions .share>button:active .material-icons,body.dark_theme .media-actions .share>button:focus .material-icons{background-image:url(../images/icons/dark-mode/active/Share_dark_hover_selected.svg)}body .media-actions .save>button .material-icons{background-image:url(../images/icons/light-mode/default/Save\ Playlist_light_active.svg)}body .media-actions .save>button:active .material-icons,body .media-actions .save>button:focus .material-icons{background-image:url(../images/icons/light-mode/active/Save\ Playlist_light_hover_selected.svg)}body.dark_theme .media-actions .save>button .material-icons{background-image:url(../images/icons/dark-mode/default/Save\ Playlist_dark_active.svg)}body.dark_theme .media-actions .save>button:active .material-icons,body.dark_theme .media-actions .save>button:focus .material-icons{background-image:url(../images/icons/dark-mode/active/Save\ Playlist_dark_hover_selected.svg)}body .media-actions .download>a .material-icons,body .media-actions .video-downloads>button .material-icons{background-image:url(../images/icons/light-mode/default/Download_light_active.svg)}body .media-actions .download>a:active .material-icons,body .media-actions .download>a:focus .material-icons,body .media-actions .video-downloads>button:active .material-icons,body .media-actions .video-downloads>button:focus .material-icons{background-image:url(../images/icons/light-mode/active/Download_light_hover_selected.svg)}body.dark_theme .media-actions .download>a .material-icons,body.dark_theme .media-actions .video-downloads>button .material-icons{background-image:url(../images/icons/dark-mode/default/Download_dark_active.svg)}body.dark_theme .media-actions .download>a:active .material-icons,body.dark_theme .media-actions .download>a:focus .material-icons,body.dark_theme .media-actions .video-downloads>button:active .material-icons,body.dark_theme .media-actions .video-downloads>button:focus .material-icons{background-image:url(../images/icons/dark-mode/active/Download_dark_hover_selected.svg)}body .viewer-section .viewer-section.viewer-section-nested,body .viewer-section.viewer-wide{max-width:1920px}body.dark_theme .media-title-banner{border-color:#676e75}body.dark_theme .viewer-sidebar .auto-play .item{border-color:#6f767c}body .video-js.vjs-mediacms .vjs-progress-control .vjs-progress-holder .vjs-play-progress{background-color:#025196}body .video-js.vjs-mediacms .vjs-progress-control .vjs-progress-holder .vjs-play-progress:before{color:#025196}@media screen and (min-width:390px){body .viewer-sidebar .items-list-hor .item{margin-bottom:27px}}@media screen and (min-width:640px){body .viewer-container{padding-left:29px}body .viewer-info-inner{margin-left:29px}}@media screen and (min-width:1008px){body .viewer-sidebar .items-list-hor .item{margin-bottom:21px}body .viewer-sidebar{padding-left:16px!important;padding-right:47px!important}body .sliding-sidebar .viewer-sidebar .item-thumb,body .sliding-sidebar .viewer-sidebar a.item-thumb,body .viewer-sidebar .item-thumb,body .viewer-sidebar a.item-thumb,body .visible-sidebar .viewer-sidebar .item-thumb,body .visible-sidebar .viewer-sidebar a.item-thumb{height:123.442px!important;width:220px!important}body .sliding-sidebar .viewer-sidebar .item-content,body .viewer-sidebar .item-content,body .visible-sidebar .viewer-sidebar .item-content{padding-left:220px!important}body .sliding-sidebar .viewer-sidebar .item-main,body .viewer-sidebar .item-main,body .visible-sidebar .viewer-sidebar .item-main{min-height:135.442px!important}}body.dark_theme .user-contact-form input,body.dark_theme .user-contact-form textarea{border-color:#436776}body.dark_theme .profile-page-header .profile-info-nav-wrap,body.dark_theme .profile-page-header .profile-info-nav-wrap:before{background-color:var(--header-bg-color)}body.dark_theme .profile-page-header .profile-info h1{font-family:Facultad,Arial,sans-serif}body.dark_theme .profile-page-header .profile-nav{background-color:#0b3144;background-color:var(--header-bg-color);border-bottom-color:#0b3144;border-bottom-color:var(--header-bg-color)}body.dark_theme .profile-page-header .profile-nav ul li a{color:#bad8dd}body.dark_theme .profile-page-header .profile-nav ul li.active a{color:#fff}body.dark_theme .profile-page-header .profile-nav ul li.active:after{background-color:var(--default-theme-color)}body .playlist-item .playlist-count,body .playlist-item .playlist-hover-play-all{background-color:rgba(15,26,37,.8)}body.dark_theme .playlist-item .item-main a.view-full-playlist{color:hsla(0,0%,100%,.4);font-weight:500}body.dark_theme .playlist-item .item-main a:hover.view-full-playlist{color:#fff}body.dark_theme #page-profile-about .profile-details li>span:first-child{color:hsla(0,0%,100%,.4);font-weight:500}body .playlist-view .playlist-media{background-color:var(--playlist-page-video-list-bg-color)}body.dark_theme .playlist-view .playlist-media{background-color:#0f1a25}body .playlist-view .playlist-media .item{margin-bottom:0}body .playlist-view .playlist-media .items-list-hor .item-main h3{font-size:14px!important}body .playlist-view .playlist-title{font-family:Facultad,Arial,sans-serif;font-size:16px}body .playlist-meta,body .playlist-meta .counter{font-weight:600}body .playlist-view .playlist-media .item-order-number{font-weight:500}body .playlist-view .playlist-meta a{color:#000}body.dark_theme .playlist-view .playlist-meta a{color:#fff}body .playlist-view .playlist-media .item-order-number,body .playlist-view .playlist-meta .counter{color:#869ea5}body .playlist-view .playlist-media .item-order-number,body.dark_theme .playlist-meta .counter{color:#bad8dd}body .playlist-view .playlist-actions,body .playlist-view .playlist-actions .circle-icon-button,body .playlist-view .playlist-header,body .playlist-view .playlist-header .toggle-playlist-view{background-color:var(--playlist-page-details-bg-color)}body .playlist-view .playlist-actions .circle-icon-button.active{color:#ed7c30}body.dark_theme .playlist-view .playlist-actions,body.dark_theme .playlist-view .playlist-actions .circle-icon-button,body.dark_theme .playlist-view .playlist-header,body.dark_theme .playlist-view .playlist-header .toggle-playlist-view{background-color:#0b3145}body.dark_theme .playlist-details{background:rgba(11,49,68,.6);background-color:#0b3145}body.dark_theme .playlist-details .playlist-title h1{font-family:Facultad,Arial,sans-serif}body.dark_theme .playlist-details .playlist-meta{color:#869ea5;font-weight:500}body.dark_theme .playlist-details .playlist-description{color:#fff;font-weight:500}body.dark_theme #page-playlist,body.dark_theme .playlist-videos-list,body.dark_theme .playlist-videos-list .item .item-content h3 span,body.dark_theme .playlist-videos-list>*{background:#0f1a25}body.dark_theme .playlist-videos-list .item:hover,body.dark_theme .playlist-videos-list .item:hover .item-content h3 span{background:#0d202e}body.dark_theme .user-action-form-inner{background-color:#0b3145}body.dark_theme .user-action-form-inner input,body.dark_theme .user-action-form-inner textarea{background-color:#0b3145;border-color:#436776;border-width:1px;box-shadow:none}body.dark_theme .user-action-form-inner [type=button],body.dark_theme .user-action-form-inner [type=submit],body.dark_theme .user-action-form-inner button{background-color:#7bbbbf;color:#fff}body .user-action-form-wrap{margin-top:60px}body .user-action-form-wrap>h1{margin:0 auto 20px;max-width:640px;padding-bottom:10px;position:relative}body .user-action-form-wrap>h1:after{background-color:#e7a27b;bottom:0;content:"";display:block;height:3px;left:0;position:absolute;width:50px}body .hw-even-list{background-color:#0c3144}body .hw-recent-videos-section{display:inline}body .hw-category{align-items:flex-end;display:flex;justify-content:space-between;margin-bottom:20px}body .hw-category-title{color:#fff;margin:30px 0 0}body .hw-category-description{color:#fff;max-width:512px;padding:5px 0 30px}body a.hw-category-link{color:#ed7c30;flex-shrink:0;font-size:14px;margin-right:25px;text-decoration:none;text-transform:none}.homepage-popup{padding:16px}.homepage-popup,.homepage-popup-fullscreen{bottom:0;left:0;position:fixed;right:0;top:0}.homepage-popup-fullscreen{background:rgba(17,26,36,.7);-webkit-box-shadow:none;-moz-box-shadow:none;box-shadow:none;display:table;height:100%;padding:24px 40px;padding-top:calc(var(--header-height) + 24px);width:100%;z-index:4}.homepage-popup--container{align-items:center;display:flex;flex-direction:column;justify-content:center;max-width:100%;min-height:100vh;position:relative;width:100%}.homepage-popup--img-container{position:relative;z-index:1050}.homepage-popup--image{height:auto;margin:0 auto;max-width:900px;width:100%}.homepage-popup--close-btn{align-items:center;background:none;border:none;display:flex;opacity:.6;position:absolute;right:-4px;top:-32px;transition:all .3s}.homepage-popup--close-btn:hover{opacity:1}.homepage-popup--close-btn span{color:#fff;margin-right:4px}.homepage-popup--close-btn--icon{color:#fff;height:24px;width:24px}.top-message-body #app-sidebar,.top-message-body .page-header,.top-message-body .page-sidebar-inner{margin-top:43px}.top-message--text{font-size:14px}
+body {
+
+	/* --default-logo-height: 48px !important; */
+
+	/* --header-height: 84px !important; */
+
+	/* --default-theme-color: #025196 !important;
+	--default-brand-color: #025196 !important;
+
+	--default-item-width: 260px !important;
+	--default-max-row-items: 5 !important;
+	--default-item-margin-right-width: 12px !important; */
+
+	--body-bg-color: #f8ffff !important;
+	--body-text-color: #000 !important;
+
+	--default-logo-height: 50px !important;
+
+	--header-height: 90px !important;
+
+	--default-theme-color: #1a3f61 !important;
+	--default-brand-color: #e7a27b !important;
+
+	--header-bg-color: #122536 !important;
+	--sidebar-bg-color: #dfeff4	 !important;
+
+	--sidebar-nav-border-color: #d5e9ee !important;
+
+	--nav-menu-active-item-bg-color: #cbdde5 !important;
+
+	--default-item-width: 372px !important;
+	--default-max-item-width: 372px !important;
+	--default-max-row-items: 4 !important;
+	--default-item-margin-right-width: 27px !important;
+	--default-item-margin-bottom-width: 27px !important;
+
+	--item-title-line-height: 20px !important;
+
+	--default-horizontal-item-margin-bottom-width: 29px !important;
+
+	--horizontal-item-title-line-height: 20px;
+
+	--sidebar-nav-item-icon-color: #1a3f61 !important;
+	--sidebar-nav-item-icon-color-active: #7bbbbf !important;
+
+	--header-popup-menu-icon-color:#869ea5 !important;
+}
+
+body.dark_theme{
+
+	--body-text-color: #fff !important;
+	--body-bg-color: #101a24 !important;
+
+	/* --default-theme-color: #0F80D7 !important; */
+	--default-theme-color: #659ba0 !important;
+	--default-brand-color: #e7a27b !important;
+
+	--header-bg-color: #122536 !important;
+	--sidebar-bg-color: #0f2230 !important;
+
+	--sidebar-nav-border-color: #182b39 !important;
+
+	--nav-menu-active-item-bg-color: #163652 !important;
+	--nav-menu-item-hover-bg-color: #163652 !important;
+
+	--sidebar-nav-item-icon-color: #026691 !important;
+
+	--media-actions-more-options-popup-bg-color: #0b3145 !important;
+
+	--popup-bg-color: #0b3145 !important;
+	--header-popup-menu-icon-color: #bad8dd !important;
+
+	--media-actions-share-copy-field-border-color:#0f1a25 !important;
+	--media-actions-share-copy-field-bg-color:#101a24 !important;
+
+	--share-embed-inner-textarea-text-color: rgba(255,255,255,0.88) !important;
+	--share-embed-inner-textarea-border-color: #0f1a25 !important;
+	--share-embed-inner-textarea-bg-color: #101a24 !important;
+
+	--input-border-color: #0f1a25 !important;
+	--input-bg-color: #101a24 !important;
+
+	--add-media-page-tmplt-uploader-bg-color: #0b3145 !important;
+}
+
+/*
+ * Typography.
+ *
+ */
+
+html body{
+	font-family: 'Amulya', Arial, sans-serif;
+}
+
+html body h1,
+html body .h1,
+html body h2,
+html body .h2,
+html body h3,
+html body .h3,
+html body h4,
+html body .h4,
+html body h5,
+html body .h5,
+html body h6,
+html body .h6{
+	/* font-family: 'Amulya', Arial, sans-serif; */
+	font-family: 'Facultad', Arial, sans-serif;
+}
+
+a{
+	color:#3385a6;
+}
+
+body.dark_theme a{
+	color:#659ba0;
+}
+
+body.dark_theme .top-message--text a{
+	color: white;
+}
+body .auto-play-header .checkbox-switcher-wrap{
+	width:30px;
+}
+
+body .auto-play-header .checkbox-switcher-wrap .checkbox-switcher{
+	height:20px;
+}
+
+body .auto-play-header .checkbox-switcher-wrap .checkbox-switcher input[type="checkbox"]:after{
+	width:14px;
+	height:14px;
+}
+
+body .auto-play-header .checkbox-switcher-wrap .checkbox-switcher input[type="checkbox"]:checked:after{
+	background:var(--body-bg-color);
+}
+
+body .auto-play-header .checkbox-switcher{
+	height:14px;
+}
+
+body .auto-play-header .checkbox-switcher input[type="checkbox"]:before{
+	border-radius: 99em;
+	background: rgba(186, 216, 221, .4);
+}
+
+body .auto-play-header .checkbox-switcher input[type="checkbox"]:checked:before{
+	background: #bad8dd;
+}
+
+body .auto-play-header .checkbox-switcher input[type="checkbox"]:after{
+	background:var(--body-bg-color);
+	box-shadow:none;
+	top:3px;
+	left:3px;
+	width:14px;
+	height:14px;
+}
+
+body .auto-play-header .checkbox-switcher input[type="checkbox"]:checked:after{
+	left:50%;
+	margin-left:-2px;
+	box-shadow:none;
+}
+
+/* body.dark_theme .popup{
+	background:#0f1a25 !important;
+} */
+
+body .popup .nav-menu li a,
+body .popup .nav-menu li button{
+	font-weight:500;
+}
+
+body .popup .nav-menu li a,
+body .popup .nav-menu li button,
+body .popup .nav-menu li a:hover,
+body .popup .nav-menu li a:focus,
+body .popup .nav-menu li button:hover,
+body .popup .nav-menu li button:focus{
+	color: #323333;
+}
+
+body.dark_theme .popup .nav-menu li a,
+body.dark_theme .popup .nav-menu li button,
+body.dark_theme .popup .nav-menu li a:hover,
+body.dark_theme .popup .nav-menu li a:focus,
+body.dark_theme .popup .nav-menu li button:hover,
+body.dark_theme .popup .nav-menu li button:focus{
+	/* color: #bad8dd; */
+	color: #fff;
+}
+
+body .popup .nav-menu .menu-item-icon{
+	color:var(--header-popup-menu-icon-color);
+}
+
+body.dark_theme .user-menu-top-link{
+	color:#fff;
+}
+
+body .media-title-banner .media-actions > * > *.share .popup-fullscreen .popup-main > div,
+body .media-title-banner .media-actions > * > *.save .popup-fullscreen .popup-main > div,
+body .media-title-banner .media-actions > * > *.more-options .popup-fullscreen .popup-main > div,
+body .media-title-banner .media-actions > * > *.video-downloads .popup-fullscreen .popup-main > div{
+	background-color:var(--popup-bg-color);
+}
+
+body .share-options .circle-icon-button{
+	background: var(--media-actions-share-copy-field-bg-color);
+}
+
+body .share-embed .on-right-top-inner .circle-icon-button{
+	background: var(--popup-bg-color);
+}
+
+body .media-title-banner .media-actions > * > *.share,
+body .media-title-banner .media-actions > * > *.save,
+body .media-title-banner .media-actions > * > *.download a{
+	color:#869ea5;
+}
+
+body.dark_theme .media-title-banner .media-actions > * > *.share,
+body.dark_theme .media-title-banner .media-actions > * > *.save,
+body.dark_theme .media-title-banner .media-actions > * > *.download a{
+	color:#bad8dd;
+}
+
+/*
+ * Header bar.
+ *
+ */
+
+header.page-header {
+	/* background-color: #025196; */
+}
+
+header.page-header:before {
+	content: '';
+	position:absolute;
+	top:-67px;
+	left:282px;
+	width:140px;
+	height:140px;
+	display:block;
+	background-image: url('../images/ripple_white.svg');
+	background-repeat: no-repeat;
+	background-size: contain;
+	opacity:0.5;
+}
+
+header.page-header .mobile-search-toggle{
+	padding-right:16px;
+}
+
+header.page-header .page-header-left div > .circle-icon-button,
+header.page-header .page-header-right div > .circle-icon-button{
+	color: white;
+	background-color: rgba(255,255,255,0);
+}
+
+@media screen and (min-width: 640px) and (max-width: 1023px){
+	body .page-header-left{
+		max-width:88%;
+	}
+}
+
+header.page-header .on-logo-right{
+	padding-top:9px;
+	padding-left:20px;
+	padding-right:0;
+	font-size:14px;
+	font-weight:500;
+	color:#bad8dd;
+}
+
+@media (max-width: 767px) {
+
+	header.page-header .on-logo-right{
+		display:none !important;
+	}
+}
+
+header.page-header.mobile-search-field .on-logo-right{
+	display:none;
+}
+
+@media (min-width: 1520px) {
+
+	header.page-header .search-field-wrap{
+		/* margin-left:800px; */
+		/* margin-left:42%;
+		width:33%; */
+
+		/* margin-left:56%;
+		width:28%; */
+
+		/* width:39.5833333333%;
+		margin-left:36.1681372184%; */
+		/* margin-left:54%; */
+	}
+}
+
+/* @media (min-width: 1280px) { */
+
+	header.page-header .search-field-wrap{
+
+		width:39.5833333333%;
+		margin-left:689px;
+		margin-left:46.1681372184%;
+		/* margin-left:48%; */
+
+		width:39.5833333333%;
+		margin-left:36.1681372184%;
+		margin-left:567px;
+		width:30%;
+	}
+/* } */
+
+@media (min-width: 1024px) {
+
+	header.page-header .search-field-wrap{
+		margin-left:567px;
+		width:30%;
+	}
+}
+
+@media (min-width: 1366px) {
+
+	header.page-header .search-field-wrap{
+		width:39.5833333333%;
+	}
+}
+
+@media (min-width: 1580px) {
+
+	header.page-header .search-field-wrap{
+		width:39.5833333333%;
+		margin-left:36.1681372184%;
+	}
+}
+
+header.page-header.mobile-search-field .search-field-wrap{
+	width:auto;
+	margin-left:0;
+}
+
+header.page-header .search-field-wrap input[type="text"]{
+	color: white;
+	border-color: #102c40;
+	border-width:1px;
+	/* border-color:var(--header-bg-color); */
+	/* background-color: var(--header-bg-color);
+	background-color: rgba(0,0,0,0.1); */
+	/* background:none; */
+	background:#102c40;
+	padding-left:47px;
+	padding-right:20px;
+	font-size:16px;
+	line-height: 2.55;
+	-moz-border-radius: 99em;
+	-webkit-border-radius: 99em;
+	border-radius: 99em;
+}
+
+header.page-header .search-field-wrap input[type="text"]:focus{
+	color:#bad8dd;
+	border-color: #223647;
+	box-shadow: 0px 0px 2px 0px rgba(0, 0, 0, 0.1);
+}
+
+header.page-header .search-field-wrap input[type="text"]::-webkit-input-placeholder {
+	color:#87a2aa;
+}
+
+header.page-header .search-field-wrap input[type="text"]::-moz-placeholder {
+	color:#87a2aa;
+}
+
+header.page-header .search-field-wrap input[type="text"]:-ms-input-placeholder {
+	color:#87a2aa;
+}
+
+header.page-header .search-field-wrap input[type="text"]:-moz-placeholder {
+	color:#87a2aa;
+}
+
+header.page-header .search-field-wrap button[type="submit"]{
+	width:18px;
+	left:20px;
+	right:auto;
+	color:white;
+	-moz-border-radius: 0 1px 1px 0;
+	-webkit-border-radius: 0 1px 1px 0;
+	border-radius: 0 1px 1px 0;
+}
+
+header.page-header .search-field-wrap button[type="submit"]{
+	/* border-color: #223647;
+	background-color: #223647; */
+	background:none;
+	border-width:0;
+}
+
+header.page-header .search-field-wrap button[type="submit"]:hover,
+header.page-header .search-field-wrap button[type="submit"]:focus{
+	/* border-color: rgba(255, 255, 255, 0.0);
+	background-color: rgba(255, 255, 255, 0.18); */
+}
+
+header.page-header .search-field-wrap button[type="submit"] .material-icons:after,
+header.page-header .mobile-search-toggle .material-icons:after{
+	display:none;
+}
+
+header.page-header .search-field-wrap button[type="submit"] .material-icons,
+header.page-header .mobile-search-toggle .material-icons{
+	width:18px;
+	height:18px;
+	margin:0;
+	padding:0;
+	line-height:1;
+	background-image: url('../images/icons/search-icon.svg');
+	background-repeat: no-repeat;
+	background-size: contain;
+}
+
+header.page-header .search-field-wrap .text-field-wrap{
+	padding-left:18px;
+	padding-left:0px;
+	padding-right:0;
+}
+
+header.page-header .search-field-wrap .text-field-wrap .popup{
+	right:0;
+	border:0;
+}
+
+header.page-header .search-predictions-list{
+	padding-top:4px;
+	padding-bottom:4px;
+	background-color:#1a3f61;
+}
+
+header.page-header .search-predictions-item{
+	cursor:pointer;
+	padding:0;
+	font-weight:500;
+	color:#fff;
+	background-color:#1a3f61;
+	border-bottom:2px solid #224667;
+}
+
+header.page-header .search-predictions-item span{
+	display:block;
+	padding:12px 24px;
+}
+
+header.page-header .search-predictions-item:focus span{
+	background-color:#224667;
+}
+
+header.page-header .search-predictions-item:last-child{
+	border:0;
+}
+
+header.page-header .page-header-right{
+	padding-right:0;
+}
+
+.logo a:focus span:before{
+	border-color: rgba(255,255,255,0.88) !important;
+}
+
+.page-header-right .button-link.sign-in,
+.page-header-right .button-link.register-link{
+	height:50px;
+	line-height:50px;
+	margin:0 24px 0 0;
+	padding:0 30px;
+	font-weight:bold;
+	text-transform: initial;
+	color:#fff;
+	background-color:#ed7c30;
+}
+
+/*
+ * Side bar.
+ *
+ */
+
+body .nav-menu li.link-item{
+	position:relative;
+}
+
+body .nav-menu li.link-item .menu-item-icon{
+	color:var(--sidebar-nav-item-icon-color);
+}
+
+body .nav-menu li.link-item.active .menu-item-icon{
+	color:var(--sidebar-nav-item-icon-color-active);
+}
+
+body .nav-menu li.link-item.active:before{
+	content:"";
+	position:absolute;
+	top:0;
+	left:0;
+	bottom:0;
+	width:4px;
+	background-color: #ed7c30;
+}
+
+body.dark_theme .nav-menu li.link-item a{
+	color: #bad8dd;
+}
+
+@media (min-width: 1024px) {
+
+	.page-sidebar-inner .nav-menu:first-child ul li:first-child{
+		display:none;
+	}
+}
+
+.nav-menu nav .menu-item-icon{
+	margin-right:16px;
+	margin-left:4px;
+}
+
+.nav-menu nav .menu-item-icon .material-icons {
+	font-size: 1.2em;
+}
+
+/*
+ * Media page.
+ *
+ */
+
+body .media-info-content .media-author-banner+.media-content-banner{
+	width:100%;
+	max-width:1152px;
+}
+
+body .media-info-content .media-content-banner .media-content-banner-inner,
+body .media-info-content .media-author-banner + .media-content-banner .media-content-banner-inner{
+	max-width:100%;
+}
+
+.media-content-description p,
+.media-content-description ul {
+	margin: 0;
+}
+
+.comments-list .comment{
+	width:100%;
+	max-width:1152px;
+}
+
+/*
+ * Sidebar's social media (icons) links.
+ *
+ */
+
+ul.social-media-links{
+	position: relative;
+	width:100%;
+	display:table;
+	list-style:none;
+	margin:0;
+	padding:0;
+	/*padding:16px;*/
+	padding:16px 32px;
+	border-style:solid;
+	border-width:1px 0;
+	border-color:var(--sidebar-nav-border-color);
+	text-align: center;
+}
+
+ul.social-media-links li{
+	display:table-cell;
+}
+
+ul.social-media-links li a{
+	position:relative;
+	display:block;
+	width:36px;
+	height:36px;
+	line-height:40px;
+	overflow:hidden;
+	margin:0 auto;
+	text-align: center;
+	border-radius:99em;
+	border:1px solid rgba(26, 63, 67, .4);
+	border-color:#bbd9de;
+}
+
+body.dark_theme ul.social-media-links li a{
+	border-color: rgba(186, 216, 221, .4);
+}
+
+body.dark_theme ul.social-media-links li a img.in-light-mode{
+	display:inline-block;
+}
+
+/* ul.social-media-links li a img{
+	display:inline-block;
+}
+
+ul.social-media-links li a img.in-dark-mode{
+	display:none;
+}
+
+body.dark_theme ul.social-media-links li a img{
+	display:none;
+}
+
+body.dark_theme ul.social-media-links li a img.in-dark-mode{
+	display:inline-block;
+} */
+
+.copyright-wrap{
+	width:170px;
+	display:inline-block;
+	padding:10px 0;
+	margin:0 auto;
+	border-radius:0.75em;
+	/* background-color:rgba(0,0,0,0.1); */
+	background-color:#112a40;
+}
+
+body.dark_theme .copyright-wrap{
+	/* background-color:#112a40; */
+}
+
+.copyright-notice{
+	position: relative;
+	width:100%;
+	/*padding:0 0 16px 0;*/
+	margin:0 0 8px 0;
+	line-height:1;
+	/*border-bottom:1px solid var(--sidebar-nav-border-color);*/
+	/*font-style: italic;
+	font-size:0.785714em;*/
+}
+
+.copyright-notice p{
+	padding:0 24px 0;
+	margin:0 0 16px;
+	line-height:1.2857;
+	text-align:center;
+}
+
+.copyright-notice a{
+	display:table;
+	margin:0 auto;
+}
+
+.copyright-notice a span{
+	display:table-cell;
+}
+
+.copyright-notice a img{
+	display:block;
+	max-width:125px;
+	/* max-width:100px; */
+}
+
+.copyright-notice img.em-dark{
+	display:none;
+}
+
+.copyright-notice img.em-light{
+
+}
+
+/* .dark_theme .copyright-notice img.em-dark{
+	display:none;
+}
+
+.dark_theme .copyright-notice img.em-light{
+	display:block;
+} */
+
+body .page-sidebar .social-media-links{
+	border-bottom:0;
+}
+
+body .page-sidebar .sidebar-theme-switcher{
+	position: static;
+	bottom:132px;
+	left:0;
+	float:none;
+	border:0;
+	padding:24px 0 4px 0;
+}
+
+body .page-sidebar.fixed-bottom .sidebar-theme-switcher{
+	position:absolute;
+}
+
+body .sidebar-theme-switcher .theme-icon{
+	z-index:+1;
+	display:block;
+	position:absolute;
+	top:0;
+	bottom:0;
+	width:84px !important;
+	line-height:40px;
+	padding:0;
+	text-align:center;
+	opacity:0.3;
+	pointer-events: none;
+}
+
+body .sidebar-theme-switcher .theme-icon .material-icons:after{
+	display:none;
+}
+
+body .sidebar-theme-switcher .theme-icon .material-icons{
+	z-index: +1;
+	width:100%;
+	height:100%;
+	background-size:20px;
+	background-position: center;
+	background-repeat: no-repeat;
+	transform:none;
+}
+
+body .sidebar-theme-switcher .theme-icon{
+	right:4px;
+	opacity:1;
+}
+
+body .sidebar-theme-switcher .theme-icon .material-icons{
+	background-image: url('../images/icons/moon.png');
+}
+
+body .sidebar-theme-switcher .theme-icon.active .material-icons{
+	background-image: url('../images/icons/moon-active.png');
+}
+
+body .sidebar-theme-switcher .theme-icon:first-child{
+	left:4px;
+	right:auto;
+}
+
+body .sidebar-theme-switcher .theme-icon:first-child .material-icons{
+	background-image: url('../images/icons/sun.png');
+}
+
+body .sidebar-theme-switcher .theme-icon:first-child.active .material-icons{
+	background-image: url('../images/icons/sun-active.png');
+}
+
+body .sidebar-theme-switcher .sidebar-theme-switcher-inner{
+	position:relative;
+	padding:0;
+	width:170px;
+	display:block;
+	margin:0 auto;
+}
+
+body .sidebar-theme-switcher .sidebar-theme-switcher-inner > *{
+	width:170px;
+}
+
+body .sidebar-theme-switcher .checkbox-switcher{
+	height:40px;
+}
+
+body .sidebar-theme-switcher .checkbox-switcher input[type="checkbox"]:after{
+	width: 84px;
+	height: 32px;
+}
+
+body .sidebar-theme-switcher .checkbox-switcher{
+	height:40px;
+}
+body .sidebar-theme-switcher .checkbox-switcher input[type="checkbox"]:before{
+	border-radius: 99em;
+	background: #112a40;
+}
+
+body .sidebar-theme-switcher .checkbox-switcher input[type="checkbox"]:after{
+	left:4px;
+	top:4px;
+	border-radius: 99em;
+	width: 84px;
+	height: 32px;
+	background: #ed7c30;
+	box-shadow:none;
+}
+
+body .sidebar-theme-switcher .checkbox-switcher input[type="checkbox"]:checked:after{
+	left:100%;
+	margin-left:-88px;
+	box-shadow:none;
+	background: #ed7c30;
+}
+
+body .page-sidebar .page-sidebar-bottom{
+	text-align:center;
+	padding-left: 0;
+	padding-right:0;
+	font-size:1em;
+	color:inherit;
+}
+
+body .page-sidebar .page-sidebar-bottom a{
+	color:inherit;
+}
+
+body .page-sidebar-bottom-content{
+	display:block;
+	padding:0 0;
+	font-size:0.785714em;
+	color:#fff;
+}
+
+body .page-sidebar .page-sidebar-bottom .page-sidebar-bottom-content a{
+	font-style:italic;
+	text-decoration:none;
+	color:inherit;
+}
+
+body .page-sidebar .page-sidebar-bottom .page-sidebar-bottom-content a:hover{
+	color:inherit !important;
+	text-decoration: underline;
+}
+
+ul.sidebar-bottom-menu{
+	width:auto;
+	display:inline-block;
+	text-align: center;
+	list-style:none;
+	line-height: 1;
+	margin:20px 0 0;
+}
+
+ul.sidebar-bottom-menu li{
+	position:relative;
+	width:auto;
+	float:left;
+	display:block;
+	padding:0 4px;
+}
+
+ul.sidebar-bottom-menu li a{
+	float:left;
+	padding:0 4px;
+	font-size:12px;
+	font-style:normal;
+	text-transform: uppercase;
+}
+
+ul.sidebar-extra-menu{
+	width:auto;
+	display:inline-block;
+	text-align: center;
+	list-style:none;
+	line-height: 1;
+	margin:20px 0 0;
+}
+
+ul.sidebar-extra-menu li{
+	position:relative;
+	width:auto;
+	float:left;
+	display:block;
+	padding:0 4px;
+}
+
+ul.sidebar-extra-menu li a{
+	float:left;
+	padding:0 4px;
+	font-size:12px;
+	font-style:normal;
+	text-transform: uppercase;
+}
+
+body.dark_theme ul.sidebar-bottom-menu li a,
+body.dark_theme ul.sidebar-bottom-menu li a:hover,
+body.dark_theme ul.sidebar-bottom-menu li a:active{
+	color:#bad8dd !important;
+}
+
+body.dark_theme ul.sidebar-bottom-menu li a:hover,
+body.dark_theme ul.sidebar-bottom-menu li a:active{
+	text-decoration: underline;
+}
+
+body.dark_theme ul.sidebar-extra-menu li a,
+body.dark_theme ul.sidebar-extra-menu li a:hover,
+body.dark_theme ul.sidebar-extra-menu li a:active{
+	color:#bad8dd !important;
+}
+
+body.dark_theme ul.sidebar-extra-menu li a:hover,
+body.dark_theme ul.sidebar-extra-menu li a:active{
+	text-decoration: underline;
+}
+
+
+/* #################################################################################################### */
+
+/* #page-tags .media-list-header h2,
+#page-topics .media-list-header h2,
+#page-countries .media-list-header h2,
+#page-languages .media-list-header h2,
+#page-categories .media-list-header h2{
+	font-family: 'Facultad', Arial, sans-serif;
+	font-size:30px;
+	line-height: 32px;
+	padding:12px 0 8px;
+} */
+
+body .items-list-header h2,
+body .media-list-header h2{
+	font-family: 'Facultad', Arial, sans-serif;
+	font-size:30px;
+	line-height: 32px;
+	padding:12px 0 8px;
+}
+
+#page-categories .item-meta .item-meta{
+
+}
+
+body .hover-overlay-title .item .item-content-link{
+	display:flex;
+	align-content: flex-end;
+	flex-wrap:wrap;
+	padding:24px 19px;
+}
+
+body .hover-overlay-title .item h3{
+	display:block;
+	width:100%;
+	padding:0;
+	text-align: left;
+	font-family: 'Facultad', Arial, sans-serif;
+	font-size: 26px;
+	line-height:1;
+}
+
+body .hover-overlay-title .item h3 span{
+	position: relative;
+	display:inline-block;
+	overflow:visible;
+}
+
+body .hover-overlay-title .item h3 span:after{
+	content: "";
+	width:21px;
+	height:29px;
+	margin-top:-1px;
+	margin-left: 14px;
+	display:none;
+	vertical-align: middle;
+	background-size:contain;
+	background-position: center;
+	background-repeat: no-repeat;
+	background-image: url('../images/icons/taxonomy-item-title-arrow.svg');
+}
+
+body .hover-overlay-title .item .item-meta{
+	z-index: +1;
+	/* display:block; */
+	width:100%;
+	padding-top:16px;
+	text-align: left;
+}
+
+body .hover-overlay-title .item .item-meta .item-media-count{
+	display:inline-block;
+	padding:8px 16px;
+	font-size:12px;
+	font-weight:500;
+	line-height:1;
+	color:#fff;
+	background-color: #7bbbbf;
+	border-radius:2em;
+}
+
+body .hover-overlay-title .item .item-content-link:before{
+	opacity:0.6;
+	background: #0f1a25;
+}
+
+body .hover-overlay-title .item .item-content-link:hover:before{
+	opacity:0.8;
+	background: #0f1a25;
+}
+
+body .hover-overlay-title .item .item-content-link:after{
+	top:0;
+	left:0;
+	right:0;
+	bottom:0;
+	background:none;
+	opacity:0.6;
+	border: 1px solid #026690;
+}
+
+body .hover-overlay-title .item .item-content-link:hover:after{
+	background:none;
+	opacity:0.8;
+	border-color:#7bbbbf;
+}
+
+body .hover-overlay-title .item .item-content-link:hover h3{
+	color:#fff;
+}
+
+body .hover-overlay-title .item .item-content-link:hover h3 span:after{
+	display:inline-block;
+}
+
+body .hover-overlay-title .item .item-content-link:hover .item-meta{
+	display:block;
+}
+
+/* #################################################################################################### */
+
+@media (min-width: 580px) {
+	.media-list-wrapper.items-list-ver {
+		padding:0;
+	}
+
+	.media-list-wrapper.items-list-ver .media-list-row {
+		max-width:100%;
+	}
+}
+
+/* #################################################################################################### */
+
+body .empty-channel-media .button-link{
+	border-color:#ed7c30;
+	background-color:#ed7c30;
+}
+
+body .profile-page-header .profile-nav ul li a{
+	text-transform: capitalize;
+}
+
+body a.item-edit-link{
+	color:#fff;
+	background-color:#ed7c30;
+}
+
+body .media-list-wrapper{
+	max-width: calc( var( --item-margin-right-width, var(--default-item-margin-right-width) ) + ( 4 * var( --item-width, var(--default-item-width) )) );
+}
+
+body .profile-page-header a.edit-channel,
+body .profile-page-header a.edit-profile,
+body .profile-page-header .delete-profile-wrap > button{
+	background-color:#ed7c30;
+}
+
+@media (min-width: 600px ) and (max-width: 802px ) {
+
+	body .media-list-wrapper.items-list-ver .media-list-row,
+	body .profile-page-header .profile-info,
+	body .profile-page-header .profile-nav .profile-nav-inner {
+		width: 100%;
+		padding-left: var( --item-margin-right-width, var(--default-item-margin-right-width) );
+	}
+
+	body .media-list-wrapper.items-list-ver .media-list-row .item,
+	body .profile-page-header .profile-info .item,
+	body .profile-page-header .profile-nav .profile-nav-inner .item {
+		display:inline-block;
+		max-width: 50%;
+	}
+}
+
+@media (min-width: 803px ) {
+	body .media-list-wrapper.items-list-ver .media-list-row,
+	body .profile-page-header .profile-info,
+	body .profile-page-header .profile-nav .profile-nav-inner {
+		width:771px;
+		padding-left: var( --item-margin-right-width, var(--default-item-margin-right-width) );
+	}
+}
+
+@media (min-width: 1175px ) {
+	body .media-list-wrapper.items-list-ver .media-list-row,
+	body .profile-page-header .profile-info,
+	body .profile-page-header .profile-nav .profile-nav-inner {
+		width: calc( var( --item-margin-right-width, var(--default-item-margin-right-width) ) + ( 3 * var( --item-width, var(--default-item-width) )) );
+	}
+}
+
+@media (min-width: 1547px ) {
+	body .media-list-wrapper.items-list-ver .media-list-row,
+	body .profile-page-header .profile-info,
+	body .profile-page-header .profile-nav .profile-nav-inner {
+		width: calc( var( --item-margin-right-width, var(--default-item-margin-right-width) ) + ( 4 * var( --item-width, var(--default-item-width) )) );
+		max-width: calc( var( --item-margin-right-width, var(--default-item-margin-right-width) ) + ( 4 * var( --item-width, var(--default-item-width) )) );
+	}
+}
+
+/* #################################################################################################### */
+
+/* @media (min-width: 748px) and (max-width: 819px ) {
+	body.sliding-sidebar .media-list-wrapper.items-list-ver .media-list-row,
+	body.sliding-sidebar .profile-page-header .profile-info,
+	body.sliding-sidebar .profile-page-header .profile-nav .profile-nav-inner,
+	body.visible-sidebar .media-list-wrapper.items-list-ver .media-list-row,
+	body.visible-sidebar .profile-page-header .profile-info,
+	body.visible-sidebar .profile-page-header .profile-nav .profile-nav-inner {
+		width: 480px;
+	}
+
+	body.sliding-sidebar .media-list-wrapper.items-list-ver .media-list-row .item,
+	body.sliding-sidebar .profile-page-header .profile-info .item,
+	body.sliding-sidebar .profile-page-header .profile-nav .profile-nav-inner .item,
+	body.visible-sidebar .media-list-wrapper.items-list-ver .media-list-row .item,
+	body.visible-sidebar .profile-page-header .profile-info .item,
+	body.visible-sidebar .profile-page-header .profile-nav .profile-nav-inner .item{
+		display:inline-block;
+		max-width: 240px;
+	}
+
+	body.sliding-sidebar .media-list-wrapper.items-list-ver .media-list-row .item-content,
+	body.sliding-sidebar .profile-page-header .profile-info .item-content,
+	body.sliding-sidebar .profile-page-header .profile-nav .profile-nav-inner .item-content,
+	body.visible-sidebar .media-list-wrapper.items-list-ver .media-list-row .item-content,
+	body.visible-sidebar .profile-page-header .profile-info .item-content,
+	body.visible-sidebar .profile-page-header .profile-nav .profile-nav-inner .item-content {
+		margin-right: 8px;
+	}
+}
+
+@media (min-width: 880px ) {
+	body.visible-sidebar .media-list-wrapper.items-list-ver .media-list-row,
+	body.visible-sidebar .profile-page-header .profile-info,
+	body.visible-sidebar .profile-page-header .profile-nav .profile-nav-inner {
+		width: calc( 2 * var( --item-width, var(--default-item-width) ) );
+	}
+}
+
+@media (min-width: 1100px ) {
+	body.visible-sidebar .media-list-wrapper.items-list-ver .media-list-row,
+	body.visible-sidebar .profile-page-header .profile-info,
+	body.visible-sidebar .profile-page-header .profile-nav .profile-nav-inner {
+		width: calc( 3 * var( --item-width, var(--default-item-width) ) );
+	}
+}
+
+@media (min-width: 1360px ) {
+	body.visible-sidebar .media-list-wrapper.items-list-ver .media-list-row,
+	body.visible-sidebar .profile-page-header .profile-info,
+	body.visible-sidebar .profile-page-header .profile-nav .profile-nav-inner {
+		width: calc( 4 * var( --item-width, var(--default-item-width) ) );
+	}
+}
+
+@media (min-width: 1600px ) {
+	body.visible-sidebar .media-list-wrapper.items-list-ver .media-list-row,
+	body.visible-sidebar .profile-page-header .profile-info,
+	body.visible-sidebar .profile-page-header .profile-nav .profile-nav-inner {
+		width: calc( 5 * var( --item-width, var(--default-item-width) ) );
+	}
+
+	body.visible-sidebar #page-home .media-list-wrapper.items-list-ver .media-list-row,
+	body.visible-sidebar #page-home .profile-page-header .profile-info,
+	body.visible-sidebar #page-home .profile-page-header .profile-nav .profile-nav-inner {
+		width: calc( 4 * var( --item-width, var(--default-item-width) ) );
+	}
+} */
+
+@media (min-width: 600px ) and (max-width: 1046px ) {
+
+	body.visible-sidebar .media-list-wrapper.items-list-ver .media-list-row,
+	body.visible-sidebar .profile-page-header .profile-info,
+	body.visible-sidebar .profile-page-header .profile-nav .profile-nav-inner {
+		width: 100%;
+		padding-left: var( --item-margin-right-width, var(--default-item-margin-right-width) );
+	}
+
+	body .media-list-wrapper.items-list-ver .media-list-row .item,
+	body .profile-page-header .profile-info .item,
+	body .profile-page-header .profile-nav .profile-nav-inner .item {
+		display:inline-block;
+		max-width: 50%;
+	}
+}
+
+@media (min-width: 1047px ) {
+	body.visible-sidebar .media-list-wrapper.items-list-ver .media-list-row,
+	body.visible-sidebar .profile-page-header .profile-info,
+	body.visible-sidebar .profile-page-header .profile-nav .profile-nav-inner {
+		width: calc( var( --item-margin-right-width, var(--default-item-margin-right-width) ) + ( 2 * var( --item-width, var(--default-item-width) )) );
+		max-width: calc( var( --item-margin-right-width, var(--default-item-margin-right-width) ) + ( 2 * var( --item-width, var(--default-item-width) )) );
+		padding-left: var( --item-margin-right-width, var(--default-item-margin-right-width) );
+	}
+}
+
+@media (min-width: 1419px ) {
+	body.visible-sidebar .media-list-wrapper.items-list-ver .media-list-row,
+	body.visible-sidebar .profile-page-header .profile-info,
+	body.visible-sidebar .profile-page-header .profile-nav .profile-nav-inner {
+		width: calc( var( --item-margin-right-width, var(--default-item-margin-right-width) ) + ( 3 * var( --item-width, var(--default-item-width) )) );
+		max-width: calc( var( --item-margin-right-width, var(--default-item-margin-right-width) ) + ( 3 * var( --item-width, var(--default-item-width) )) );
+	}
+}
+
+@media (min-width: 1791px ) {
+	body.visible-sidebar .media-list-wrapper.items-list-ver .media-list-row,
+	body.visible-sidebar .profile-page-header .profile-info,
+	body.visible-sidebar .profile-page-header .profile-nav .profile-nav-inner {
+		width:1547px;
+		max-width:1547px;
+		width: calc( var( --item-margin-right-width, var(--default-item-margin-right-width) ) + ( 4 * var( --item-width, var(--default-item-width) )) );
+		max-width: calc( var( --item-margin-right-width, var(--default-item-margin-right-width) ) + ( 4 * var( --item-width, var(--default-item-width) )) );
+	}
+}
+
+/* #################################################################################################### */
+
+@media (max-width: 619px) and (max-width: 709px) {
+	body .profile-page-header .profile-nav.fixed-nav .profile-nav{
+		padding-left:1em;
+	}
+}
+
+@media (max-width: 619px) and (max-width: 768px)  {
+	body .profile-page-header .profile-nav.fixed-nav .profile-nav{
+		padding-left:1.5em;
+	}
+}
+
+/* #################################################################################################### */
+
+@media (min-width: 580px) {
+
+	body .items-list-outer.list-inline.list-slider .previous-slide,
+	body .items-list-outer.list-inline.list-slider .next-slide{
+		padding-top:calc( 0.28125 * calc( var(--default-item-width) ));
+	}
+
+	body .items-list-outer.list-inline.list-slider .previous-slide{
+		left: -20px;
+	}
+
+	body .items-list-outer.list-inline.list-slider .next-slide{
+		right: calc( -20px + var(--default-item-margin-right-width) );
+	}
+}
+
+/* #################################################################################################### */
+
+@media (min-width: 620px) {
+
+	body .items-list-ver.media-list-wrapper .media-list-row .item{
+		/* display:inline-block; */
+		/* max-width: var( --item-width, var(--default-item-width) ); */
+	}
+
+	body .items-list-ver.media-list-wrapper .media-list-row .item-content{
+		/* margin-right: var( --item-margin-right-width, var(--default-item-margin-right-width) ); */
+	}
+}
+
+/* #################################################################################################### */
+
+body .item-main h3{
+	display:inline-block;
+	margin: 17px 0 10px !important;
+	font-size: 18px;
+	line-height: 20px;
+	letter-spacing: 0.2px;
+}
+
+body .item-meta{
+	font-family:inherit;
+	font-weight:500;
+	font-size:12px;
+	color:#869ea5;
+}
+
+body .item-author{
+	margin-bottom:2px;
+}
+
+body .item-author a,
+body .item-author a:hover,
+body .item-author a:active{
+	color:var(--default-brand-color);
+}
+
+body .item-author a:hover,
+body .item-author a:active{
+	/* text-decoration: underline; */
+}
+
+body .item-content h3 span{
+	background-color: var(--body-bg-color);
+}
+
+body.dark_theme .item-content h3 a{
+	color:#fff;
+}
+
+body .items-list-ver .feat-first-item .item:first-child .item-content h3 span{
+	display:block;
+	max-height:unset;
+	-webkit-line-clamp:unset;
+	-webkit-box-orient:unset;
+}
+
+body .items-list-ver .feat-first-item .item:first-child .item-description{
+	display:block;
+	max-height:unset;
+	-webkit-line-clamp:unset;
+	-webkit-box-orient:unset;
+}
+
+body .items-list-ver .feat-first-item .item:first-child .item-description div{
+	display:block;
+	max-height:unset;
+	-webkit-line-clamp:unset;
+	-webkit-box-orient:unset;
+	text-overflow:unset;
+}
+
+body .items-list-ver .feat-first-item .item:first-child {
+	width:100%;
+	max-width:100%;
+}
+
+body .items-list-ver .feat-first-item .item:first-child .item-content{
+	background-color:#dfeff4;
+}
+
+body.dark_theme .items-list-ver .feat-first-item .item:first-child .item-content{
+	background-color:#0b3144;
+}
+
+/* body .items-list-ver .feat-first-item .item:first-child .item-player-wrapper{
+	width:65%;
+	padding-bottom:36.7%;
+}
+
+body .items-list-ver .feat-first-item .item:first-child .item-main{
+	position:absolute;
+	top:40px;
+	bottom:40px;
+	right:0;
+	width:35%;
+	padding:0 50px;
+}
+
+body .items-list-ver .feat-first-item .item:first-child .item-main .item-meta{
+	position:absolute;
+	width:auto;
+	left:50px;
+	right:50px;
+	bottom:0;
+}*/
+
+body .items-list-ver .feat-first-item .item:first-child .item-main{
+	padding:8px 24px 80px;
+}
+
+body .items-list-ver .feat-first-item .item:first-child .item-main h3{
+	max-height: unset;
+	margin:35px 0 0;
+	color:#000;
+}
+
+body.dark_theme .items-list-ver .feat-first-item .item:first-child .item-main h3{
+	color:#fff;
+}
+
+body .items-list-ver .feat-first-item .item:first-child .item-main h3 span{
+	font-family: 'Facultad', Arial, sans-serif;
+	font-size: 22px;
+	line-height: 27px;
+	background-color:#dfeff4;
+}
+
+body.dark_theme .items-list-ver .feat-first-item .item:first-child .item-main h3 span{
+	background-color:#0b3144;
+}
+
+body .items-list-ver .feat-first-item .item:first-child .item-main .item-description{
+	line-height:21px;
+	margin:12px 0 32px;
+	color:#000;
+}
+
+body .items-list-ver .feat-first-item .item:first-child .item-main .item-description div{
+	font-size:14.5px;
+	line-height:22.5px;
+}
+
+body.dark_theme .items-list-ver .feat-first-item .item:first-child .item-main .item-description{
+	color:#bad8dd;
+}
+
+body .items-list-ver .feat-first-item .item:first-child .item-main .item-meta{
+	position:absolute;
+	width:auto;
+	left:24px;
+	right:24px;
+	bottom:32px;
+	font-size:14px;
+}
+
+@media (min-width: 600px ) {
+
+	body .items-list-ver .feat-first-item .item:first-child .item-main{
+		padding:12px 32px 80px;
+	}
+
+	body .items-list-ver .feat-first-item .item:first-child .item-main .item-meta{
+		left:32px;
+		right:32px;
+	}
+}
+
+@media (min-width: 1175px ) {
+
+	body:not(.visible-sidebar) .items-list-ver .feat-first-item .item:first-child .item-player-wrapper{
+		width:60%;
+		padding-bottom:33.5%;
+	}
+
+	body:not(.visible-sidebar) .items-list-ver .feat-first-item .item:first-child .item-main{
+		position:absolute;
+		top:32px;
+		bottom:32px;
+		right:0;
+		width:40%;
+		padding:0 40px;
+	}
+
+	body:not(.visible-sidebar) .items-list-ver .feat-first-item .item:first-child .item-main h3 span{
+		font-size: 24px;
+		line-height: 32px;
+	}
+
+	body:not(.visible-sidebar) .items-list-ver .feat-first-item .item:first-child .item-main .item-description{
+		margin:24px 0 0;
+	}
+
+	body:not(.visible-sidebar) .items-list-ver .feat-first-item .item:first-child .item-main .item-meta{
+		bottom:0;
+		left:40px;
+		right:40px;
+	}
+
+	body:not(.visible-sidebar) .items-list-ver .feat-first-item .item:first-child .item-main .item-description,
+	body:not(.visible-sidebar) .items-list-ver .feat-first-item .item:first-child .item-main .item-description > *{
+		max-height: 135px;
+		display: -webkit-box;
+		-webkit-line-clamp: 6;
+		-webkit-box-orient: vertical;
+		overflow:hidden;
+		text-overflow:ellipsis;
+	}
+}
+
+@media (min-width: 1547px ) {
+
+	body:not(.visible-sidebar) .items-list-ver .feat-first-item .item:first-child .item-player-wrapper{
+		width:65%;
+		padding-bottom:36.5%;
+	}
+
+	body:not(.visible-sidebar) .items-list-ver .feat-first-item .item:first-child .item-main{
+		width:35%;
+		top:40px;
+		bottom:40px;
+		padding:0 50px;
+	}
+
+	body:not(.visible-sidebar) .items-list-ver .feat-first-item .item:first-child .item-main h3 span{
+		font-size: 24px;
+		line-height: 29.5px;
+	}
+
+	body:not(.visible-sidebar) .items-list-ver .feat-first-item .item:first-child .item-main .item-meta{
+		left:50px;
+		right:50px;
+	}
+
+	body:not(.visible-sidebar) .items-list-ver .feat-first-item .item:first-child .item-main .item-description,
+	body:not(.visible-sidebar) .items-list-ver .feat-first-item .item:first-child .item-main .item-description > *{
+		max-height: 293px;
+		display: -webkit-box;
+		-webkit-line-clamp: 13;
+		-webkit-box-orient: vertical;
+		overflow:hidden;
+		text-overflow:ellipsis;
+	}
+}
+
+@media (min-width: 1419px ) {
+
+	body .items-list-ver .feat-first-item .item:first-child .item-player-wrapper{
+		width:60%;
+		padding-bottom:33.5%;
+	}
+
+	body .items-list-ver .feat-first-item .item:first-child .item-main{
+		position:absolute;
+		top:32px;
+		bottom:32px;
+		right:0;
+		width:40%;
+		padding:0 40px;
+	}
+
+	body .items-list-ver .feat-first-item .item:first-child .item-main h3 span{
+		font-size: 24px;
+		line-height: 32px;
+	}
+
+	body .items-list-ver .feat-first-item .item:first-child .item-main .item-description{
+		margin:24px 0 0;
+	}
+
+	body .items-list-ver .feat-first-item .item:first-child .item-main .item-meta{
+		bottom:0;
+		left:40px;
+		right:40px;
+	}
+
+	body .items-list-ver .feat-first-item .item:first-child .item-main .item-description,
+	body .items-list-ver .feat-first-item .item:first-child .item-main .item-description > *{
+		max-height: 135px;
+		display: -webkit-box;
+		-webkit-line-clamp: 6;
+		-webkit-box-orient: vertical;
+		overflow:hidden;
+		text-overflow:ellipsis;
+	}
+}
+
+@media (min-width: 1791px ) {
+
+	body .items-list-ver .feat-first-item .item:first-child .item-player-wrapper{
+		width:65%;
+		padding-bottom:36.5%;
+	}
+
+	body .items-list-ver .feat-first-item .item:first-child .item-main{
+		width:35%;
+		top:40px;
+		bottom:40px;
+		padding:0 50px;
+	}
+
+	body .items-list-ver .feat-first-item .item:first-child .item-main h3 span{
+		font-size: 24px;
+		line-height: 29.5px;
+	}
+
+	body .items-list-ver .feat-first-item .item:first-child .item-main .item-meta{
+		left:50px;
+		right:50px;
+	}
+
+	body .items-list-ver .feat-first-item .item:first-child .item-main .item-description,
+	body .items-list-ver .feat-first-item .item:first-child .item-main .item-description > *{
+		max-height: 293px;
+		display: -webkit-box;
+		-webkit-line-clamp: 12;
+		-webkit-box-orient: vertical;
+		overflow:hidden;
+		text-overflow:ellipsis;
+	}
+}
+
+	/* 4px 24pxitem-main{
+		width:35%;
+		top:40px;
+		bottom:40px;
+		padding:0 50px;
+	}
+
+	body .items-list-ver .feat-first-item .item:first-child .item-main h3 span{
+		font-size: 24px;
+		line-height: 29.5px;
+	}
+
+	body .items-list-ver .feat-first-item .item:first-child .item-main .item-meta{
+		left:50px;
+		right:50px;
+	}
+
+	body .items-list-ver .feat-first-item .item:first-child .item-main .item-description,
+	body .items-list-ver .feat-first-item .item:first-child .item-main .item-description > *{
+		max-height: 293px;
+		display: -webkit-box;
+		-webkit-line-clamp: 12;
+		-webkit-box-orient: vertical;
+		overflow:hidden;
+		text-overflow:ellipsis;
+	}
+} */
+
+/*@media (min-width: 580px) {
+
+	body .items-list-ver .feat-first-item .item:first-child {
+		width:100%;
+		max-width:100%;
+	}
+}*/
+
+/*@media (min-width: 600px ) and (max-width: 802px ) {
+
+	body .media-list-wrapper.items-list-ver .media-list-row,
+	body .profile-page-header .profile-info,
+	body .profile-page-header .profile-nav .profile-nav-inner {
+		width: 100%;
+		padding-left: var( --item-margin-right-width, var(--default-item-margin-right-width) );
+	}
+
+	body .media-list-wrapper.items-list-ver .media-list-row .item,
+	body .profile-page-header .profile-info .item,
+	body .profile-page-header .profile-nav .profile-nav-inner .item {
+		display:inline-block;
+		max-width: 50%;
+	}
+}*/
+
+/*@media (min-width: 803px ) {
+	body .media-list-wrapper.items-list-ver .media-list-row,
+	body .profile-page-header .profile-info,
+	body .profile-page-header .profile-nav .profile-nav-inner {
+		width:771px;
+		padding-left: var( --item-margin-right-width, var(--default-item-margin-right-width) );
+	}
+}*/
+
+/*@media (min-width: 1175px ) {
+	body .media-list-wrapper.items-list-ver .media-list-row,
+	body .profile-page-header .profile-info,
+	body .profile-page-header .profile-nav .profile-nav-inner {
+		width: calc( var( --item-margin-right-width, var(--default-item-margin-right-width) ) + ( 3 * var( --item-width, var(--default-item-width) )) );
+	}
+}*/
+
+/*@media (min-width: 1547px ) {
+	body .media-list-wrapper.items-list-ver .media-list-row,
+	body .profile-page-header .profile-info,
+	body .profile-page-header .profile-nav .profile-nav-inner {
+		width: calc( var( --item-margin-right-width, var(--default-item-margin-right-width) ) + ( 4 * var( --item-width, var(--default-item-width) )) );
+		max-width: calc( var( --item-margin-right-width, var(--default-item-margin-right-width) ) + ( 4 * var( --item-width, var(--default-item-width) )) );
+	}
+}*/
+
+/* #################################################################################################### */
+
+body .items-list-ver .feat-first-item .item{
+	clear:none !important;
+	min-height: 0 !important;
+	margin-bottom: var(--default-item-margin-bottom-width) !important;
+}
+
+/* #################################################################################################### */
+
+@media (min-width: 748px) and (max-width: 819px ) {
+
+	body.sliding-sidebar .items-list-ver .feat-first-item .item:first-child,
+	body.visible-sidebar .items-list-ver .feat-first-item .item:first-child{
+		/* max-width:100%; */
+	}
+}
+
+/* #################################################################################################### */
+
+#page-search .media-list-header h2{
+	font-size:21px;
+	line-height:32px;
+	font-family: 'Facultad', Arial, sans-serif;
+}
+
+body.dark_theme #page-search .media-list-header h2{
+	color:#fff;
+	opacity:0.5;
+}
+
+body #page-search .items-list-hor{
+
+}
+
+body #page-search .items-list-hor .media-list-header{
+	padding-right:144px;
+}
+
+@media (max-width: 389px) {
+
+	body #page-search .items-list-hor .item .item-thumb{
+		padding-bottom: 69%;
+	}
+}
+
+@media (min-width: 390px) {
+
+	body #page-search .items-list-hor .item{
+		margin-bottom:27px;
+	}
+
+	body #page-search .items-list-hor .item .item-thumb{
+		/* padding-bottom: 0; */
+		width:145px;
+		height:calc( 0.69 * 145px);
+	}
+
+	body #page-search .items-list-hor .item-content{
+		padding-left:145px;
+		max-height:unset;
+	}
+
+	body #page-search .items-list-hor .item-main h3{
+		margin:10px 0 !important;
+	}
+}
+
+@media (min-width: 600px) {
+
+	body #page-search .items-list-hor .item .item-thumb{
+		padding-bottom: 0;
+		width:290px;
+		height:200px;
+		max-height: 200px;
+	}
+
+	body #page-search .items-list-hor .item-content{
+		padding-left:290px;
+		min-height:200px;
+	}
+
+	body.dark_theme #page-search .items-list-hor .item-main{
+		padding-left:21px;
+	}
+}
+
+@media (min-width: 1366px) {
+	body #page-search .items-list-hor .item{
+		display:inline-block;
+		width: 50%;
+		max-width: 50%;
+		padding-right:16px;
+	}
+
+	body #page-search .items-list-hor .item:nth-child(2n){
+		padding-left:16px;
+		padding-right:0;
+	}
+}
+
+body #page-search .items-list-hor .item-main h3{
+	font-size:18px;
+}
+
+body #page-search .items-list-hor .item-main .item-meta{
+	color:#869ea5;
+}
+
+body #page-search .items-list-hor .item-main .item-author{
+	display:block;
+	margin-bottom:2px;
+}
+
+body #page-search .items-list-hor .item-main .item-author a,
+body #page-search .items-list-hor .item-main .item-author a:hover,
+body #page-search .items-list-hor .item-main .item-author a:active{
+	color:var(--default-brand-color);
+}
+
+body #page-search .items-list-hor .item-main .item-views:before{
+	display:none;
+}
+
+body.dark_theme #page-search .items-list-hor .item-main .item-description{
+	font-weight:500;
+	color:#fff;
+	margin-top:27px;
+	margin-bottom:0;
+}
+
+body.dark_theme #page-search .items-list-hor .item-main .item-description,
+body.dark_theme #page-search .items-list-hor .item-main .item-description div{
+	-webkit-line-clamp: 3;
+	max-height:54px;
+}
+
+body .mi-filters-toggle{
+	top:34px;
+	background-color:#1a3f61;
+}
+
+body .mi-filters-toggle button{
+	height:36px;
+	line-height:36px;
+	margin:0;
+	padding:0 14px;
+	color:#fff;
+	opacity:0.75 !important;
+}
+
+body .mi-filters-toggle button.active,
+body .mi-filters-toggle button:hover{
+	color:#fff !important;
+	opacity:1 !important;
+}
+
+body .mi-filters-row-inner .mi-filter-options > * button{
+	font-weight:500;
+	opacity:1 !important;
+}
+
+body .mi-filters-row-inner .mi-filter-options > * button{
+	color:#869ea5 !important;
+}
+
+body .mi-filters-row-inner .mi-filter-options > * button:hover,
+body .mi-filters-row-inner .mi-filter-options > *.active button{
+	color:inherit !important;
+}
+
+body.dark_theme .mi-filters-row-inner .mi-filter-options > * button:hover,
+body.dark_theme .mi-filters-row-inner .mi-filter-options > *.active button{
+	color:#fff !important;
+}
+
+@media (max-width: 767px){
+	body .mi-filters-row-inner .mi-filter.mi-filter-license{
+		padding-left:0;
+	}
+}
+
+/* #################################################################################################### */
+
+/*
+ * Video player.
+ *
+ */
+
+ body .video-js.vjs-mediacms .vjs-big-play-button{
+	width:100px;
+	height:100px;
+	line-height:100px;
+	margin-top:-50px;
+	margin-left:-50px;
+	font-size:5.5em;
+	border-radius:99em;
+}
+
+/*
+ * Edit media page.
+ *
+ */
+
+ .user-action-form-inner .editorial-pocicy-notice{
+	display:block;
+	padding:16px;
+	text-align:center;
+	-moz-border-radius: 1px;
+	-webkit-border-radius: 1px;
+	border-radius: 1px;
+    border: 1px solid var(--user-action-form-inner-title-border-bottom-color);
+}
+
+/*
+ * Managemenet pages.
+ *
+ */
+
+body.dark_theme .manage-media-item .mi-title > a,
+body.dark_theme .manage-users-item .mi-name > a {
+	color:inherit;
+	font-weight:400;
+}
+
+/*
+ * Members managemenet page.
+ *
+ */
+
+.export-csv .media-list-row{
+	min-height:0;
+	padding:16px 0 0;
+	text-align: right;
+}
+
+@media (max-width: 1365px) {
+
+	.export-csv {
+		max-width:100%;
+	}
+
+	.export-csv .media-list-row{
+		padding:16px 24px 0;
+	}
+}
+
+@media (max-width: 709px) {
+	.export-csv .media-list-row{
+		padding:16px 16px 0;
+	}
+}
+
+.export-csv a{
+	display:inline-block;
+	padding:1em 2em;
+	line-height:1.125;
+	text-decoration:none;
+	color:#fff !important;
+	background-color: #1a3f61;
+}
+
+/*
+ * Uploader page.
+ *
+ */
+
+.media-uploader-wrap .pre-upload-msg{
+	font-weight:500;
+}
+
+.media-uploader-wrap .pre-upload-msg a{
+	text-decoration:none;
+}
+
+.media-uploader-wrap .pre-upload-msg a:hover{
+	text-decoration:underline;
+}
+
+/*
+ * Custom content pages.
+ *
+ */
+
+.custom-page-wrapper p,
+.custom-page-wrapper ul,
+.custom-page-wrapper ol{
+	font-size: 1em;
+}
+
+/* #################################################################################################### */
+
+/* This css file is being used in the TinyMCE editor. */
+
+.page-main-inner .custom-page-wrapper {
+    display: block;
+    margin: 0 auto;
+    /* the 2 rules below is tinymce-only */
+    /* padding-left: 8px !important;
+    padding-right: 8px !important; */
+    padding-top: 32px !important;
+    padding-bottom: 64px !important;
+    width: 800px;
+    /* width: 1448px; */
+    max-width: 100%;
+}
+
+.in-dark-mode {
+    display: none;
+}
+
+body.dark_theme .in-dark-mode {
+    display: initial;
+}
+
+
+body.dark_theme .in-light-mode {
+    display: none;
+}
+
+body .page-main-inner .custom-page-wrapper {
+    color: #323333;
+}
+
+body.dark_theme .page-main-inner .custom-page-wrapper {
+    color: #cfd1d3;
+}
+
+.page-main-inner .custom-page-wrapper p,
+.page-main-inner .custom-page-wrapper ul li {
+    font-size: 16px;
+    font-family: 'Amulya', Arial, Helvetica, sans-serif;
+    font-weight: 500;
+    line-height: 1.5;
+    letter-spacing: 0;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+
+    /* Make the last paragraph not have 30px margin-bottom */
+    &:not(:last-child) {
+        margin-bottom: 30px;
+    }
+}
+
+.page-main-inner .custom-page-wrapper ul li {
+    padding-left: 0;
+    margin-left: 0;
+}
+
+.page-main-inner .custom-page-wrapper ul {
+    padding-left: 0;
+    margin-left: 20px;
+    list-style-position: outside;
+}
+
+/* Make images and videos responsive */
+.page-main-inner .custom-page-wrapper img,
+.page-main-inner .custom-page-wrapper iframe {
+    max-width: 100%;
+    height: auto;
+    margin-left: auto;
+    margin-right: auto;
+    display: block;
+}
+
+.page-main-inner .custom-page-wrapper iframe {
+    aspect-ratio: 16 / 9;
+}
+
+.page-main-inner .custom-page-wrapper a {
+    text-decoration: underline;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+}
+
+.page-main-inner .custom-page-wrapper a:hover {
+    text-decoration: none;
+}
+
+.page-main-inner .custom-page-wrapper h1 {
+    position: relative;
+    display: block;
+    padding-bottom: 10px;
+    font-family: 'Facultad', Arial, Helvetica, sans-serif;
+    font-size: 32px;
+    line-height: 1.2;
+    color: #000;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+}
+
+.page-main-inner .custom-page-wrapper h2 {
+    position: relative;
+    display: block;
+    padding-bottom: 10px;
+    font-family: 'Facultad', Arial, sans-serif;
+    font-size: 24px;
+    line-height: 1.2;
+    letter-spacing: 0.01;
+    color: #000;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+}
+
+.page-main-inner .custom-page-wrapper h3 {
+    position: relative;
+    display: block;
+    padding-bottom: 10px;
+    font-family: 'Facultad', Arial, sans-serif;
+    font-size: 18px;
+    line-height: 1.5;
+    letter-spacing: 0.01;
+    color: #000;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+}
+
+body.dark_theme .page-main-inner .custom-page-wrapper h1,
+body.dark_theme .page-main-inner .custom-page-wrapper h2,
+body.dark_theme .page-main-inner .custom-page-wrapper h3 {
+    color: #fff;
+}
+
+.page-main-inner .custom-page-wrapper h1:after,
+.page-main-inner .custom-page-wrapper h2:after {
+    content: "";
+    position: absolute;
+    display: block;
+    bottom: 0;
+    left: 0;
+    width: 50px;
+    height: 3px;
+    background-color: #e7a27b;
+}
+
+.page-main-inner .custom-page-wrapper .emphasis,
+.page-main-inner .custom-page-wrapper .emphasis-large {
+    color: #026690;
+}
+
+body.dark_theme .page-main-inner .custom-page-wrapper .emphasis,
+body.dark_theme .page-main-inner .custom-page-wrapper .emphasis-large {
+    color: #7bbbbf;
+}
+
+.page-main-inner .custom-page-wrapper .emphasis-large {
+    font-size: 24px;
+    line-height: 32px;
+    font-family: 'Facultad', Arial, sans-serif;
+}
+
+.page-main-inner .custom-page-wrapper .emphasis-large strong,
+.page-main-inner .custom-page-wrapper em strong {
+    font-weight: 500;
+}
+
+.page-main-inner .custom-page-wrapper ul.tick-list {
+    list-style: none;
+}
+
+.page-main-inner .custom-page-wrapper ul.tick-list li {
+    position: relative;
+    padding-left: 26px;
+}
+
+.page-main-inner .custom-page-wrapper ul.tick-list li:before {
+    content: '';
+    position: absolute;
+    top: 4px;
+    left: 0;
+    width: 16px;
+    height: 16px;
+    display: block;
+    /* font-size:24px; */
+    line-height: 1;
+    color: #7bbbbf;
+    background-image: url('../images/icons/tick.svg');
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: contain;
+}
+
+.page-main-inner .custom-page-wrapper .box {
+    display: inline-block;
+    width: 100%;
+    padding: 30px;
+    color: #000;
+    background-color: #ebf7f9;
+}
+
+body.dark_theme .page-main-inner .custom-page-wrapper .box {
+    color: #fff;
+    background-color: #0b3145;
+}
+
+.page-main-inner .custom-page-wrapper .box img.fl {
+    margin-right: 57px;
+    margin-bottom: 0;
+}
+
+/* .page-main-inner .custom-page-wrapper .box a,
+.page-main-inner .custom-page-wrapper .box-list a{
+	text-decoration:none;
+}
+
+.page-main-inner .custom-page-wrapper .box a:hover,
+.page-main-inner .custom-page-wrapper .box-list a:hover{
+	text-decoration:underline;
+} */
+
+.page-main-inner .custom-page-wrapper ul.box-list {
+    position: relative;
+    display: inline-block;
+    width: 100%;
+    list-style: none;
+    margin-bottom: 0;
+}
+
+.page-main-inner .custom-page-wrapper ul.box-list li {
+    position: relative;
+    float: left;
+    margin-bottom: 40px;
+    padding-left: 0;
+}
+
+.page-main-inner .custom-page-wrapper ul.box-list li:before {
+    display: none;
+}
+
+.page-main-inner .custom-page-wrapper ul.box-list li>* {
+    display: block;
+    margin: 0 20px;
+    padding: 30px;
+    color: #000;
+    background-color: #ebf7f9;
+}
+
+body.dark_theme .page-main-inner .custom-page-wrapper ul.box-list li>* {
+    color: #fff;
+    background-color: #0b3145;
+}
+
+.page-main-inner .custom-page-wrapper ul.box-list li>* .board-member {
+    display: block;
+    font-size: 24px;
+    font-weight: 500;
+    font-family: 'Facultad', Arial, sans-serif;
+}
+
+.page-main-inner .custom-page-wrapper ul.box-list-half li {
+    width: 50%;
+}
+
+.page-main-inner .custom-page-wrapper ul.box-list-half li:nth-child(2n+1) {
+    clear: left;
+}
+
+.page-main-inner .custom-page-wrapper ul.box-list-half li:nth-child(2n+1) span {
+    margin-left: 0;
+}
+
+.page-main-inner .custom-page-wrapper ul.box-list-half li:nth-child(2n) span {
+    margin-right: 0;
+}
+
+.page-main-inner .custom-page-wrapper ul.box-list-third li {
+    width: 33.333333%;
+}
+
+.page-main-inner .custom-page-wrapper ul.box-list-third li:nth-child(3n+1) {
+    clear: left;
+}
+
+.page-main-inner .custom-page-wrapper ul.box-list-third li:nth-child(3n+1) span {
+    margin-left: 0;
+}
+
+.page-main-inner .custom-page-wrapper ul.box-list-third li:nth-child(3n) span {
+    margin-right: 0;
+}
+
+@media screen and (max-width: 1023px) {
+
+    .page-main-inner .custom-page-wrapper ul.box-list li,
+    .page-main-inner .custom-page-wrapper ul.box-list li>* {
+        width: 100%;
+        margin-left: 0 !important;
+        margin-right: 0 !important;
+    }
+}
+
+.page-main-inner .custom-page-wrapper .box-list .box-icon-title {
+    display: inline-block;
+    width: 100%;
+    padding-left: 60px;
+    margin-bottom: 16px;
+    font-size: 18px;
+    font-weight: 500;
+    background-repeat: no-repeat;
+    background-position: top left;
+    background-size: contain;
+}
+
+.page-main-inner .custom-page-wrapper .box-list .box-icon-title.open-tech {
+    background-image: url('../images/icons/open_technology.svg');
+}
+
+.page-main-inner .custom-page-wrapper .box-list .box-icon-title.video4change {
+    background-image: url('../images/icons/video4change.svg');
+}
+
+.page-main-inner .custom-page-wrapper .box-list .box-icon-title.research {
+    background-image: url('../images/icons/research.svg');
+}
+
+.page-main-inner .custom-page-wrapper .box-list .box-icon-title.skills-build {
+    background-image: url('../images/icons/skill_building.svg');
+}
+
+.page-main-inner .custom-page-wrapper .box-list .box-icon-title a {
+    color: inherit;
+    text-decoration: underline;
+}
+
+.page-main-inner .custom-page-wrapper .box-list .box-icon-title a:hover {
+    text-decoration: none;
+}
+
+/* #################################################################################################### */
+
+.page-sidebar li{
+
+}
+
+.page-sidebar li.nav-item-featured .material-icons,
+.page-sidebar li.nav-item-recommended .material-icons,
+.page-sidebar li.nav-item-latest .material-icons,
+.page-sidebar li.nav-item-categories .material-icons,
+.page-sidebar li.nav-item-topics .material-icons,
+.page-sidebar li.nav-item-languages .material-icons,
+.page-sidebar li.nav-item-countries .material-icons,
+.page-sidebar li.nav-item-about-us .material-icons,
+.page-sidebar li.nav-item-playlist .material-icons,
+.page-sidebar li.nav-item-upload-media .material-icons,
+/* .page-sidebar li.nav-item-my-media .material-icons, */
+.page-sidebar li.nav-item-my-playlists .material-icons,
+.page-sidebar li.nav-item-history .material-icons,
+.page-sidebar li.nav-item-editorial-policy .material-icons,
+.page-sidebar li.nav-item-contact-us .material-icons,
+.page-sidebar li.nav-item-manage-media .material-icons,
+.page-sidebar li.nav-item-manage-users .material-icons,
+.page-sidebar li.nav-item-manage-comments .material-icons{
+	width:16px;
+	height:16px;
+	background-size:contain;
+	background-position: center;
+	background-repeat: no-repeat;
+}
+
+.page-sidebar li.nav-item-featured .material-icons:after,
+.page-sidebar li.nav-item-recommended .material-icons:after,
+.page-sidebar li.nav-item-latest .material-icons:after,
+.page-sidebar li.nav-item-categories .material-icons:after,
+.page-sidebar li.nav-item-topics .material-icons:after,
+.page-sidebar li.nav-item-languages .material-icons:after,
+.page-sidebar li.nav-item-countries .material-icons:after,
+.page-sidebar li.nav-item-playlist .material-icons:after,
+.page-sidebar li.nav-item-upload-media .material-icons:after,
+/* .page-sidebar li.nav-item-my-media .material-icons:after, */
+.page-sidebar li.nav-item-my-playlists .material-icons:after,
+.page-sidebar li.nav-item-history .material-icons:after,
+.page-sidebar li.nav-item-about-us .material-icons:after,
+.page-sidebar li.nav-item-editorial-policy .material-icons:after,
+.page-sidebar li.nav-item-contact-us .material-icons:after,
+.page-sidebar li.nav-item-manage-media .material-icons:after,
+.page-sidebar li.nav-item-manage-users .material-icons:after,
+.page-sidebar li.nav-item-manage-comments .material-icons:after{
+	display:none;
+}
+
+.page-sidebar li.material-icons{
+	color:#1a3f61;
+}
+
+.page-sidebar li.active .material-icons,
+.page-sidebar li:hover .material-icons{
+	color:#7bbbbf;
+}
+
+.page-sidebar li.nav-item-featured .material-icons{
+	background-image: url('../images/icons/light-mode/default/Featured_light_active.svg');
+}
+
+.page-sidebar li.active.nav-item-featured .material-icons,
+.page-sidebar li:hover.nav-item-featured .material-icons{
+	background-image: url('../images/icons/light-mode/active/Featured_light_hover_selected.svg');
+}
+
+.page-sidebar li.nav-item-recommended .material-icons{
+	background-image: url('../images/icons/light-mode/default/Trending_light_active.svg');
+}
+
+.page-sidebar li.active.nav-item-recommended .material-icons,
+.page-sidebar li:hover.nav-item-recommended .material-icons{
+	background-image: url('../images/icons/light-mode/active/Trending_light_hover_selected.svg');
+}
+
+.page-sidebar li.nav-item-latest .material-icons{
+	background-image: url('../images/icons/light-mode/default/Recent Uploads_light_active.svg');
+}
+
+.page-sidebar li.active.nav-item-latest .material-icons,
+.page-sidebar li:hover.nav-item-latest .material-icons{
+	background-image: url('../images/icons/light-mode/active/Recent Uploads_light_hover_selected.svg');
+}
+
+.page-sidebar li.nav-item-categories .material-icons{
+	background-image: url('../images/icons/light-mode/default/Categories_light_active.svg');
+}
+
+.page-sidebar li.active.nav-item-categories .material-icons,
+.page-sidebar li:hover.nav-item-categories .material-icons{
+	background-image: url('../images/icons/light-mode/active/Categories_light_hover_selected.svg');
+}
+
+.page-sidebar li.nav-item-topics .material-icons{
+	background-image: url('../images/icons/light-mode/default/Topics_light_active.svg');
+}
+
+.page-sidebar li.active.nav-item-topics .material-icons,
+.page-sidebar li:hover.nav-item-topics .material-icons{
+	background-image: url('../images/icons/light-mode/active/Topics_light_hover_selected.svg');
+}
+
+.page-sidebar li.nav-item-languages .material-icons{
+	background-image: url('../images/icons/light-mode/default/Languages_light_active.svg');
+}
+
+.page-sidebar li.active.nav-item-languages .material-icons,
+.page-sidebar li:hover.nav-item-languages .material-icons{
+	background-image: url('../images/icons/light-mode/active/Languages_light_hover_selected.svg');
+}
+
+.page-sidebar li.nav-item-countries .material-icons{
+	background-image: url('../images/icons/light-mode/default/Countries_light_active.svg');
+}
+
+.page-sidebar li.active.nav-item-countries .material-icons,
+.page-sidebar li:hover.nav-item-countries .material-icons{
+	background-image: url('../images/icons/light-mode/active/Countries_light_hover_selected.svg');
+}
+
+.page-sidebar li.nav-item-playlist .material-icons{
+	background-image: url('../images/icons/light-mode/default/Playlists_light_active.svg');
+}
+
+.page-sidebar li.active.nav-item-playlist .material-icons,
+.page-sidebar li:hover.nav-item-playlist .material-icons{
+	background-image: url('../images/icons/light-mode/active/Playlists_light_hover_selected.svg');
+}
+
+.page-sidebar li.nav-item-upload-media .material-icons{
+	background-image: url('../images/icons/light-mode/default/Upload Media_light_active.svg');
+}
+
+.page-sidebar li.active.nav-item-upload-media .material-icons,
+.page-sidebar li:hover.nav-item-upload-media .material-icons{
+	background-image: url('../images/icons/light-mode/active/Upload Media_light_hover_selected.svg');
+}
+
+/* .page-sidebar li.nav-item-my-media .material-icons{
+	background-image: url('../images/icons/light-mode/default/Upload Media_light_active.svg');
+}
+
+.page-sidebar li.active.nav-item-my-media .material-icons,
+.page-sidebar li:hover.nav-item-my-media .material-icons{
+	background-image: url('../images/icons/light-mode/active/Upload Media_light_hover_selected.svg');
+} */
+
+.page-sidebar li.nav-item-my-playlists .material-icons{
+	background-image: url('../images/icons/light-mode/default/My Playlists_light_active.svg');
+}
+
+.page-sidebar li.active.nav-item-my-playlists .material-icons,
+.page-sidebar li:hover.nav-item-my-playlists .material-icons{
+	background-image: url('../images/icons/light-mode/active/My Playlists_light_hover_selected.svg');
+}
+
+.page-sidebar li.nav-item-history .material-icons{
+	background-image: url('../images/icons/light-mode/default/My History_light_active.svg');
+}
+
+.page-sidebar li.active.nav-item-history .material-icons,
+.page-sidebar li:hover.nav-item-history .material-icons{
+	background-image: url('../images/icons/light-mode/active/My History_light_hover_selected.svg');
+}
+
+.page-sidebar li.nav-item-about-us .material-icons{
+	background-image: url('../images/icons/light-mode/default/About Us_light_active.svg');
+}
+
+.page-sidebar li.active.nav-item-about-us .material-icons,
+.page-sidebar li:hover.nav-item-about-us .material-icons{
+	background-image: url('../images/icons/light-mode/active/About Us_light_hover_selected.svg');
+}
+
+.page-sidebar li.nav-item-editorial-policy .material-icons{
+	background-image: url('../images/icons/light-mode/default/Editorial Policy_light_active.svg');
+}
+
+.page-sidebar li.active.nav-item-editorial-policy .material-icons,
+.page-sidebar li:hover.nav-item-editorial-policy .material-icons{
+	background-image: url('../images/icons/light-mode/active/Editorial Policy_light_hover_selected.svg');
+}
+
+.page-sidebar li.nav-item-contact-us .material-icons{
+	background-image: url('../images/icons/light-mode/default/Contact_light_active.svg');
+}
+
+.page-sidebar li.active.nav-item-contact-us .material-icons,
+.page-sidebar li:hover.nav-item-contact-us .material-icons{
+	background-image: url('../images/icons/light-mode/active/Contact_light_hover_selected.svg');
+}
+
+
+
+
+
+.page-sidebar li.nav-item-manage-media .material-icons,
+.page-sidebar li.nav-item-manage-users .material-icons,
+.page-sidebar li.nav-item-manage-comments .material-icons{
+	background-image: url('../images/icons/light-mode/default/Manage_light_active.svg');
+}
+
+.page-sidebar li.active.nav-item-manage-media .material-icons,
+.page-sidebar li:hover.nav-item-manage-media .material-icons,
+.page-sidebar li.active.nav-item-manage-users .material-icons,
+.page-sidebar li:hover.nav-item-manage-users .material-icons,
+.page-sidebar li.active.nav-item-manage-comments .material-icons,
+.page-sidebar li:hover.nav-item-manage-comments .material-icons{
+	background-image: url('../images/icons/light-mode/active/Manage_light_hover_selected.svg');
+}
+
+
+
+
+
+body.dark_theme .page-sidebar li.material-icons{
+	color:#026691;
+}
+
+body.dark_theme .page-sidebar li.active .material-icons,
+body.dark_theme .page-sidebar li:hover .material-icons{
+	color:#7bbbbf;
+}
+
+body.dark_theme .page-sidebar li.nav-item-featured .material-icons{
+	background-image: url('../images/icons/dark-mode/default/Featured_dark_active.svg');
+}
+
+body.dark_theme .page-sidebar li.active.nav-item-featured .material-icons,
+body.dark_theme .page-sidebar li:hover.nav-item-featured .material-icons{
+	background-image: url('../images/icons/dark-mode/active/Featured_dark_hover_selected.svg');
+}
+
+body.dark_theme .page-sidebar li.nav-item-recommended .material-icons{
+	background-image: url('../images/icons/dark-mode/default/Trending_dark_active.svg');
+}
+
+body.dark_theme .page-sidebar li.active.nav-item-recommended .material-icons,
+body.dark_theme .page-sidebar li:hover.nav-item-recommended .material-icons{
+	background-image: url('../images/icons/dark-mode/active/Trending_dark_hover_selected.svg');
+}
+
+body.dark_theme .page-sidebar li.nav-item-latest .material-icons{
+	background-image: url('../images/icons/dark-mode/default/Recent Uploads_dark_active.svg');
+}
+
+body.dark_theme .page-sidebar li.active.nav-item-latest .material-icons,
+body.dark_theme .page-sidebar li:hover.nav-item-latest .material-icons{
+	background-image: url('../images/icons/dark-mode/active/Recent Uploads_dark_hover_selected.svg');
+}
+
+body.dark_theme .page-sidebar li.nav-item-categories .material-icons{
+	background-image: url('../images/icons/dark-mode/default/Categories_dark_active.svg');
+}
+
+body.dark_theme .page-sidebar li.active.nav-item-categories .material-icons,
+body.dark_theme .page-sidebar li:hover.nav-item-categories .material-icons{
+	background-image: url('../images/icons/dark-mode/active/Categories_dark_hover_selected.svg');
+}
+
+body.dark_theme .page-sidebar li.nav-item-topics .material-icons{
+	background-image: url('../images/icons/dark-mode/default/Topics_dark_active.svg');
+}
+
+body.dark_theme .page-sidebar li.active.nav-item-topics .material-icons,
+body.dark_theme .page-sidebar li:hover.nav-item-topics .material-icons{
+	background-image: url('../images/icons/dark-mode/active/Topics_dark_hover_selected.svg');
+}
+
+body.dark_theme .page-sidebar li.nav-item-languages .material-icons{
+	background-image: url('../images/icons/dark-mode/default/Languages_dark_active.svg');
+}
+
+body.dark_theme .page-sidebar li.active.nav-item-languages .material-icons,
+body.dark_theme .page-sidebar li:hover.nav-item-languages .material-icons{
+	background-image: url('../images/icons/dark-mode/active/Languages_dark_hover_selected.svg');
+}
+
+body.dark_theme .page-sidebar li.nav-item-countries .material-icons{
+	background-image: url('../images/icons/dark-mode/default/Countries_dark_active.svg');
+}
+
+body.dark_theme .page-sidebar li.active.nav-item-countries .material-icons,
+body.dark_theme .page-sidebar li:hover.nav-item-countries .material-icons{
+	background-image: url('../images/icons/dark-mode/active/Countries_dark_hover_selected.svg');
+}
+
+body.dark_theme .page-sidebar li.nav-item-playlist .material-icons{
+	background-image: url('../images/icons/dark-mode/default/Playlists_dark_active.svg');
+}
+
+body.dark_theme .page-sidebar li.active.nav-item-playlist .material-icons,
+body.dark_theme .page-sidebar li:hover.nav-item-playlist .material-icons{
+	background-image: url('../images/icons/dark-mode/active/Playlists_dark_hover_selected.svg');
+}
+
+body.dark_theme .page-sidebar li.nav-item-upload-media .material-icons{
+	background-image: url('../images/icons/dark-mode/default/Upload Media_dark_active.svg');
+}
+
+body.dark_theme .page-sidebar li.active.nav-item-upload-media .material-icons,
+body.dark_theme .page-sidebar li:hover.nav-item-upload-media .material-icons{
+	background-image: url('../images/icons/dark-mode/active/Upload Media_dark_hover_selected.svg');
+}
+
+/* body.dark_theme .page-sidebar li.nav-item-my-media .material-icons{
+	background-image: url('../images/icons/dark-mode/default/Upload Media_dark_active.svg');
+}
+
+body.dark_theme .page-sidebar li.active.nav-item-my-media .material-icons,
+body.dark_theme .page-sidebar li:hover.nav-item-my-media .material-icons{
+	background-image: url('../images/icons/dark-mode/active/Upload Media_dark_hover_selected.svg');
+} */
+
+body.dark_theme .page-sidebar li.nav-item-my-playlists .material-icons{
+	background-image: url('../images/icons/dark-mode/default/My Playlists_dark_active.svg');
+}
+
+body.dark_theme .page-sidebar li.active.nav-item-my-playlists .material-icons,
+body.dark_theme .page-sidebar li:hover.nav-item-my-playlists .material-icons{
+	background-image: url('../images/icons/dark-mode/active/My Playlists_dark_hover_selected.svg');
+}
+
+body.dark_theme .page-sidebar li.nav-item-history .material-icons{
+	background-image: url('../images/icons/dark-mode/default/My History_dark_active.svg');
+}
+
+body.dark_theme .page-sidebar li.active.nav-item-history .material-icons,
+body.dark_theme .page-sidebar li:hover.nav-item-history .material-icons{
+	background-image: url('../images/icons/dark-mode/active/My History_dark_hover_selected.svg');
+}
+
+body.dark_theme .page-sidebar li.nav-item-about-us .material-icons{
+	background-image: url('../images/icons/dark-mode/default/About Us_dark_active.svg');
+}
+
+body.dark_theme .page-sidebar li.active.nav-item-about-us .material-icons,
+body.dark_theme .page-sidebar li:hover.nav-item-about-us .material-icons{
+	background-image: url('../images/icons/dark-mode/active/About Us_dark_hover_selected.svg');
+}
+
+body.dark_theme .page-sidebar li.nav-item-editorial-policy .material-icons{
+	background-image: url('../images/icons/dark-mode/default/Editorial Policy_dark_active.svg');
+}
+
+body.dark_theme .page-sidebar li.active.nav-item-editorial-policy .material-icons,
+body.dark_theme .page-sidebar li:hover.nav-item-editorial-policy .material-icons{
+	background-image: url('../images/icons/dark-mode/active/Editorial Policy_dark_hover_selected.svg');
+}
+
+body.dark_theme .page-sidebar li.nav-item-contact-us .material-icons{
+	background-image: url('../images/icons/dark-mode/default/Contact_dark_active.svg');
+}
+
+body.dark_theme .page-sidebar li.active.nav-item-contact-us .material-icons,
+body.dark_theme .page-sidebar li:hover.nav-item-contact-us .material-icons{
+	background-image: url('../images/icons/dark-mode/active/Contact_dark_hover_selected.svg');
+}
+
+
+
+
+
+body.dark_theme .page-sidebar li.nav-item-manage-media .material-icons,
+body.dark_theme .page-sidebar li.nav-item-manage-users .material-icons,
+body.dark_theme .page-sidebar li.nav-item-manage-comments .material-icons{
+	background-image: url('../images/icons/dark-mode/default/Manage_dark_active.svg');
+}
+
+body.dark_theme .page-sidebar li.active.nav-item-manage-media .material-icons,
+body.dark_theme .page-sidebar li:hover.nav-item-manage-media .material-icons,
+body.dark_theme .page-sidebar li.active.nav-item-manage-users .material-icons,
+body.dark_theme .page-sidebar li:hover.nav-item-manage-users .material-icons,
+body.dark_theme .page-sidebar li.active.nav-item-manage-comments .material-icons,
+body.dark_theme .page-sidebar li:hover.nav-item-manage-comments .material-icons{
+	background-image: url('../images/icons/dark-mode/active/Manage_dark_hover_selected.svg');
+}
+
+/* #################################################################################################### */
+
+body .media-title-banner h1{
+	font-size: 26px;
+	line-height:32px;
+	margin-bottom: 8px;
+	font-family: 'Facultad', Arial, sans-serif;
+}
+
+body.dark_theme .media-title-banner h1{
+	color:#fff;
+}
+
+body .media-content-summary,
+body .media-content-description,
+body .media-content-description p{
+	line-height:21px;
+	font-weight:500;
+}
+
+body.dark_theme .thumbnail,
+body.dark_theme .thumbnail.circle-icon-button{
+	color:var(--body-bg-color);
+	background-color:#bad8dd;
+}
+
+body .media-info-content .media-author-banner .author-banner-name{
+	font-size:16px;
+	line-height:21px;
+}
+
+body.dark_theme .media-info-content .media-author-banner .author-banner-name{
+	color:#fff;
+}
+
+body .media-title-banner .media-views .author-banner-date,
+body .media-info-content .media-author-banner,
+body .media-content-field-label h4{
+	font-size:14px;
+	font-weight:500;
+	line-height:21px;
+}
+
+body.dark_theme .media-title-banner .media-views,
+body.dark_theme .media-info-content .media-author-banner,
+body.dark_theme .media-content-field-label h4{
+	color:rgba(255,255,255,0.4);
+}
+
+body .media-year-produced {
+	color: #1a3f61;
+}
+
+body.dark_theme .media-year-produced,
+body.dark_theme .media-content-field-content a{
+	color:#7bbbbf;
+}
+
+
+
+body.dark_theme button.load-more{
+	color:#bad8dd;
+}
+
+body .media-author-actions a{
+	color:#fff;
+}
+
+body .viewer-sidebar .auto-play-header .next-label,
+body .viewer-sidebar .auto-play-header .auto-play-option label{
+	font-size: 15px;
+	font-weight:500;
+	line-height:1;
+	text-transform: uppercase;
+}
+
+body.dark_theme .viewer-sidebar .auto-play-header .auto-play-option label{
+	color:rgba(255,255,255,0.5);
+}
+
+@media screen and (min-width: 1008px){
+	body .viewer-sidebar .auto-play-header{
+		margin-top:24px;
+		margin-bottom:32px;
+	}
+}
+
+body .viewer-sidebar .auto-play .item{
+	padding-bottom:40px;
+	margin-bottom:40px;
+}
+
+@media screen and (min-width: 390px){
+
+	body .viewer-sidebar .item-main{
+		padding-left:12px !important;
+	}
+
+	body .viewer-sidebar .item-main h3,
+	body .sliding-sidebar .viewer-sidebar .item-main h3,
+	body .visible-sidebar .viewer-sidebar .item-main h3{
+		margin-top:0 !important;
+	}
+}
+
+body .viewer-sidebar .item-main h3,
+body .sliding-sidebar .viewer-sidebar .item-main h3,
+body .visible-sidebar .viewer-sidebar .item-main h3{
+	font-size: 18px !important;
+	line-height: 24px !important;
+	margin-bottom:12px !important;
+}
+
+@media screen and (min-width: 390px){
+	body .viewer-sidebar .item-main span{
+		max-height: 42px;
+	}
+}
+
+body .viewer-sidebar .item-author{
+	margin-bottom:6px;
+}
+
+body .viewer-sidebar .item-author span,
+body .viewer-sidebar .item-views{
+	font-size:12px !important;
+	font-weight:500 !important;
+}
+
+body .viewer-sidebar .item-meta{
+	color:#869ea5;
+}
+
+body.dark_theme .viewer-sidebar .item-meta{
+	color:#bad8dd;
+}
+
+body .viewer-sidebar .item-author span{
+	color: var(--default-brand-color);
+}
+
+@media screen and (min-width: 1217px) and (max-width: 1439px){
+
+	body .viewer-wide .viewer-container,
+	body .viewer-wide .viewer-info{
+		width:65%;
+	}
+
+	body .viewer-wide .viewer-sidebar{
+		width:35%;
+	}
+}
+
+@media screen and (min-width: 1440px) and (max-width: 1919px){
+
+	body .viewer-wide .viewer-container,
+	body .viewer-wide .viewer-info{
+		width:70%;
+	}
+
+	body .viewer-wide .viewer-sidebar{
+		width:30%;
+	}
+}
+
+@media screen and (min-width: 390px){
+
+	body .items-list-hor .item-main h3 span{
+		max-height: calc( 3 + var(--horizontal-item-title-line-height) );
+		-webkit-line-clamp: 3;
+	}
+}
+
+/* #################################################################################################### */
+
+body .media-actions{
+
+}
+
+body .media-actions .like > button,
+body .media-actions .share > button,
+body .media-actions .save > button,
+body .media-actions .download > a,
+body .media-actions .video-downloads > button{
+	/* background:none !important; */
+}
+
+body .media-country,
+body .author-banner-date,
+body .media-actions .media-views,
+body .media-actions .like > button,
+body .media-actions .share > button,
+body .media-actions .save > button,
+body .media-actions .download > a,
+body .media-actions .video-downloads > button,
+body .media-actions .more-options > span > button{
+	font-size:14px !important;
+	color:#323333;
+	/* font-weight:400 !important; */
+}
+
+body .media-title-banner .media-actions > div > div > button,
+body .media-title-banner .media-actions > div > div > .circle-icon-button{
+	color:#323333;
+}
+
+body.dark_theme .media-country,
+body.dark_theme .author-banner-date,
+body.dark_theme .media-actions .media-views,
+body.dark_theme .media-actions .like > button,
+body.dark_theme .media-actions .share > button,
+body.dark_theme .media-actions .save > button,
+body.dark_theme .media-actions .download > a,
+body.dark_theme .media-actions .video-downloads > button,
+body.dark_theme .media-actions .more-options > span > button{
+	color:#bad8dd;
+}
+
+body .media-actions .like > button .circle-icon-button > *,
+body .media-actions .share > button .circle-icon-button > *,
+body .media-actions .save > button .circle-icon-button > *,
+body .media-actions .download > a .circle-icon-button > *,
+body .media-actions .video-downloads > button .circle-icon-button > *{
+	background:none !important;
+}
+
+body .media-actions .like > button .material-icons,
+body .media-actions .share > button .material-icons,
+body .media-actions .save > button .material-icons,
+body .media-actions .download > a .material-icons,
+body .media-actions .video-downloads > button .material-icons{
+	width:20px;
+	height:20px;
+	background-size:contain;
+	background-position: center;
+	background-repeat: no-repeat;
+}
+
+body .media-actions .like:before,
+body .media-actions .like > button .material-icons:after,
+body .media-actions .share > button .material-icons:after,
+body .media-actions .save > button .material-icons:after,
+body .media-actions .download > a .material-icons:after,
+body .media-actions .video-downloads > button .material-icons:after{
+	display:none;
+}
+
+body .media-actions .like{
+
+}
+
+body .media-actions .like > button .material-icons{
+	background-image: url('../images/icons/light-mode/default/Like_light_active.svg');
+}
+
+body .media-actions .like > button:focus .material-icons,
+body .media-actions .like > button:active .material-icons{
+	background-image: url('../images/icons/light-mode/active/Like_light_hover_selected.svg');
+}
+
+body.dark_theme .media-actions .like > button .material-icons{
+	background-image: url('../images/icons/dark-mode/default/Like_dark_active.svg');
+}
+
+body.dark_theme .media-actions .like > button:focus .material-icons,
+body.dark_theme .media-actions .like > button:active .material-icons{
+	background-image: url('../images/icons/dark-mode/active/Like_dark_hover_selected.svg');
+}
+
+body .media-actions .share{
+
+}
+
+body .media-actions .share > button .material-icons{
+	background-image: url('../images/icons/light-mode/default/Share_light_active.svg');
+}
+
+body .media-actions .share > button:focus .material-icons,
+body .media-actions .share > button:active .material-icons{
+	background-image: url('../images/icons/light-mode/active/Share_light_hover_selected.svg');
+}
+
+body.dark_theme .media-actions .share > button .material-icons{
+	background-image: url('../images/icons/dark-mode/default/Share_dark_active.svg');
+}
+
+body.dark_theme .media-actions .share > button:focus .material-icons,
+body.dark_theme .media-actions .share > button:active .material-icons{
+	background-image: url('../images/icons/dark-mode/active/Share_dark_hover_selected.svg');
+}
+
+body .media-actions .save{
+
+}
+
+body .media-actions .save > button .material-icons{
+	background-image: url('../images/icons/light-mode/default/Save Playlist_light_active.svg');
+}
+
+body .media-actions .save > button:focus .material-icons,
+body .media-actions .save > button:active .material-icons{
+	background-image: url('../images/icons/light-mode/active/Save Playlist_light_hover_selected.svg');
+}
+
+body.dark_theme .media-actions .save > button .material-icons{
+	background-image: url('../images/icons/dark-mode/default/Save Playlist_dark_active.svg');
+}
+
+body.dark_theme .media-actions .save > button:focus .material-icons,
+body.dark_theme .media-actions .save > button:active .material-icons{
+	background-image: url('../images/icons/dark-mode/active/Save Playlist_dark_hover_selected.svg');
+}
+
+body .media-actions .video-downloads{
+
+}
+
+body .media-actions .download > a .material-icons,
+body .media-actions .video-downloads > button .material-icons{
+	background-image: url('../images/icons/light-mode/default/Download_light_active.svg');
+}
+
+body .media-actions .download > a:focus .material-icons,
+body .media-actions .download > a:active .material-icons,
+body .media-actions .video-downloads > button:focus .material-icons,
+body .media-actions .video-downloads > button:active .material-icons{
+	background-image: url('../images/icons/light-mode/active/Download_light_hover_selected.svg');
+}
+
+body.dark_theme .media-actions .download > a .material-icons,
+body.dark_theme .media-actions .video-downloads > button .material-icons{
+	background-image: url('../images/icons/dark-mode/default/Download_dark_active.svg');
+}
+
+body.dark_theme .media-actions .download > a:focus .material-icons,
+body.dark_theme .media-actions .download > a:active .material-icons,
+body.dark_theme .media-actions .video-downloads > button:focus .material-icons,
+body.dark_theme .media-actions .video-downloads > button:active .material-icons{
+	background-image: url('../images/icons/dark-mode/active/Download_dark_hover_selected.svg');
+}
+
+body .viewer-section.viewer-wide,
+body .viewer-section .viewer-section.viewer-section-nested{
+	max-width:1920px;
+}
+
+body.dark_theme .media-title-banner{
+	border-color:#676e75;
+}
+
+body.dark_theme .viewer-sidebar .auto-play .item{
+	border-color:#6f767c;
+}
+
+body .video-js.vjs-mediacms .vjs-progress-control .vjs-progress-holder .vjs-play-progress{
+	background-color: #025196;
+}
+
+body .video-js.vjs-mediacms .vjs-progress-control .vjs-progress-holder .vjs-play-progress:before{
+	color: #025196;
+}
+
+@media screen and (min-width: 390px){
+
+	body .viewer-sidebar .items-list-hor .item{
+		margin-bottom:27px;
+	}
+}
+
+@media screen and (min-width: 640px){
+
+	body .viewer-container{
+		padding-left:29px;
+	}
+
+	body .viewer-info-inner{
+		margin-left:29px;
+	}
+}
+
+@media screen and (min-width: 1008px) {
+
+	body .viewer-sidebar .items-list-hor .item{
+		margin-bottom:21px;
+	}
+
+	body .viewer-sidebar{
+		padding-left:16px !important;
+		padding-right:47px !important;
+	}
+
+	body .viewer-sidebar .item-thumb,
+	body .viewer-sidebar a.item-thumb,
+	body .sliding-sidebar .viewer-sidebar .item-thumb,
+	body .sliding-sidebar .viewer-sidebar a.item-thumb,
+	body .visible-sidebar .viewer-sidebar .item-thumb,
+	body .visible-sidebar .viewer-sidebar a.item-thumb{
+		width:220px !important;
+		height: calc( 0.5611 * 220px) !important;
+	}
+
+	body .viewer-sidebar .item-content,
+	body .sliding-sidebar .viewer-sidebar .item-content,
+	body .visible-sidebar .viewer-sidebar .item-content{
+		padding-left:220px !important;
+	}
+
+	body .viewer-sidebar .item-main,
+	body .sliding-sidebar .viewer-sidebar .item-main,
+	body .visible-sidebar .viewer-sidebar .item-main{
+		min-height: calc( 12px + calc( 0.5611 * 220px) ) !important;
+	}
+}
+
+/* #################################################################################################### */
+
+body.dark_theme .user-contact-form input,
+body.dark_theme .user-contact-form textarea{
+	border-color: #436776;
+}
+
+body.dark_theme .profile-page-header .profile-info-nav-wrap,
+body.dark_theme .profile-page-header .profile-info-nav-wrap:before{
+	/* background-color:#0b3144; */
+	background-color:var(--header-bg-color);
+}
+
+body.dark_theme .profile-page-header .profile-info h1{
+	font-family: 'Facultad', Arial, sans-serif;
+}
+
+body.dark_theme .profile-page-header .profile-nav{
+	background-color:#0b3144;
+	border-bottom-color:#0b3144;
+
+	background-color:var(--header-bg-color);
+	border-bottom-color:var(--header-bg-color);
+}
+
+body.dark_theme .profile-page-header .profile-nav ul li a{
+	color:#bad8dd;
+}
+
+body.dark_theme .profile-page-header .profile-nav ul li.active a{
+	color:#fff;
+}
+
+body.dark_theme .profile-page-header .profile-nav ul li.active:after{
+	background-color:var(--default-theme-color);
+}
+
+/* #################################################################################################### */
+
+body .playlist-item .playlist-count,
+body .playlist-item .playlist-hover-play-all{
+	background-color: rgba(15, 26, 37, .8);
+}
+
+
+body .playlist-item .playlist-hover-play-all{
+	background-color: rgba(15, 26, 37, .8);
+}
+
+body.dark_theme .playlist-item .item-main a.view-full-playlist{
+	font-weight:500;
+	color:rgba(255,255,255,0.4);
+}
+
+body.dark_theme .playlist-item .item-main a:hover.view-full-playlist{
+	color:#fff;
+}
+
+body.dark_theme #page-profile-about .profile-details li > span:first-child{
+	font-weight:500;
+	color:rgba(255,255,255,0.4);
+}
+
+body .playlist-view .playlist-media{
+	background-color:var(--playlist-page-video-list-bg-color);
+}
+
+body.dark_theme .playlist-view .playlist-media{
+	background-color:rgba(15, 26, 37, 1);
+}
+
+body .playlist-view .playlist-media .item{
+	margin-bottom:0;
+}
+
+body .playlist-view .playlist-media .items-list-hor .item-main h3{
+	font-size:14px !important;
+}
+
+body .playlist-view .playlist-title{
+	font-family: 'Facultad', Arial, sans-serif;
+	font-size:16px;
+}
+
+body .playlist-meta,
+body .playlist-meta .counter{
+	font-weight:600;
+}
+
+body .playlist-view .playlist-media .item-order-number{
+	font-weight:500;
+}
+
+body .playlist-view .playlist-meta a{
+	color:#000;
+}
+
+body.dark_theme .playlist-view .playlist-meta a{
+	color:#fff;
+}
+
+body .playlist-view .playlist-meta .counter,
+body .playlist-view .playlist-media .item-order-number{
+	color:#869ea5;
+}
+
+body.dark_theme .playlist-meta .counter,
+body .playlist-view .playlist-media .item-order-number{
+	color:#bad8dd;
+}
+
+body .playlist-view .playlist-header,
+body .playlist-view .playlist-actions,
+body .playlist-view .playlist-header .toggle-playlist-view,
+body .playlist-view .playlist-actions .circle-icon-button{
+	background-color:var(--playlist-page-details-bg-color);
+}
+
+body .playlist-view .playlist-actions .circle-icon-button.active{
+	color:#ed7c30;
+}
+
+body.dark_theme .playlist-view .playlist-header,
+body.dark_theme .playlist-view .playlist-actions,
+body.dark_theme .playlist-view .playlist-header .toggle-playlist-view,
+body.dark_theme .playlist-view .playlist-actions .circle-icon-button{
+	background-color:#0b3145;
+}
+
+/* #################################################################################################### */
+
+body.dark_theme .playlist-details{
+	background: rgba(11, 49, 68, .6);
+	background-color:#0b3145;
+}
+
+body.dark_theme .playlist-details .playlist-title h1{
+	font-family: 'Facultad', Arial, sans-serif;
+}
+
+body.dark_theme .playlist-details .playlist-meta{
+	font-weight:500;
+	color:#869ea5;
+}
+
+body.dark_theme .playlist-details .playlist-description{
+	font-weight:500;
+	color:#fff;
+}
+
+body.dark_theme #page-playlist,
+body.dark_theme .playlist-videos-list,
+body.dark_theme .playlist-videos-list > *,
+body.dark_theme .playlist-videos-list .item .item-content h3 span{
+	background: rgba(15, 26, 37, 1);
+}
+
+body.dark_theme .playlist-videos-list .item:hover,
+body.dark_theme .playlist-videos-list .item:hover .item-content h3 span{
+	background: #0d202e;
+}
+
+/* #################################################################################################### */
+
+body.dark_theme .user-action-form-inner{
+	background-color:#0b3145;
+}
+
+body.dark_theme .user-action-form-inner input,
+body.dark_theme .user-action-form-inner textarea{
+	border-width:1px 1px 2px 1px;
+	border-color:#0b3145 #0b3145 #436776 #0b3145;
+	background-color:#0b3145;
+	box-shadow:none;
+
+	border-width:1px;
+	border-color:#436776;
+}
+
+body.dark_theme .user-action-form-inner input:focus,
+body.dark_theme .user-action-form-inner textarea:focus{
+	/* background-color:rgba(15, 26, 37, 0.2); */
+}
+
+body.dark_theme .user-action-form-inner button,
+body.dark_theme .user-action-form-inner *[type="submit"],
+body.dark_theme .user-action-form-inner *[type="button"]{
+	color:#fff;
+	background-color:#7BBBBF;
+}
+
+body .user-action-form-wrap{
+	margin-top:60px;
+}
+
+body .user-action-form-wrap > h1{
+	position:relative;
+	max-width:640px;
+	margin:0 auto;
+	padding-bottom:10px;
+	margin-bottom:20px;
+}
+
+body .user-action-form-wrap > h1:after{
+	content:"";
+	position:absolute;
+	display:block;
+	bottom:0;
+	left:0;
+	width:50px;
+	height: 3px;
+	background-color:#e7a27b;
+}
+
+/**
+Home Page
+*/
+/* Styling the even lists */
+body .hw-even-list {
+	background-color: #0c3144
+}
+body .hw-recent-videos-section {
+	display: inline;
+}
+/* Category Title & Description */
+body .hw-category {
+	display: flex;
+	justify-content: space-between;
+	align-items: flex-end;
+	margin-bottom: 20px;
+}
+body .hw-category-title {
+	color: #fff;
+	margin: 30px 0 0 0;
+}
+body .hw-category-description {
+	color: #fff;
+	padding: 5px 0 30px 0;
+	max-width: 512px;
+}
+/* View all (link to the category) */
+body a.hw-category-link {
+	color: #ed7c30;
+	font-size: 14px;
+	flex-shrink: 0;
+	text-decoration: none;
+	text-transform: none;
+	margin-right: 25px;
+}
+
+/* Do not show again the recent videos that was displayed in the first section */
+/*
+body .items-list-ver .feat-first-item.hw-most-recent-videos .item:first-child,
+body .items-list-ver .feat-first-item.hw-most-recent-videos .item:nth-child(3),
+body .items-list-ver .feat-first-item.hw-most-recent-videos .item:nth-child(4),
+body .items-list-ver .feat-first-item.hw-most-recent-videos .item:nth-child(5),
+body .items-list-ver .feat-first-item.hw-most-recent-videos .item:nth-child(6),
+body .items-list-ver .feat-first-item.hw-most-recent-videos .item:nth-child(7),
+body .items-list-ver .feat-first-item.hw-most-recent-videos .item:nth-child(8),
+body .items-list-ver .feat-first-item.hw-most-recent-videos .item:nth-child(9),
+body .items-list-ver .feat-first-item.hw-most-recent-videos .item:nth-child(2) {
+	display: none;
+}
+*/
+
+/* body .items-list-ver .feat-first-item.hw-most-recent-videos .item:first-child {
+	display: none;
+} */
+
+/* Homepage Popup */
+.homepage-popup {
+	position: fixed;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	padding: 16px;
+}
+.homepage-popup-fullscreen {
+	z-index: +4;
+	position: fixed;
+	display: table;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	width: 100%;
+	height: 100%;
+	padding: 24px 40px;
+	padding-top: -webkit-calc( var(--header-height) + 24px);
+	padding-top: -moz-calc( var(--header-height) + 24px);
+	padding-top: calc( var(--header-height) + 24px);
+	-webkit-box-shadow: none;
+	-moz-box-shadow: none;
+	box-shadow: none;
+	background: rgb(17 26 36 / 70%);
+}
+.homepage-popup--container {
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+	max-width: 100%;
+	width: 100%;
+	min-height: 100vh;
+}
+.homepage-popup--img-container {
+	position: relative;
+	z-index: 1050;
+}
+.homepage-popup--image {
+	height: auto;
+	max-width: 900px;
+	width: 100%;
+	margin: 0 auto;
+}
+.homepage-popup--close-btn {
+	position: absolute;
+	top: -32px;
+	right: -4px;
+	background: none;
+	border: none;
+	display: flex;
+	align-items: center;
+	opacity: 0.6;
+	transition: all 0.3s;
+}
+.homepage-popup--close-btn:hover {
+	opacity: 1;
+}
+.homepage-popup--close-btn span {
+	color: #ffffff;
+	margin-right: 4px;
+}
+.homepage-popup--close-btn--icon {
+	width: 24px;
+	height: 24px;
+	color: #ffffff;
+}
+/* When the top bar is displayed, give margin to logo navbar. */
+.top-message-body .page-header,
+.top-message-body #app-sidebar,
+.top-message-body .page-sidebar-inner {
+	margin-top: 43px;
+}
+
+
+.top-message--text {
+	font-size: 14px;
+}


### PR DESCRIPTION
## Summary
Reduces the TinyMCE page content width from 1366px to 800px to improve readability and provide a more modern layout.

## Changes
- Modified `.page-main-inner .custom-page-wrapper` width in `frontend/src/static/css/_extra.css`
- Changed from `width: 1366px` to `width: 800px`

## Benefits
- ✅ Better text readability (optimal 65-75 characters per line)
- ✅ Reduced image size requirements for content
- ✅ More modern, focused layout
- ✅ Improved mobile responsiveness

## Testing
- [x] Verified CSS change is applied
- [x] Tested with various content types (headings, paragraphs, images, videos)
- [x] Confirmed responsive behavior maintained

[Screencast from Wednesday, 23 July, 2025 11:02:23 AM PST.webm](https://github.com/user-attachments/assets/453ba823-5154-4bac-920a-96c6201853ba)
