### PR TITLE
fix: celery makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ COMPOSE_FILE = docker-compose.dev.yml
 
 # Common variables
 APP_DIR := .
-CELERY_BIN := $(shell which celery)
+CELERY_BIN := uv run celery
 CELERY_APP := cms
 CELERYD_LOG_LEVEL := INFO
 CELERYD_PID_DIR := $(APP_DIR)/pids
@@ -94,12 +94,10 @@ dev-server:
 
 ## BEAT Service
 celery-beat-start:
-	$(CELERY_BIN) beat \
-		-A $(CELERY_APP) \
+	$(CELERY_BIN) -A $(CELERY_APP) beat \
 		--pidfile=$(BEAT_PID_FILE) \
 		--logfile=$(BEAT_LOG_FILE) \
-		--loglevel=$(CELERYD_LOG_LEVEL) \
-		--workdir=$(APP_DIR)
+		--loglevel=$(CELERYD_LOG_LEVEL)
 
 celery-beat-stop:
 	@if [ -f $(BEAT_PID_FILE) ]; then \
@@ -117,15 +115,12 @@ LONG_QUEUE := long_tasks
 LONG_OPTS := -Ofair --prefetch-multiplier=1
 
 celery-long-start:
-	$(CELERY_BIN) worker \
-		-A $(CELERY_APP) \
+	$(CELERY_BIN) -A $(CELERY_APP) worker \
 		--pidfile=$(CELERYD_PID_DIR)/long.pid \
 		--logfile=$(CELERYD_LOG_DIR)/long.log \
 		--loglevel=$(CELERYD_LOG_LEVEL) \
 		$(LONG_OPTS) \
-		--workdir=$(APP_DIR) \
-		-Q $(LONG_QUEUE) \
-		-n long@%h
+		-Q $(LONG_QUEUE)
 
 celery-long-stop:
 	@if [ -f $(CELERYD_PID_DIR)/long.pid ]; then \
@@ -140,18 +135,15 @@ celery-long-restart: celery-long-stop celery-long-start
 ## SHORT Tasks Worker
 SHORT_NODES := short1 short2
 SHORT_QUEUE := short_tasks
-SHORT_OPTS := --soft-time-limit=300 -c10
+SHORT_OPTS := --soft-time-limit=300 --concurrency=10
 
 celery-short-start:
-	$(CELERY_BIN) worker \
-		-A $(CELERY_APP) \
+	$(CELERY_BIN) -A $(CELERY_APP) worker \
 		--pidfile=$(CELERYD_PID_DIR)/short.pid \
 		--logfile=$(CELERYD_LOG_DIR)/short.log \
 		--loglevel=$(CELERYD_LOG_LEVEL) \
 		$(SHORT_OPTS) \
-		--workdir=$(APP_DIR) \
-		-Q $(SHORT_QUEUE) \
-		-n short@%h
+		-Q $(SHORT_QUEUE)
 
 celery-short-stop:
 	@if [ -f $(CELERYD_PID_DIR)/short.pid ]; then \
@@ -169,15 +161,12 @@ WHISPER_QUEUE := whisper_tasks
 WHISPER_OPTS := -Ofair --prefetch-multiplier=1
 
 celery-whisper-start:
-	$(CELERY_BIN) worker \
-		-A $(CELERY_APP) \
+	$(CELERY_BIN) -A $(CELERY_APP) worker \
 		--pidfile=$(CELERYD_PID_DIR)/whisper.pid \
 		--logfile=$(CELERYD_LOG_DIR)/whisper.log \
 		--loglevel=$(CELERYD_LOG_LEVEL) \
 		$(WHISPER_OPTS) \
-		--workdir=$(APP_DIR) \
-		-Q $(WHISPER_QUEUE) \
-		-n whisper@%h
+		-Q $(WHISPER_QUEUE)
 
 celery-whisper-stop:
 	@if [ -f $(CELERYD_PID_DIR)/whisper.pid ]; then \

--- a/cms/settings.py
+++ b/cms/settings.py
@@ -246,8 +246,6 @@ CELERY_BEAT_SCHEDULE = {
         # every Sunday 1:01 AM
         "schedule": crontab(hour="1", minute="1", day_of_week="0"),
     },
-        "schedule": crontab(hour="*/10"),
-
     "update_listings_thumbnails": {
         "task": "update_listings_thumbnails",
         "schedule": crontab(hour="*/30"),


### PR DESCRIPTION
This pull request updates the `Makefile` to modernize how Celery tasks are run during development and simplifies the Celery worker command invocations. It also makes a minor cleanup in the Celery beat schedule configuration in `cms/settings.py`.

Key changes include:

**Celery command modernization and simplification:**

* Changed `CELERY_BIN` from using the system-installed `celery` to `uv run celery`, aligning with the project's current process management approach.
* Simplified all Celery worker and beat commands by moving the `-A $(CELERY_APP)` argument directly after the executable and removing the unnecessary `--workdir` and `-n` options from the worker commands. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L97-R100) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L120-R123) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L143-R146) [[4]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L172-R169)
* Updated `SHORT_OPTS` to use the more explicit `--concurrency=10` instead of `-c10` for clarity.

**Configuration cleanup:**

* Removed a duplicate or misplaced Celery beat schedule entry in `cms/settings.py` to avoid confusion or misconfiguration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Simplified and standardized Celery start commands for beat and workers, using a consistent launcher and consolidated flags for clearer, more reliable startup.
- Chores
  - Updated build scripts to remove deprecated options and align concurrency flags for workers.
  - Adjusted background task schedule by removing a periodic job entry, aligning schedules with current operations.
- Bug Fixes
  - Reduced potential startup inconsistencies across environments by unifying how Celery is invoked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->