### PR TITLE
fix: correct syntax for 'tinymce_media' in PUBLIC_MEDIA_PATHS

### DIFF
--- a/files/secure_media_views.py
+++ b/files/secure_media_views.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 # Configuration constants
 CACHE_CONTROL_MAX_AGE = 604800  # 1 week
 PUBLIC_MEDIA_PATHS = [
-    'thumbnails/', 'userlogos/', 'logos/', 'favicons/', 'social-media-icons/',
+    'thumbnails/', 'userlogos/', 'logos/', 'favicons/', 'social-media-icons/','tinymce_media/'
 ]
 
 # Security headers for different content types


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Adding X-Accel-Redirect to Public Path

## Related Issue
<!--- Please link to the issue here: -->
Fixes #(issue)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed broken or missing media from the rich-text editor by allowing public access to TinyMCE-uploaded assets.
  * Embedded images and files now display correctly for all users, including in previews and shared/public pages.
  * Improves reliability of content rendering without requiring authentication for editor media.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->