### PR TITLE
fix: bootstrap 2 config

### DIFF
--- a/cms/settings.py
+++ b/cms/settings.py
@@ -61,7 +61,7 @@ INSTALLED_APPS = [
     "actions.apps.ActionsConfig",
     "mptt",
     "crispy_forms",
-    "crispy_bootstrap5",
+    "crispy_forms_bootstrap2",
     "uploader.apps.UploaderConfig",
     "djcelery_email",
     "tinymce",
@@ -564,5 +564,4 @@ ALLOWED_MEDIA_UPLOAD_TYPES = ['video']
 RECAPTCHA_PRIVATE_KEY = ""
 RECAPTCHA_PUBLIC_KEY = ""
 
-CRISPY_ALLOWED_TEMPLATE_PACKS = {"bootstrap5"}
-CRISPY_TEMPLATE_PACK = "bootstrap5"
+CRISPY_TEMPLATE_PACK = "bootstrap"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "django-celery-email==3.0.0",
     "django-cors-headers==4.7.0",
     "django-crispy-forms>=2.3,<3.0",
-    "crispy-forms-bootstrap2>=2024.1",
+    "crispy-forms-bootstrap2==2024.1",
     "django-debug-toolbar==6.0.0",
     "django-filter==25.1",
     "django-imagekit==5.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "django-celery-email==3.0.0",
     "django-cors-headers==4.7.0",
     "django-crispy-forms>=2.3,<3.0",
-    "crispy-bootstrap5>=2024.10",
+    "crispy-forms-bootstrap2>=2024.1",
     "django-debug-toolbar==6.0.0",
     "django-filter==25.1",
     "django-imagekit==5.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ uwsgi==2.0.30
 django-redis==4.12.1
 celery==5.2.2
 django-crispy-forms>=2.3,<3.0
-crispy-bootstrap5>=2024.10
+crispy-forms-bootstrap2>=2024.1
 Pillow==11.3.0
 django-imagekit==5.0.0
 markdown==3.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ uwsgi==2.0.30
 django-redis==4.12.1
 celery==5.2.2
 django-crispy-forms>=2.3,<3.0
-crispy-forms-bootstrap2>=2024.1
+crispy-forms-bootstrap2==2024.1
 Pillow==11.3.0
 django-imagekit==5.0.0
 markdown==3.9

--- a/uv.lock
+++ b/uv.lock
@@ -269,7 +269,7 @@ version = "1.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "celery" },
-    { name = "crispy-bootstrap5" },
+    { name = "crispy-forms-bootstrap2" },
     { name = "django" },
     { name = "django-allauth" },
     { name = "django-celery-email" },
@@ -311,7 +311,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "celery", specifier = "==5.2.2" },
-    { name = "crispy-bootstrap5", specifier = ">=2024.10" },
+    { name = "crispy-forms-bootstrap2", specifier = ">=2024.1" },
     { name = "django", specifier = "==5.2.6" },
     { name = "django-allauth", specifier = "==65.8.1" },
     { name = "django-celery-email", specifier = "==3.0.0" },
@@ -409,16 +409,15 @@ wheels = [
 ]
 
 [[package]]
-name = "crispy-bootstrap5"
-version = "2025.6"
+name = "crispy-forms-bootstrap2"
+version = "2024.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "django" },
     { name = "django-crispy-forms" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/97/30/36cc4144b6dff91bb54490a3b474897b7469bcda9517bf9f54681ea91011/crispy_bootstrap5-2025.6.tar.gz", hash = "sha256:f1bde7cac074c650fc82f31777d4a4cfd0df2512c68bc4128f259c75d3daada4", size = 23950, upload-time = "2025-06-08T07:43:35.461Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/ab/c5edd7e8f4a7a5e55f97e4245e661738e38007d122feff632c82d5c36319/crispy-forms-bootstrap2-2024.1.tar.gz", hash = "sha256:792a8f7e13ed7f71cf504db46f680bb2b2bcf90830cf79b06d7abcbed53d3a23", size = 19268, upload-time = "2024-01-27T15:37:24.195Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/d4/8cf1ba773a91fc17bab1fd46b75bbdef780c4cccbbb8230e617980a0362c/crispy_bootstrap5-2025.6-py3-none-any.whl", hash = "sha256:a343aa128b4383f35f00295b94de2b10862f2a4f24eda21fa6ead45234c07050", size = 24794, upload-time = "2025-06-08T07:43:34.206Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/04/d4dbb29ec83fea4f90e618291214ac81ba5f198c66d9b5bfa191bd5dbc1c/crispy_forms_bootstrap2-2024.1-py3-none-any.whl", hash = "sha256:cc5bd1f5534f991722066480300d65f757bdf51c95463a48a28cc01618c0ea07", size = 33493, upload-time = "2024-01-27T15:37:21.318Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -311,7 +311,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "celery", specifier = "==5.2.2" },
-    { name = "crispy-forms-bootstrap2", specifier = ">=2024.1" },
+    { name = "crispy-forms-bootstrap2", specifier = "==2024.1" },
     { name = "django", specifier = "==5.2.6" },
     { name = "django-allauth", specifier = "==65.8.1" },
     { name = "django-celery-email", specifier = "==3.0.0" },


### PR DESCRIPTION
# Fix django-crispy-forms Bootstrap 2 Template Rendering

## Description
Fixed template rendering issues with django-crispy-forms 2.4 and Bootstrap 2. The application was failing to generate Bootstrap 2 control-group classes after upgrading django-crispy-forms from version 1.9 to 2.4.

## Related Issue
<!--- Please link to the issue here: -->
Fixes #(issue)

## Motivation and Context
After upgrading django-crispy-forms from 1.9 to 2.4, the Bootstrap 2 control-group classes were not being generated correctly, causing form styling issues. This fix ensures proper compatibility between django-crispy-forms 2.4 and the crispy-forms-bootstrap2 package.

## How Has This Been Tested?
- Fixed invalid template tag syntax in edit_media.html
- Corrected the CRISPY_TEMPLATE_PACK setting to use the proper value
- Verified that forms now render correctly with Bootstrap 2 classes

## Screenshots (if appropriate):

<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/da50fd59-cb11-4b1c-8b13-de3aa5fac2bd" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Changes Made
### 1. Django Settings (cms/settings.py)
- Corrected CRISPY_TEMPLATE_PACK from "Bootstrap2" to "bootstrap" to match the template directory structure in crispy-forms-bootstrap2 package

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Style
  - Updated form styling to the Bootstrap 2 template pack; inputs, buttons, spacing, and validation messages may look slightly different across forms.

- Chores
  - Switched the crispy-forms UI dependency from the Bootstrap 5 variant to the Bootstrap 2 variant and aligned configuration to use the new pack, removing references to the previous pack.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->