### PR TITLE
Revert "chore(deps-dev): bump dotenv-webpack from 8.1.0 to 8.1.1 in /frontend"

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -36,7 +36,7 @@
         "css-minimizer-webpack-plugin": "^7.0.2",
         "css-url-relative-plugin": "^1.1.0",
         "dotenv": "^16.5.0",
-        "dotenv-webpack": "^8.1.1",
+        "dotenv-webpack": "^8.1.0",
         "ejs": "^3.1.10",
         "ejs-compiled-loader": "file:packages/ejs-compiled-loader",
         "html-prettify": "^1.0.7",
@@ -5727,9 +5727,9 @@
       }
     },
     "node_modules/dotenv-webpack": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/dotenv-webpack/-/dotenv-webpack-8.1.1.tgz",
-      "integrity": "sha512-+TY/AJ2k9bU2EML3mxgLmaAvEcqs1Wbv6deCIUSI3eW3Xeo8LBQumYib6puyaSwbjC9JCzg/y5Pwjd/lePX04w==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/dotenv-webpack/-/dotenv-webpack-8.1.0.tgz",
+      "integrity": "sha512-owK1JcsPkIobeqjVrk6h7jPED/W6ZpdFsMPR+5ursB7/SdgDyO+VzAU+szK8C8u3qUhtENyYnj8eyXMR5kkGag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,7 @@
     "css-minimizer-webpack-plugin": "^7.0.2",
     "css-url-relative-plugin": "^1.1.0",
     "dotenv": "^16.5.0",
-    "dotenv-webpack": "^8.1.1",
+    "dotenv-webpack": "^8.1.0",
     "ejs": "^3.1.10",
     "ejs-compiled-loader": "file:packages/ejs-compiled-loader",
     "html-prettify": "^1.0.7",


### PR DESCRIPTION
Reverts EngageMedia-video/cinematacms#162

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a development dependency used in the frontend build pipeline for handling environment variables.
  * Routine maintenance to keep tooling versions aligned and builds stable.
  * No functional or visual changes in the application are expected from this update.
  * Testing and deployment processes should remain unaffected, with no configuration changes required for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->