### PR TITLE
Update taxonomies.js – Enable all taxonomies including Countries

### DIFF
--- a/frontend/src/static/js/mediacms/taxonomies.js
+++ b/frontend/src/static/js/mediacms/taxonomies.js
@@ -4,23 +4,23 @@ export function init( settings ){
 
 	TAXONOMIES = {
 	    tags: {
-	    	enabled: false,
+	    	enabled: true,
 	    	title: 'Tags',
 	    },
 	    categories: {
-	    	enabled: false,
+	    	enabled: true,
 	    	title: 'Categories',
 	    },
 	    topics: {
-	    	enabled: false,
+	    	enabled: true,
 	    	title: 'Topics',
 	    },
 	    languages: {
-	    	enabled: false,
+	    	enabled: true,
 	    	title: 'Languages',
 	    },
 	    countries: {
-	    	enabled: false,
+	    	enabled: true,
 	    	title: 'Countries',
 	    },
     };


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This change updates `taxonomies.js` to enable all taxonomies (tags, categories, topics, languages, countries) by setting `enabled: true`.
It ensures that all taxonomy-based content browsing features supported by the backend are visible in the sidebar, allowing users to browse content by category, topic, language, or country directly.

## Related Issue
<!--- Please link to the issue here: -->
Fixes #102 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

- Previously, some taxonomies such as Countries were hidden in the sidebar because `enabled` was set to `false`, even though backend support was fully functional.
- This reduced discoverability of the feature.
- Enabling these taxonomies aligns the media upload experience with browsing, improves UI consistency, and makes it easier for users to find content by taxonomy.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Updated `taxonomies.js` → set enabled to `true` for all taxonomies.
- Verified that all taxonomy menus appear in the sidebar and work correctly.

## Screenshots (if appropriate):
<img width="566" height="702" alt="Countries section from the sidebar navigation" src="https://github.com/user-attachments/assets/7a55cd28-9ca5-4d72-80f7-d60c2a473928" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
