### PR TITLE
Fix/frontend language appearances

### DIFF
--- a/docs/admin-guides/languages.md
+++ b/docs/admin-guides/languages.md
@@ -1,0 +1,38 @@
+# CinemataCMS Language Setup and Configuration
+
+This document outlines the setting up and configuration of additional languages within your organization's build of CinemataCMS.
+
+---
+## Installation
+
+Take note that in the `install.sh` script, a set of installation methods are employed as CinemataCMS comes pre-packaged with 25 native languages, and 2 additional ones for transcription and translation purposes.
+
+```zsh
+python manage.py loaddata fixtures/apac_languages.json
+# ...
+python manage.py load_apac_languages
+```
+
+These two lines of code refer to the installation of `Language` and `MediaLanguage` objects. The former refers to language **used for subtitling** while the latter refers to **UX-facing** / **website** information that can be seen by regular users and viewers of CinemataCMS.
+
+## Adding Languages / Media Languages
+
+To add languages or media languages, ensure that you have access to the Django Admin page.
+
+> [!NOTE] When adding languages and media languages, please ensure that you add both for each corresponding language.
+
+**Languages**
+1. From the admin page, select `Languages`.
+2. On the upper-right corner of the page, click `Add Language`
+3. Input a unique `code` and `title` that will be associated with the Language. (ex. code - 'ru', title - 'Russian')
+
+**Media Languages**
+1. From the admin page, select `Media languages`.
+2. On the upper-right corner of the page, click `Add Language`.
+3. For Media Languages, only the `title` will be necessary. Make sure the `title` used is equivalent to a `title` found in the Languages table.
+
+You have successfully added a language.
+
+## Deleting languages
+
+For either one, you may delete a language by ticking the language in either Media Language or Language and selecting the `Delete selected media languages` action.

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,6 +32,7 @@ Welcome to the comprehensive documentation for CinemataCMS - a platform for show
 - [💾 Backup & Recovery Procedures](admin-guides/backup_and_recovery_procedures.md)
 - [🔐 Permission System](admin-guides/permission_system.md)
 - [📊 User Roles Permission Matrix](admin-guides/cinematacms-roles-permission-matrix.md)
+- [🗣️ Language Setup and Configuration](admin-guides/languages.md)
 
 ## 🎨 Customization
 

--- a/files/admin.py
+++ b/files/admin.py
@@ -204,10 +204,10 @@ class TranscriptionRequestAdmin(admin.ModelAdmin):
     def language(self, obj):
         """Get the language of the media"""
         if obj.media and obj.media.media_language:
-            # Get the display name from the choices
-            from . import lists
-            language_dict = dict(lists.video_languages)
-            return language_dict.get(obj.media.media_language, obj.media.media_language)
+            media_language = obj.media.media_language
+            language_dict = Language.objects.exclude(code__in=["automatic-translation", "automatic"]).values("code", "title").get(code=media_language)
+            lang = language_dict.get('code')
+            return lang
         return "Not specified"
     language.short_description = "Language"
     

--- a/files/feeds.py
+++ b/files/feeds.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 from django.utils.feedgenerator import Rss201rev2Feed
 
 from . import helpers, lists
-from .models import Category, Media
+from .models import Category, Media, Language
 from .stop_words import STOP_WORDS
 
 
@@ -123,11 +123,14 @@ class SearchRSSFeed(Feed):
             media = media.filter(tags__title=tag)
         elif topic:
             media = media.filter(topics__title__contains=topic)
-        elif language:
+        elif language: 
             language = {
-                value: key for key, value in dict(lists.video_languages).items()
+                title: code for code, title in Language.objects.exclude(
+                    code__in=["automatic", "automatic-translation"]
+                ).values_list("code", "title")
             }.get(language)
-            media = media.filter(media_language=language)
+            media_language = language['code']
+            media = media.filter(media_language=media_language)
         elif country:
             country = {
                 value: key for key, value in dict(lists.video_countries).items()

--- a/files/management/commands/load_apac_languages.py
+++ b/files/management/commands/load_apac_languages.py
@@ -1,0 +1,134 @@
+from django.core.management.base import BaseCommand
+from files.models import Language, MediaLanguage
+
+class Command(BaseCommand):
+    help = 'Load APAC languages safely without conflicts'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--update',
+            action='store_true',
+            help='Update existing entries if they exist',
+        )
+        parser.add_argument(
+            '--dry-run',
+            action='store_true',
+            help='Show what would be created/updated without making changes',
+        )
+
+    def handle(self, *args, **options):
+        languages_data = [
+            {"code": "en", "title": "English"},
+            {"code": "zh", "title": "Chinese (Simplified)"},
+            {"code": "zh-TW", "title": "Chinese (Traditional)"},
+            {"code": "ja", "title": "Japanese"},
+            {"code": "ko", "title": "Korean"},
+            {"code": "th", "title": "Thai"},
+            {"code": "vi", "title": "Vietnamese"},
+            {"code": "id", "title": "Indonesian"},
+            {"code": "ms", "title": "Malay"},
+            {"code": "tl", "title": "Filipino"},
+            {"code": "hi", "title": "Hindi"},
+            {"code": "ta", "title": "Tamil"},
+            {"code": "bn", "title": "Bengali"},
+            {"code": "ur", "title": "Urdu"},
+            {"code": "pa", "title": "Punjabi"},
+            {"code": "te", "title": "Telugu"},
+            {"code": "kn", "title": "Kannada"},
+            {"code": "ml", "title": "Malayalam"},
+            {"code": "gu", "title": "Gujarati"},
+            {"code": "mr", "title": "Marathi"},
+            {"code": "ne", "title": "Nepali"},
+            {"code": "si", "title": "Sinhala"},
+            {"code": "my", "title": "Myanmar (Burmese)"},
+            {"code": "km", "title": "Khmer"},
+            {"code": "lo", "title": "Lao"},
+            {"code": "automatic", "title": "Automatic Detection"},
+            {"code": "automatic-translation", "title": "Auto-detect & Translate to English"},
+        ]
+
+        # Exclude automatic entries for MediaLanguage
+        exclude_from_media_language = ["automatic", "automatic-translation"]
+
+        created_languages = 0
+        updated_languages = 0
+        created_media_languages = 0
+        updated_media_languages = 0
+
+        for lang_data in languages_data:
+            # Handle Language model
+            if options['dry_run']:
+                exists = Language.objects.filter(code=lang_data['code']).exists()
+                if exists:
+                    self.stdout.write(f"Would update Language: {lang_data['title']}")
+                else:
+                    self.stdout.write(f"Would create Language: {lang_data['title']}")
+            else:
+                language, created = Language.objects.get_or_create(
+                    code=lang_data['code'],
+                    defaults={'title': lang_data['title']}
+                )
+                
+                if created:
+                    created_languages += 1
+                    self.stdout.write(
+                        self.style.SUCCESS(f'Created Language: {lang_data["title"]}')
+                    )
+                elif options['update']:
+                    language.title = lang_data['title']
+                    language.save()
+                    updated_languages += 1
+                    self.stdout.write(
+                        self.style.WARNING(f'Updated Language: {lang_data["title"]}')
+                    )
+                else:
+                    self.stdout.write(
+                        self.style.NOTICE(f'Skipped existing Language: {lang_data["title"]}')
+                    )
+
+            # Handle MediaLanguage model (exclude automatic entries)
+            if lang_data['code'] not in exclude_from_media_language:
+                if options['dry_run']:
+                    exists = MediaLanguage.objects.filter(title=lang_data['title']).exists()
+                    if exists:
+                        self.stdout.write(f"Would update MediaLanguage: {lang_data['title']}")
+                    else:
+                        self.stdout.write(f"Would create MediaLanguage: {lang_data['title']}")
+                else:
+                    # Using actual MediaLanguage model fields
+                    media_language, created = MediaLanguage.objects.get_or_create(
+                        title=lang_data['title'],
+                        defaults={
+                            'media_count': 0,
+                            'listings_thumbnail': '',  # Empty string, not null
+                        }
+                    )
+                    
+                    if created:
+                        created_media_languages += 1
+                        self.stdout.write(
+                            self.style.SUCCESS(f'Created MediaLanguage: {lang_data["title"]}')
+                        )
+                    elif options['update']:
+                        # Only update if explicitly requested
+                        # Note: add_date is auto_now_add, so it won't change
+                        media_language.save()
+                        updated_media_languages += 1
+                        self.stdout.write(
+                            self.style.WARNING(f'Updated MediaLanguage: {lang_data["title"]}')
+                        )
+                    else:
+                        self.stdout.write(
+                            self.style.NOTICE(f'Skipped existing MediaLanguage: {lang_data["title"]}')
+                        )
+
+        if not options['dry_run']:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f'\nSummary:\n'
+                    f'Languages - Created: {created_languages}, Updated: {updated_languages}\n'
+                    f'MediaLanguages - Created: {created_media_languages}, Updated: {updated_media_languages}'
+                )
+            )
+        else:
+            self.stdout.write(self.style.NOTICE('Dry run completed - no changes made'))

--- a/files/models.py
+++ b/files/models.py
@@ -1197,10 +1197,8 @@ class MediaLanguage(models.Model):
 
     def update_language_media(self):
         language = Language.objects.values("code", "title").get(title=self.title)
-        # print('updating language media:', language)
         if language:
             media_language = language['code']
-            # print('media-language', media_language)
             self.media_count = Media.objects.filter(
                 state="public", is_reviewed=True, media_language=media_language
             ).count()

--- a/files/models.py
+++ b/files/models.py
@@ -1187,9 +1187,7 @@ class MediaLanguage(models.Model):
         return None
 
     def update_language_media(self):
-        language = {
-            value: key for key, value in dict(lists.video_languages).items()
-        }.get(self.title)
+        language = Language.objects.values("code", "title").get(title=self.title)
         if language:
             self.media_count = Media.objects.filter(
                 state="public", is_reviewed=True, media_language=language

--- a/files/views.py
+++ b/files/views.py
@@ -1633,11 +1633,15 @@ class TopicList(APIView):
 
 
 class MediaLanguageList(APIView):
+    """
+    Enhanced API view that serves languages from database into the 'languages' page.
+    This view retrieves languages that have a non-empty listings_thumbnail and a media_count greater than zero.
+    """
     def get(self, request, format=None):
         languages = (
-            MediaLanguage.objects.exclude(listings_thumbnail=None)
-            .exclude(listings_thumbnail="")
-            .filter()
+            MediaLanguage.objects
+            .exclude(listings_thumbnail=None)
+            .filter(media_count__gt=0)
             .order_by("title")
         )
         serializer = MediaLanguageSerializer(

--- a/files/views.py
+++ b/files/views.py
@@ -1643,7 +1643,6 @@ class MediaLanguageList(APIView):
     def get(self, request, format=None):
         languages = (
             MediaLanguage.objects
-            .exclude(listings_thumbnail=None)
             .filter(media_count__gt=0)
             .order_by("title")
         )

--- a/files/views.py
+++ b/files/views.py
@@ -64,6 +64,7 @@ from .models import (
     IndexPageFeatured,
     License,
     Media,
+    Language,
     MediaCountry,
     MediaLanguage,
     Page,
@@ -126,7 +127,7 @@ def countries(request):
 
 def languages(request):
     context = {}
-    languages = [language[1] for language in lists.video_languages]
+    languages = MediaLanguage.objects.order_by('title')
     context["languages"] = languages
     return render(request, "cms/languages.html", context)
 
@@ -1036,7 +1037,9 @@ class MediaSearch(APIView):
 
         if language:
             language = {
-                value: key for key, value in dict(lists.video_languages).items()
+                value: key for key, value in Language.objects.exclude(
+                    code__in=["automatic", "automatic-translation"]
+                ).values_list("code", "title")
             }.get(language)
             media = media.filter(media_language=language)
 
@@ -1649,7 +1652,6 @@ class MediaLanguageList(APIView):
         )
         ret = serializer.data
         return Response(ret)
-
 
 class MediaCountryList(APIView):
     def get(self, request, format=None):

--- a/fixtures/apac_languages.json
+++ b/fixtures/apac_languages.json
@@ -1,0 +1,218 @@
+[
+  {
+    "model": "files.language",
+    "pk": 1,
+    "fields": {
+      "code": "en",
+      "title": "English"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 2,
+    "fields": {
+      "code": "zh",
+      "title": "Chinese (Simplified)"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 3,
+    "fields": {
+      "code": "zh-TW",
+      "title": "Chinese (Traditional)"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 4,
+    "fields": {
+      "code": "ja",
+      "title": "Japanese"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 5,
+    "fields": {
+      "code": "ko",
+      "title": "Korean"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 6,
+    "fields": {
+      "code": "th",
+      "title": "Thai"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 7,
+    "fields": {
+      "code": "vi",
+      "title": "Vietnamese"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 8,
+    "fields": {
+      "code": "id",
+      "title": "Indonesian"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 9,
+    "fields": {
+      "code": "ms",
+      "title": "Malay"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 10,
+    "fields": {
+      "code": "tl",
+      "title": "Filipino"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 11,
+    "fields": {
+      "code": "hi",
+      "title": "Hindi"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 12,
+    "fields": {
+      "code": "ta",
+      "title": "Tamil"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 13,
+    "fields": {
+      "code": "bn",
+      "title": "Bengali"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 14,
+    "fields": {
+      "code": "ur",
+      "title": "Urdu"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 15,
+    "fields": {
+      "code": "pa",
+      "title": "Punjabi"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 16,
+    "fields": {
+      "code": "te",
+      "title": "Telugu"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 17,
+    "fields": {
+      "code": "kn",
+      "title": "Kannada"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 18,
+    "fields": {
+      "code": "ml",
+      "title": "Malayalam"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 19,
+    "fields": {
+      "code": "gu",
+      "title": "Gujarati"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 20,
+    "fields": {
+      "code": "mr",
+      "title": "Marathi"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 21,
+    "fields": {
+      "code": "ne",
+      "title": "Nepali"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 22,
+    "fields": {
+      "code": "si",
+      "title": "Sinhala"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 23,
+    "fields": {
+      "code": "my",
+      "title": "Myanmar (Burmese)"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 24,
+    "fields": {
+      "code": "km",
+      "title": "Khmer"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 25,
+    "fields": {
+      "code": "lo",
+      "title": "Lao"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 26,
+    "fields": {
+      "code": "automatic",
+      "title": "Automatic Detection"
+    }
+  },
+  {
+    "model": "files.language",
+    "pk": 27,
+    "fields": {
+      "code": "automatic-translation",
+      "title": "Auto-detect & Translate to English"
+    }
+  }
+]

--- a/install.sh
+++ b/install.sh
@@ -86,6 +86,7 @@ mkdir pids
 python manage.py makemigrations files users actions
 python manage.py migrate
 python manage.py loaddata files/fixtures/creative_commons_licenses.json
+python manage.py loaddata fixtures/apac_languages.json
 python manage.py loaddata fixtures/encoding_profiles.json
 python manage.py loaddata fixtures/categories.json
 python manage.py collectstatic --noinput

--- a/install.sh
+++ b/install.sh
@@ -89,6 +89,7 @@ python manage.py loaddata files/fixtures/creative_commons_licenses.json
 python manage.py loaddata fixtures/apac_languages.json
 python manage.py loaddata fixtures/encoding_profiles.json
 python manage.py loaddata fixtures/categories.json
+python manage.py load_apac_languages
 python manage.py collectstatic --noinput
 
 ADMIN_PASS=`python -c "import secrets;chars = 'abcdefghijklmnopqrstuvwxyz0123456789';print(''.join(secrets.choice(chars) for i in range(10)))"`


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR incorporates the following changes to CinemataCMS:

- Adds two pre-installation lines to install 25 media languages out-of-the-box (27 languages if including languages associated with Whisper transcription)
- Replaces hardcoded use of `lists.video_languages` with usage of `MediaLanguage` and `Language` object imports from the backend to ensure consistency and integration of data from the Django database.
- Ensures that the /language page of CinemataCMS returns easily accessible filters for specific languages PROVIDED that the `MediaLanguage` `media_count` field for that associated MediaLanguage is greater than or equal to 1.

## Related Issue
<!--- Please link to the issue here: -->
Fixes #90 and #104 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

- Fixes a long-standing visibility issue on the frontend for Languages
- Makes installation for languages much easier out-of-the-box

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Pre-install script**
1. Execute the following lines of code via Terminal:

```zsh
python manage.py loaddata fixtures/apac_languages.json
python manage.py load_apac_languages
```

2. This is successful if no errors are returned provided that the `Language` and `MediaLanguage` tables are not populated by the same data.

**Language Frontend**
1. Upload at least ONE video
2. Edit this video and ensure that its `Media language` is selected to any language of your choosing.
3. Save
4. Go to the Languages page via the Sidebar
5. If the associated Language is visible in the Language page, this test is successful. 

## Screenshots (if appropriate):

<img width="1433" height="707" alt="Screenshot 2025-09-05 at 9 23 06 AM" src="https://github.com/user-attachments/assets/40b5e2db-0c89-45d6-ad75-c408872fd0c9" />

(This indicates that there are videos with the ff languages available, while other languages currently do not have an associated video that is linked to them.)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized, DB-backed language model used across the app; API and UI now source languages from the database.
  * New management command to load/update APAC languages and an APAC fixture included.

* **Bug Fixes**
  * Language lookups now fall back gracefully when missing and log lookup issues.

* **Chores**
  * Installer updated to seed APAC languages and run the language setup step.

* **Documentation**
  * Admin guide added for language setup and configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->