### PR TITLE
Docs: makefile installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: docker-up docker-down docker-restart docker-logs docker-ps docker-clean docker-build docker-shell-db docker-shell-redis sync help dev-server start-celery-beat stop-celery-beat start-celery-long stop-celery-long start-celery-short stop-celery-short start-celery-whisper stop-celery-whisper celery-beat-start celery-beat-stop celery-beat-restart celery-long-start celery-long-stop celery-long-restart celery-short-start celery-short-stop celery-short-restart celery-whisper-start celery-whisper-stop celery-whisper-restart celery-start-all celery-stop-all celery-restart-all celery-status frontend-build frontend-dev frontend-clean build-all
+.PHONY: docker-up docker-down docker-restart docker-logs docker-ps docker-clean docker-build docker-shell-db docker-shell-redis sync help dev-server start-celery-beat stop-celery-beat start-celery-long stop-celery-long start-celery-short stop-celery-short start-celery-whisper stop-celery-whisper celery-beat-start celery-beat-stop celery-beat-restart celery-long-start celery-long-stop celery-long-restart celery-short-start celery-short-stop celery-short-restart celery-whisper-start celery-whisper-stop celery-whisper-restart celery-start-all celery-stop-all celery-restart-all celery-status frontend-build frontend-dev frontend-clean quick-build
 
 # Docker compose file to use
 COMPOSE_FILE = docker-compose.dev.yml
@@ -43,7 +43,7 @@ help:
 	@echo "  make frontend-build  - Build all frontend packages and collect static"
 	@echo "  make frontend-dev    - Start frontend development server"
 	@echo "  make frontend-clean  - Clean frontend build directories"
-	@echo "  make build-all       - Build frontend and collect static files"
+	@echo "  make quick-build     - Quick frontend build (main app only)"
 	@echo ""
 	@echo "Celery Commands:"
 	@echo "  make celery-beat-start    - Start Celery beat scheduler"
@@ -205,9 +205,6 @@ frontend-clean:
 	rm -rf frontend/packages/media-player/dist
 	rm -rf static_collected
 	@echo "Frontend build directories cleaned"
-
-build-all: frontend-build
-	@echo "Complete build finished!"
 
 # Quick development build command
 quick-build:

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,8 @@ celery-beat-start:
 	$(CELERY_BIN) -A $(CELERY_APP) beat \
 		--pidfile=$(BEAT_PID_FILE) \
 		--logfile=$(BEAT_LOG_FILE) \
-		--loglevel=$(CELERYD_LOG_LEVEL)
+		--loglevel=$(CELERYD_LOG_LEVEL) \
+		--detach
 
 celery-beat-stop:
 	@if [ -f $(BEAT_PID_FILE) ]; then \
@@ -120,7 +121,8 @@ celery-long-start:
 		--logfile=$(CELERYD_LOG_DIR)/long.log \
 		--loglevel=$(CELERYD_LOG_LEVEL) \
 		$(LONG_OPTS) \
-		-Q $(LONG_QUEUE)
+		-Q $(LONG_QUEUE) \
+		--detach
 
 celery-long-stop:
 	@if [ -f $(CELERYD_PID_DIR)/long.pid ]; then \
@@ -143,7 +145,8 @@ celery-short-start:
 		--logfile=$(CELERYD_LOG_DIR)/short.log \
 		--loglevel=$(CELERYD_LOG_LEVEL) \
 		$(SHORT_OPTS) \
-		-Q $(SHORT_QUEUE)
+		-Q $(SHORT_QUEUE) \
+		--detach
 
 celery-short-stop:
 	@if [ -f $(CELERYD_PID_DIR)/short.pid ]; then \
@@ -166,7 +169,8 @@ celery-whisper-start:
 		--logfile=$(CELERYD_LOG_DIR)/whisper.log \
 		--loglevel=$(CELERYD_LOG_LEVEL) \
 		$(WHISPER_OPTS) \
-		-Q $(WHISPER_QUEUE)
+		-Q $(WHISPER_QUEUE) \
+		--detach
 
 celery-whisper-stop:
 	@if [ -f $(CELERYD_PID_DIR)/whisper.pid ]; then \

--- a/docs/setup/mac-setup-docker.md
+++ b/docs/setup/mac-setup-docker.md
@@ -193,9 +193,9 @@ Go back to the `/cinematacms` directory and create necessary folders and run the
 
 ```zsh
 cd ..
-mkdir logs
-mkdir pids
-mkdir media_files/hls
+mkdir -p logs
+mkdir -p pids
+mkdir -p media_files/hls
 
 uv run python manage.py makemigrations files users actions
 uv run python manage.py migrate

--- a/docs/setup/mac-setup-docker.md
+++ b/docs/setup/mac-setup-docker.md
@@ -182,7 +182,7 @@ BROKER_URL = REDIS_LOCATION
 CELERY_RESULT_BACKEND = BROKER_URL
 
 MP4HLS_COMMAND = (
-    "/opt/homebrew/bin/mp4hls"
+    "/opt/homebrew/bin/mp4hls" # IMPORTANT: run which mp4hls to find the path on your system
 )
 ```
 
@@ -195,6 +195,7 @@ Go back to the `/cinematacms` directory and create necessary folders and run the
 cd ..
 mkdir logs
 mkdir pids
+mkdir media_files/hls
 
 uv run python manage.py makemigrations files users actions
 uv run python manage.py migrate

--- a/docs/setup/mac_setup.md
+++ b/docs/setup/mac_setup.md
@@ -198,6 +198,7 @@ Go back to the `/cinematacms` directory and create necessary folders and run the
 cd ..
 mkdir logs
 mkdir pids
+mkdir media_files/hls
 
 python manage.py makemigrations files users actions
 python manage.py migrate

--- a/docs/setup/mac_setup.md
+++ b/docs/setup/mac_setup.md
@@ -196,9 +196,9 @@ Go back to the `/cinematacms` directory and create necessary folders and run the
 
 ```zsh
 cd ..
-mkdir logs
-mkdir pids
-mkdir media_files/hls
+mkdir -p logs
+mkdir -p pids
+mkdir -p media_files/hls
 
 python manage.py makemigrations files users actions
 python manage.py migrate

--- a/docs/setup/makefile-and-uv.md
+++ b/docs/setup/makefile-and-uv.md
@@ -37,9 +37,9 @@ The Cinemata CMS project includes a Makefile with various commands to help with 
 | `make celery-long-start` | Start long tasks worker |
 | `make celery-long-stop` | Stop long tasks worker |
 | `make celery-long-restart` | Restart long tasks worker |
-| `make celery-short-start` | Start short tasks worker |
-| `make celery-short-stop` | Stop short tasks worker |
-| `make celery-short-restart` | Restart short tasks worker |
+| `make celery-short-start` | Start short tasks workers |
+| `make celery-short-stop` | Stop short tasks workers |
+| `make celery-short-restart` | Restart short tasks workers |
 | `make celery-whisper-start` | Start whisper tasks worker |
 | `make celery-whisper-stop` | Stop whisper tasks worker |
 | `make celery-whisper-restart` | Restart whisper tasks worker |
@@ -47,6 +47,15 @@ The Cinemata CMS project includes a Makefile with various commands to help with 
 | `make celery-stop-all` | Stop all Celery services |
 | `make celery-restart-all` | Restart all Celery services |
 | `make celery-status` | Show Celery process status |
+
+### Frontend Commands
+
+| Command | Description |
+|---------|-------------|
+| `make frontend-build` | Build all frontend packages and collect static |
+| `make frontend-dev` | Start frontend development server |
+| `make frontend-clean` | Clean frontend build directories |
+| `make quick-build` | Quick frontend build (main app only) |
 
 ## Using uv for Dependency Management
 


### PR DESCRIPTION
## Description
This PR improves the Makefile commands and updates the documentation for better clarity and usability:

1. **Makefile improvements:**
   - Added `--detach` option to all Celery start commands (beat, long, short, whisper) to run workers in background mode
   - Renamed `build-all` command to `quick-build` for better clarity about what it does (main app only)
   - Updated help text to reflect the new `quick-build` command name

2. **Documentation updates:**
   - Fixed grammar in Celery worker commands documentation (singular/plural consistency)
   - Added new "Frontend Commands" section documenting all available frontend-related make commands
   - Improved documentation structure in [docs/setup/makefile-and-uv.md](docs/setup/makefile-and-uv.md)

## Related Issue
<!--- Please link to the issue here: -->
Fixes #(issue)

## Motivation and Context
The previous Celery start commands were running in foreground mode, blocking the terminal. Adding the `--detach` option allows workers to run in the background, improving the developer experience.

The documentation was incomplete, missing details about frontend commands, and had some grammatical inconsistencies that needed correction.

## How Has This Been Tested?
- Verified Makefile commands execute without syntax errors
- Confirmed `--detach` option is valid for Celery worker commands
- Reviewed documentation for accuracy and completeness

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a quick-build command for faster builds.
  - Celery start commands now support background execution (detached) for multiple worker types.
  - Replaced the previous build-all command with quick-build.

- Documentation
  - Expanded Makefile docs with a Frontend Commands section and clarified Celery command usage.
  - Updated wording (worker → workers) and tables for clarity.
  - Improved Mac setup guides: use mkdir -p, added media_files/hls directory, and clarified mp4hls binary location.

- Chores
  - Removed the deprecated build-all command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->