### PR TITLE
fix: update videojs tech references from hls to vhs in MediaCmsVjsPlugin

### DIFF
--- a/frontend/packages/vjs-plugin/src/MediaCmsVjsPlugin.js
+++ b/frontend/packages/vjs-plugin/src/MediaCmsVjsPlugin.js
@@ -1,4 +1,4 @@
-import { version as VERSION } from "../package.json";
+ import { version as VERSION } from "../package.json";
 
 import PluginFontIcons from "@mediacms/vjs-plugin-font-icons/dist/css/mediacms-vjs-icons.css";
 import PluginStyles from "./styles.scss";
@@ -2784,7 +2784,7 @@ function generatePlugin(/*videojs*/) {
 			this.player.removeClass("vjs-loading-video");
 
 			if ("Auto" === this.state.theSelectedQuality) {
-				if (!!this.player.tech_.hls && null === this.onBandwidthUpdate) {
+				if (!!this.player.tech_.vhs && null === this.onBandwidthUpdate) {
 					this.onBandwidthUpdate = this.onBandwidthUpdateCallback.bind(this);
 					this.player.tech_.on("bandwidthupdate", this.onBandwidthUpdate);
 
@@ -2796,7 +2796,7 @@ function generatePlugin(/*videojs*/) {
 					this.onBandwidthUpdate = null;
 				}
 
-				if (!!this.player.tech_.hls && null === this.onHlsRetryPlaylist) {
+				if (!!this.player.tech_.vhs && null === this.onHlsRetryPlaylist) {
 					// @note: Catch invalid playlists when selected resolution is not "Auto".
 					this.onHlsRetryPlaylist = this.onHlsRetryPlaylistCallback.bind(this);
 					this.player.tech_.on("retryplaylist", this.onHlsRetryPlaylist);
@@ -2825,7 +2825,7 @@ function generatePlugin(/*videojs*/) {
 
 		onBandwidthUpdateCallback(ev) {
 			this.onAutoQualitySelection(
-				this.player.tech_.hls.playlists.media_.attributes.RESOLUTION.height
+				this.player.tech_.vhs.playlists.media_.attributes.RESOLUTION.height
 			);
 		}
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Refactor player().tech.hls into player().tech.vhs to use the updated Video.js VHS (Video HTTP Streaming) library instead of the deprecated HLS implementation.

## Related Issue

<!--- Please link to the issue here: -->

Fixes [Issue#194](https://github.com/EngageMedia-video/cinematacms/issues/194) VHS warning message on CinemataCMS

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

This change is required to resolve VHS warning messages in CinemataCMS. The Video.js library has deprecated the HLS tech in favor of VHS (Video HTTP Streaming). By updating our code to use player().tech.vhs instead of player().tech.hls, we eliminate deprecation warnings and ensure compatibility with current and future versions of Video.js.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested to ensure that the current Video.js version (7.20) includes the player().tech.vhs class. Verified that:

- Video.js 7.x includes the VHS tech implementation
- The player().tech.vhs class is available and functional
- Video playback continues to work as expected after the refactor
- No deprecation warnings are displayed in the console

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/167e4030-184c-4fd4-bc2b-fe9699d6767b


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Auto-quality switching initializes and updates more reliably, improving accuracy of resolution-based selections.
  - Retry logic for playlist switching is more dependable, reducing stalls after playback errors.
  - Resolution height is detected more consistently for bandwidth updates, enhancing adaptive behavior and quality indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->