### PR TITLE
fix: update edit_date of media URL

### DIFF
--- a/files/views.py
+++ b/files/views.py
@@ -624,7 +624,7 @@ def edit_subtitle(request):
                 logger.error(f"Failed to save subtitle edit for {subtitle.subtitle_file.path}: {str(e)}")
                 form.add_error(None, f"Could not save subtitle: {str(e)}")
         else:
-            if not form.dat.get('subtitle'):
+            if not form.data.get('subtitle'):
                 form.add_error(None, "No subtitle content provided.")
     return render(request, "cms/edit_subtitle.html", context)
 

--- a/files/views.py
+++ b/files/views.py
@@ -624,23 +624,7 @@ def edit_subtitle(request):
                 logger.error(f"Failed to save subtitle edit for {subtitle.subtitle_file.path}: {str(e)}")
                 form.add_error(None, f"Could not save subtitle: {str(e)}")
         else:
-            # Use cleaned_data if available, fallback to raw data
-            subtitle_text = form.data.get("subtitle", "")
-            if subtitle_text:
-                try:
-                    with open(subtitle.subtitle_file.path, "w", encoding='utf-8') as ff:
-                        ff.write(subtitle_text)
-                    
-                    # Update media version even for invalid forms if text was provided
-                    subtitle.media.edit_date = timezone.now()
-                    subtitle.media.save(update_fields=['edit_date'])
-                    
-                    messages.add_message(request, messages.INFO, "Subtitle was edited")
-                    return HttpResponseRedirect(subtitle.media.get_absolute_url())
-                except Exception as e:
-                    logger.error(f"Failed to save subtitle: {str(e)}")
-                    form.add_error(None, f"Could not save subtitle: {str(e)}")
-            else:
+            if not form.dat.get('subtitle'):
                 form.add_error(None, "No subtitle content provided.")
     return render(request, "cms/edit_subtitle.html", context)
 

--- a/files/views.py
+++ b/files/views.py
@@ -1,5 +1,6 @@
 import csv
 import json
+import logging
 from cms.permissions import user_requires_mfa
 from datetime import datetime, timedelta
 
@@ -12,6 +13,7 @@ from django.db.models import Func, Q
 from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.template.defaultfilters import slugify
+from django.utils import timezone
 from rest_framework import permissions, status
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.parsers import (
@@ -97,6 +99,7 @@ from .tasks import save_user_action
 
 VALID_USER_ACTIONS = [action for action, name in USER_MEDIA_ACTIONS]
 
+logger = logging.getLogger(__name__)
 
 class Lower(Func):
     function = "LOWER"
@@ -538,9 +541,14 @@ def add_subtitle(request):
             new_subtitle = Subtitle.objects.filter(id=subtitle.id).first()
             try:
                 new_subtitle.convert_to_vtt()
+                
+                # UPDATE MEDIA VERSION WHEN SUBTITLE ADDED
+                media.edit_date = timezone.now()
+                media.save(update_fields=['edit_date'])
+                
                 messages.add_message(request, messages.INFO, "Subtitle was added!")
                 return HttpResponseRedirect(subtitle.media.get_absolute_url())
-            except:
+            except Exception:
                 new_subtitle.delete()
                 error_msg = "Invalid subtitle format. Use SubRip (.srt) and WebVTT (.vtt) files."
                 form.add_error("subtitle_file", error_msg)
@@ -591,15 +599,49 @@ def edit_subtitle(request):
         if confirm == "true":
             messages.add_message(request, messages.INFO, "Subtitle was deleted")
             redirect_url = subtitle.media.get_absolute_url()
+
+            # Update the edit_date as the associated URL for this media file is affected by the edit_date of subtitles
+            subtitle.media.edit_date = timezone.now()
+            subtitle.media.save(update_fields=['edit_date'])
             subtitle.delete()
+
             return HttpResponseRedirect(redirect_url)
         form = EditSubtitleForm(subtitle, request.POST)
-        subtitle_text = form.data["subtitle"]
-        with open(subtitle.subtitle_file.path, "w") as ff:
-            ff.write(subtitle_text)
 
-        messages.add_message(request, messages.INFO, "Subtitle was edited")
-        return HttpResponseRedirect(subtitle.media.get_absolute_url())
+        if form.is_valid():
+            subtitle_text = form.cleaned_data["subtitle"]
+            try:
+                with open(subtitle.subtitle_file.path, "w", encoding='utf-8') as ff:
+                    ff.write(subtitle_text)
+                
+                # CRITICAL FIX: Update media edit_date to bust cache
+                subtitle.media.edit_date = timezone.now()
+                subtitle.media.save(update_fields=['edit_date'])
+                
+                messages.add_message(request, messages.INFO, "Subtitle was edited")
+                return HttpResponseRedirect(subtitle.media.get_absolute_url())
+            except Exception as e:
+                logger.error(f"Failed to save subtitle edit for {subtitle.subtitle_file.path}: {str(e)}")
+                form.add_error(None, f"Could not save subtitle: {str(e)}")
+        else:
+            # Use cleaned_data if available, fallback to raw data
+            subtitle_text = form.data.get("subtitle", "")
+            if subtitle_text:
+                try:
+                    with open(subtitle.subtitle_file.path, "w", encoding='utf-8') as ff:
+                        ff.write(subtitle_text)
+                    
+                    # Update media version even for invalid forms if text was provided
+                    subtitle.media.edit_date = timezone.now()
+                    subtitle.media.save(update_fields=['edit_date'])
+                    
+                    messages.add_message(request, messages.INFO, "Subtitle was edited")
+                    return HttpResponseRedirect(subtitle.media.get_absolute_url())
+                except Exception as e:
+                    logger.error(f"Failed to save subtitle: {str(e)}")
+                    form.add_error(None, f"Could not save subtitle: {str(e)}")
+            else:
+                form.add_error(None, "No subtitle content provided.")
     return render(request, "cms/edit_subtitle.html", context)
 
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This fix incorporates additional lines of code related to updating the edit_date metadata of a video when subtitles are added or edited.

## Related Issue
<!--- Please link to the issue here: -->
Fixes #236

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- It fixes a critical issue regarding the appearance of subtitles after changes are made to an associated video.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. The incorporated code has been tested by uploading a video
2. One video had an SRT file attached to it while the other video had a VTT file
3. Subtitles successfully appeared; as did the edited subtitles when new subtitles were added to the file.

## Screenshots (if appropriate):
https://youtu.be/5ESY4Rap4I0 (3-minute video; no other option for uploading without taking additional time)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None
- Bug Fixes
  - Subtitles reliably refresh in the player after add, edit, or delete (cache busting).
  - Subtitle files saved with UTF-8 encoding to prevent character issues.
  - Clearer user-facing error feedback when subtitle save/write operations fail.
  - Media timestamps now update when subtitles are added, edited, or deleted.
- Refactor
  - Improved error handling and added logging around subtitle operations for better tracing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->