### PR TITLE
feat: Add dynamic featured images for text articles

### DIFF
--- a/files/templatetags/custom_tags.py
+++ b/files/templatetags/custom_tags.py
@@ -1,36 +1,83 @@
-# files/templatetags/custom_tags.py
-
 from django import template
 import re
 from urllib.parse import urlparse
+import os
 
 register = template.Library()
 
 @register.simple_tag
 def extract_first_image(html_content):
-    """Extract first image from HTML using regex"""
+    """
+    Extract first image from HTML using regex (no dependencies needed)
+    Works with TinyMCE uploaded images
+    """
     if not html_content:
         return None
     
+    # Find first img tag with src attribute
     img_pattern = r'<img[^>]+src=["\']([^"\']+)["\'][^>]*>'
     match = re.search(img_pattern, html_content, re.IGNORECASE)
     
     if match:
         src = match.group(1)
-        if src.startswith('/'):
-            return src
-        elif src.startswith('http'):
+        
+        # Clean up the URL and handle relative paths
+        if src.startswith('http'):
+            # Full URL - extract path if it's from same domain
             parsed = urlparse(src)
-            return parsed.path
-        else:
-            if not src.startswith('/media/'):
-                return f"/media/{src}"
+            src = parsed.path
+        
+        # Normalize the path to remove ../ and other relative path issues
+        src = os.path.normpath(src)
+        
+        # Ensure it starts with /
+        if not src.startswith('/'):
+            src = '/' + src
+            
+        # If it's already a proper media path, return it
+        if src.startswith('/media/'):
             return src
+        
+        # If it's a relative path to media, fix it
+        if 'tinymce_media/' in src or 'userlogos/' in src:
+            # Extract just the media part
+            if 'tinymce_media/' in src:
+                media_part = src[src.find('tinymce_media/'):]
+                return f"/media/{media_part}"
+            elif 'userlogos/' in src:
+                media_part = src[src.find('userlogos/'):]
+                return f"/media/{media_part}"
+        
+        # Default: assume it's a file that should be in /media/
+        if not src.startswith('/media/'):
+            return f"/media/{src.lstrip('/')}"
+        
+        return src
+    
     return None
 
 @register.simple_tag  
+def get_social_image_url(media_object, frontend_host):
+    """
+    Get complete social media image URL for any media type
+    """
+    default_image = f"{frontend_host}/media/userlogos/cinemata_share_banner-01.png"
+    
+    if media_object.media_type == 'text':
+        first_image = extract_first_image(media_object.description)
+        return f"{frontend_host}{first_image}" if first_image else default_image
+    elif media_object.media_type in ['video', 'audio']:
+        return f"{frontend_host}{media_object.poster_url}" if media_object.poster_url else default_image
+    elif media_object.media_type == 'image':
+        return f"{frontend_host}{media_object.original_media_url}" if media_object.original_media_url else default_image
+    else:
+        return default_image
+
+@register.simple_tag  
 def get_social_image_url_for_page(page_object, frontend_host):
-    """Get social media image URL for static pages"""
+    """
+    Get complete social media image URL for static pages
+    """
     default_image = f"{frontend_host}/media/userlogos/cinemata_share_banner-01.png"
     
     if hasattr(page_object, 'description') and page_object.description:

--- a/files/templatetags/custom_tags.py
+++ b/files/templatetags/custom_tags.py
@@ -1,0 +1,40 @@
+# files/templatetags/custom_tags.py
+
+from django import template
+import re
+from urllib.parse import urlparse
+
+register = template.Library()
+
+@register.simple_tag
+def extract_first_image(html_content):
+    """Extract first image from HTML using regex"""
+    if not html_content:
+        return None
+    
+    img_pattern = r'<img[^>]+src=["\']([^"\']+)["\'][^>]*>'
+    match = re.search(img_pattern, html_content, re.IGNORECASE)
+    
+    if match:
+        src = match.group(1)
+        if src.startswith('/'):
+            return src
+        elif src.startswith('http'):
+            parsed = urlparse(src)
+            return parsed.path
+        else:
+            if not src.startswith('/media/'):
+                return f"/media/{src}"
+            return src
+    return None
+
+@register.simple_tag  
+def get_social_image_url_for_page(page_object, frontend_host):
+    """Get social media image URL for static pages"""
+    default_image = f"{frontend_host}/media/userlogos/cinemata_share_banner-01.png"
+    
+    if hasattr(page_object, 'description') and page_object.description:
+        first_image = extract_first_image(page_object.description)
+        return f"{frontend_host}{first_image}" if first_image else default_image
+    
+    return default_image

--- a/templates/cms/page.html
+++ b/templates/cms/page.html
@@ -1,16 +1,18 @@
 {% extends "base.html" %}
 {% load static %}
+{% load custom_tags %}
 
 {% block headtitle %}{{page.title}} - {{PORTAL_NAME}}{% endblock headtitle %}
 
 {% block headermeta %}
 
+{% get_social_image_url_for_page page FRONTEND_HOST as social_image %}
 <meta property="og:title" content="{{page.title}} - {{PORTAL_NAME}}">
 <meta property="og:type" content="website">
 <meta property="og:description" content="">
-
-<meta property="og:image" content="{{FRONTEND_HOST}}/media/userlogos/cinemata_share_banner-01.png">
+<meta property="og:image" content="{{social_image}}">
 <meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:image" content="{{social_image}}">
 
 <script type="application/ld+json">
 {
@@ -37,4 +39,5 @@
 	
 	{{page.description|safe}}
 
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
Implements automatic featured image extraction for text articles when shared on social media platforms (Facebook, Twitter, LinkedIn).

## Changes Made
- ✅ Created custom Django template tags for HTML image extraction
- ✅ Updated `page.html` template to use dynamic `og:image` meta tags  
- ✅ Added regex-based image parsing (no external dependencies)
- ✅ Fallback to default Cinemata banner when no images found

## Technical Details
- **Location**: `files/templatetags/custom_tags.py`
- **Method**: Regex parsing of TinyMCE HTML content
- **Templates**: Updated `templates/cms/page.html`
- **Dependencies**: None (uses Python built-ins)

## Testing
- [x] Template tags import correctly
- [x] Image extraction works with test content
- [x] Page loads without template errors
- [x] Social media meta tags show correct image URLs
- [x] Fallback works when no images present

## Before/After
**Before**: Text articles showed generic Cinemata logo on social shares
**After**: Text articles show their first image on social shares

## Files Changed
- `files/templatetags/__init__.py` (new)
- `files/templatetags/custom_tags.py` (new) 
- `templates/cms/page.html` (modified)

