### PR TITLE
feat: Convert year field from text input to dropdown (2000-2025)

### DIFF
--- a/files/forms.py
+++ b/files/forms.py
@@ -58,11 +58,21 @@ class MediaForm(forms.ModelForm):
 
         widgets = {
             "tags": MultipleSelect(),
+            "year_produced": forms.Select(), 
         }
 
     def __init__(self, user, *args, **kwargs):
         self.user = user
         super(MediaForm, self).__init__(*args, **kwargs)
+        current_year = datetime.now().year
+        year_choices = [('', '-- Select Year --')]  # Empty option first
+
+        # Create list of years from current year down to 2000
+        for year in range(current_year, 1999, -1):  # 1999 because range is exclusive
+            year_choices.append((year, str(year)))
+
+        # Apply choices to the dropdown widget
+        self.fields["year_produced"].widget.choices = year_choices
         self.fields["state"].label = "Status"
         self.fields["allow_download"].label = "Allow Download"
         self.fields["reported_times"].label = "Reported Times"
@@ -146,11 +156,12 @@ class MediaForm(forms.ModelForm):
         if year_produced:
             if not isinstance(year_produced, int):
                 raise forms.ValidationError(
-                    "Year produced must be a year between 1900 and now"
+                    "Year produced must be a year between 2000 and now"
                 )
-            if not (1900 <= year_produced and year_produced <= datetime.now().year):
+            current_year = datetime.now().year
+            if not (2000 <= year_produced <= current_year):
                 raise forms.ValidationError(
-                    "Year produced must be a year between 1900 and now"
+                    f"Year produced must be between 2000 and {current_year}"
                 )
         return year_produced
 


### PR DESCRIPTION
- Replace year_produced text input with Select widget
- Add dynamic year choices generation (current year down to 2000)
- Update validation to match new year range
- Improve UX by preventing invalid year entries and typos
- Copy working Makefile and celery.py from tinymce-width branch

Resolves year input usability issues in media edit form. An enhancement is available in #126 

## Motivation and Context
It doesn't look good,d and it's prone to errors

## How Has This Been Tested?
- Ubuntu 22.0.4 running locally using Brave and Chromium

## Screenshots (if appropriate):
<img width="2541" height="1522" alt="Screenshot from 2025-07-24 15-13-54" src="https://github.com/user-attachments/assets/1a5fb3e6-8224-469a-b6c4-99af021b5f9f" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- {x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
