### PR TITLE
Add Asia-Pacific Language Fixture and Improve Frontend Language Integration

### DIFF
--- a/files/urls.py
+++ b/files/urls.py
@@ -21,22 +21,22 @@ urlpatterns = [
     re_path("^tos$", views.tos, name="terms_of_service"),
     re_path("^creative-commons$", views.creative_commons, name="creative_commons"),
     re_path("^categories$", views.categories, name="categories"),
-    re_path("^members", views.members, name="members"),
-    re_path("^tags", views.tags, name="tags"),
+    re_path("^members$", views.members, name="members"),
+    re_path("^tags$", views.tags, name="tags"),
     re_path("^contact$", views.contact, name="contact"),
     re_path("^countries$", views.countries, name="countries"),
     re_path("^languages$", views.languages, name="languages"),
     re_path("^topics$", views.topics, name="topics"),
     re_path("^history$", views.history, name="history"),
     re_path("^liked$", views.liked_media, name="liked_media"),
-    re_path("^view", views.view_media, name="get_media"),
+    re_path("^view$", views.view_media, name="get_media"),
     re_path("^edit$", views.edit_media, name="edit_media"),
-    re_path("^add_subtitle", views.add_subtitle, name="add_subtitle"),
-    re_path("^edit_subtitle", views.edit_subtitle, name="edit_subtitle"),
-    re_path("^embed", views.embed_media, name="get_embed"),
-    re_path("^upload", views.upload_media, name="upload_media"),
-    re_path("^scpublisher", views.upload_media, name="upload_media"),
-    re_path("^search", views.search, name="search"),
+    re_path("^add_subtitle$", views.add_subtitle, name="add_subtitle"),
+    re_path("^edit_subtitle$", views.edit_subtitle, name="edit_subtitle"),
+    re_path("^embed$", views.embed_media, name="get_embed"),
+    re_path("^upload$", views.upload_media, name="upload_media"),
+    re_path("^scpublisher$", views.upload_media, name="upload_media"),
+    re_path("^search$", views.search, name="search"),
     re_path(
         r"^playlist/(?P<friendly_token>[\w]*)$",
         views.view_playlist,
@@ -47,6 +47,7 @@ urlpatterns = [
         views.view_playlist,
         name="get_playlist",
     ),
+    
     # API VIEWS
     re_path("^api/v1/media$", views.MediaList.as_view()),
     re_path("^api/v1/media/$", views.MediaList.as_view()),
@@ -65,11 +66,9 @@ urlpatterns = [
         r"^api/v1/media/(?P<friendly_token>[\w]*)/actions$",
         views.MediaActions.as_view(),
     ),
-    #    url(r'^api/v1/media/(?P<friendly_token>[\w]*)/subtitless$',
-    #        views.MediaSubtitles.as_view()),
     re_path("^api/v1/categories$", views.CategoryList.as_view()),
     re_path("^api/v1/topics$", views.TopicList.as_view()),
-    re_path("^api/v1/languages$", views.MediaLanguageList.as_view()),
+    re_path("^api/v1/languages$", views.MediaLanguageList.as_view(), name='api_get_languages'),
     re_path("^api/v1/countries$", views.MediaCountryList.as_view()),
     re_path("^api/v1/tags$", views.TagList.as_view()),
     re_path("^api/v1/comments$", views.CommentList.as_view()),
@@ -90,7 +89,7 @@ urlpatterns = [
     ),
     re_path("^api/v1/user/action/(?P<action>[\w]*)$", views.UserActions.as_view()),
     re_path("^fu/", include(("uploader.urls", "uploader"), namespace="uploader")),
-    # TODO: https://site.com/channel/UCwobzUc3z-0PrFpoRxNszXQ channel
+    
     # ADMIN VIEWS
     re_path("^api/v1/manage_media$", management_views.MediaList.as_view()),
     re_path("^api/v1/manage_comments$", management_views.CommentList.as_view()),
@@ -106,8 +105,8 @@ urlpatterns = [
     re_path("^api/v1/topmessage/$", views.TopMessageList.as_view()),
     re_path("^api/v1/indexfeatured/$", views.IndexPageFeaturedList.as_view()),
     re_path("^api/v1/homepagepopup/$", views.HomepagePopupList.as_view()),
-    ################################
-    # These are URLs related with the migration of plumi (plumi.org) systems...
+    
+    # Old URLs related to plumi (plumi.org)
     re_path(
         r"^Members/(?P<user>[\w.@-]*)/videos/(?P<video>[\w.@-]*)$",
         views.view_old_media,
@@ -128,17 +127,14 @@ urlpatterns = [
         views.embed_old_media,
         name="embed_old_media",
     ),
-    ################################
+    
+    # Page and TinyMCE upload handlers
     re_path("^(?P<slug>[\w.-]*)$", views.view_page, name="get_page"),
-    # TinyMCE upload handlers
     path("tinymce/upload/", tinymce_handlers.upload_image, name="tinymce_upload_image"),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
-# urlpatterns = format_suffix_patterns(urlpatterns)
-
-
+# Handle media serving during development
 if settings.DEBUG:
-    # Fixed: removed leading slash and removed all duplicate patterns
     urlpatterns += [
         re_path(
             r"^media/(?P<path>.*)$",  # NO leading slash
@@ -147,5 +143,4 @@ if settings.DEBUG:
                 "document_root": settings.MEDIA_ROOT,
             },
         ),
-        # ALL duplicate playlist patterns REMOVED
     ]

--- a/fixtures/apac_languages.json
+++ b/fixtures/apac_languages.json
@@ -1,0 +1,218 @@
+[
+  {
+    "model": "files.language",
+    "pk": 1,
+    "fields": {
+      "code": "en",
+      "title": "English"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 2,
+    "fields": {
+      "code": "zh",
+      "title": "Chinese (Simplified)"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 3,
+    "fields": {
+      "code": "zh-TW",
+      "title": "Chinese (Traditional)"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 4,
+    "fields": {
+      "code": "ja",
+      "title": "Japanese"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 5,
+    "fields": {
+      "code": "ko",
+      "title": "Korean"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 6,
+    "fields": {
+      "code": "th",
+      "title": "Thai"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 7,
+    "fields": {
+      "code": "vi",
+      "title": "Vietnamese"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 8,
+    "fields": {
+      "code": "id",
+      "title": "Indonesian"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 9,
+    "fields": {
+      "code": "ms",
+      "title": "Malay"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 10,
+    "fields": {
+      "code": "tl",
+      "title": "Filipino"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 11,
+    "fields": {
+      "code": "hi",
+      "title": "Hindi"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 12,
+    "fields": {
+      "code": "ta",
+      "title": "Tamil"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 13,
+    "fields": {
+      "code": "bn",
+      "title": "Bengali"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 14,
+    "fields": {
+      "code": "ur",
+      "title": "Urdu"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 15,
+    "fields": {
+      "code": "pa",
+      "title": "Punjabi"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 16,
+    "fields": {
+      "code": "te",
+      "title": "Telugu"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 17,
+    "fields": {
+      "code": "kn",
+      "title": "Kannada"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 18,
+    "fields": {
+      "code": "ml",
+      "title": "Malayalam"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 19,
+    "fields": {
+      "code": "gu",
+      "title": "Gujarati"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 20,
+    "fields": {
+      "code": "mr",
+      "title": "Marathi"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 21,
+    "fields": {
+      "code": "ne",
+      "title": "Nepali"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 22,
+    "fields": {
+      "code": "si",
+      "title": "Sinhala"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 23,
+    "fields": {
+      "code": "my",
+      "title": "Myanmar (Burmese)"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 24,
+    "fields": {
+      "code": "km",
+      "title": "Khmer"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 25,
+    "fields": {
+      "code": "lo",
+      "title": "Lao"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 26,
+    "fields": {
+      "code": "automatic",
+      "title": "Automatic Detection"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 27,
+    "fields": {
+      "code": "automatic-translation",
+      "title": "Auto-detect & Translate to English"
+    }
+  }
+]

--- a/frontend/config/cinemata/cinemata.window.MediaCMS.js
+++ b/frontend/config/cinemata/cinemata.window.MediaCMS.js
@@ -8,9 +8,9 @@ const MediaCMS = {
 	features: require("./installation/features.config.js"),
 };
 
-MediaCMS.api.topics = "/topics";
-MediaCMS.api.languages = "/languages";
-MediaCMS.api.countries = "/countries";
+MediaCMS.api.topics = "/api/v1/topics";
+MediaCMS.api.languages = "/api/v1/languages";
+MediaCMS.api.countries = "/api/v1/countries";
 
 MediaCMS.url.topics = "./topics.html";
 MediaCMS.url.languages = "./languages.html";


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This pull request introduces support for 27 Asia-Pacific languages in CinemataCMS via a preloaded fixture `apac_languages.json`. It also addresses the long-standing bug where languages added through Django Admin were not appearing in the frontend dropdown by making the language list dynamic and fetched from the database.

## Related Issue
<!--- Please link to the issue here: -->
Fixes #90 
Fixes #104 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

- Motivation: This change is required to ensure that all 27 Asia-Pacific languages are available in the system, both during installation and in the frontend, without hardcoding values.
- Context: The issue occurred due to a static list being used for languages, which caused problems when languages were added or modified via Django Admin. This PR resolves that by querying the Language model directly from the database.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- I have tested the changes by loading the `apac_languages.json` fixture using the loaddata command and verified that the languages are properly populated in the database.
- The API now dynamically loads languages using the updated `/api/v1/languages` endpoint.
- Manual testing was done to ensure that the languages appear in the frontend dropdown, and the `MediaLanguageList` API returns the correct list of languages.
- All existing unit tests for language-related functionality were re-run to confirm there were no regressions.

## Screenshots (if appropriate):
<img width="1366" height="719" alt="Languages fix" src="https://github.com/user-attachments/assets/fa97436e-00fe-4e9b-a725-aec9fdcfb25b" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Languages list now sourced from the database with expanded APAC options.
  - Added versioned API endpoints for topics, languages, and countries.

- Refactor
  - Tightened URL routing to use exact matches.
  - Adjusted access control: CMS management views restricted for certain roles; MFA enforcement narrowed to superusers.

- Chores
  - Added language fixtures to seed initial options.

- Bug Fixes
  - Standardized language API exposure and naming to improve consistency across frontend and backend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->