### PR TITLE
Feature: Add "Other" Option to Year Dropdown for Edge Cases

### DIFF
--- a/files/forms.py
+++ b/files/forms.py
@@ -131,9 +131,6 @@ class MediaForm(forms.ModelForm):
         self.fields["media_file"].label = "Media Upload"
         self.fields["media_file"].required = False  # Made optional for separate upload via Fine Uploader
 
-        self.fields["year_produced"].label = "Year Produced"
-
-        self.fields["year_produced"].required = True
         self.fields["category"].required = True
         self.fields["media_country"].required = True
 
@@ -218,7 +215,7 @@ class MediaForm(forms.ModelForm):
             
             if year_produced == 'other':
                 year_produced_custom = self.cleaned_data.get('year_produced_custom')
-                if not year_produced_custom:
+                if year_produced_custom is None:
                     if not self.has_error('year_produced_custom'):
                         self.add_error('year_produced_custom', 'Please specify a year.')
                 else:

--- a/files/forms.py
+++ b/files/forms.py
@@ -26,7 +26,28 @@ class MediaForm(forms.ModelForm):
     )
     no_license = forms.BooleanField(required=False, label="All Rights Reserved")
     custom_license = forms.CharField(required=False, label="Just a placeholder")
+    
+    # Add New Field Declarations to MediaForm
+    # Override year_produced to handle dropdown + custom input
+    year_produced = forms.CharField(
+        required=True,
+        label="Year Produced",
+        widget=forms.Select()
+    )
 
+    # Add hidden field for custom year input
+    year_produced_custom = forms.IntegerField(
+        required=False,
+        label="Specify Year",
+        widget=forms.NumberInput(attrs={
+            'class': 'year-custom-input',
+            'placeholder': 'Enter year (e.g. 1995)',
+            'min': '1900',
+            'max': '2030',
+            'style': 'display: none;'
+            })
+    )
+    
     class Meta:
         model = Media
         fields = [
@@ -34,6 +55,7 @@ class MediaForm(forms.ModelForm):
             "summary",
             "description",
             "year_produced",
+            "year_produced_custom",
             "media_file",
             "uploaded_poster",
             "allow_whisper_transcribe_and_translate",
@@ -63,6 +85,31 @@ class MediaForm(forms.ModelForm):
     def __init__(self, user, *args, **kwargs):
         self.user = user
         super(MediaForm, self).__init__(*args, **kwargs)
+        # Update Year Choices Generation
+        # Generate year choices with "other" option
+        current_year = datetime.now().year
+        year_choices = [('', '-- Select Year --')]
+
+        # Add years from current down to 2000
+        for year in range(current_year, 1999, -1):
+            year_choices.append((str(year), str(year)))
+
+        # Add "Other" option at the end
+        year_choices.append(('other', 'Other (specify year)'))
+
+        # Apply choices to the dropdown
+        self.fields["year_produced"].widget.choices = year_choices
+
+        # Set initial values if editing existing media
+        if self.instance and self.instance.year_produced:
+            instance_year = str(self.instance.year_produced)
+            available_years = [choice[0] for choice in year_choices if choice[0] not in ('', 'other')]
+            if instance_year in available_years:
+                self.fields["year_produced"].initial = instance_year
+            else:
+                self.fields["year_produced"].initial = 'other'
+                self.fields["year_produced_custom"].initial = self.instance.year_produced
+                
         self.fields["state"].label = "Status"
         self.fields["allow_download"].label = "Allow Download"
         self.fields["reported_times"].label = "Reported Times"
@@ -148,19 +195,6 @@ class MediaForm(forms.ModelForm):
             raise forms.ValidationError("Synopsis should have 60 words maximum")
         return summary
 
-    def clean_year_produced(self):
-        year_produced = self.cleaned_data.get("year_produced", "")
-        if year_produced:
-            if not isinstance(year_produced, int):
-                raise forms.ValidationError(
-                    "Year produced must be a year between 1900 and now"
-                )
-            if not (1900 <= year_produced and year_produced <= datetime.now().year):
-                raise forms.ValidationError(
-                    "Year produced must be a year between 1900 and now"
-                )
-        return year_produced
-
     def clean_uploaded_poster(self):
         image = self.cleaned_data.get("uploaded_poster", False)
         if image:
@@ -169,16 +203,59 @@ class MediaForm(forms.ModelForm):
             return image
 
     def clean(self):
+        """
+        Custom validation to handle the dropdown + custom year input,
+        and validation for the 'restricted' media state.
+        """
         cleaned_data = super().clean()
+
+        # --- Validation for "Year Produced" ---
+        year_produced = cleaned_data.get('year_produced')
+        year_custom = cleaned_data.get('year_produced_custom')
+
+        if year_produced == 'other':
+            # User selected "Other", validate the custom input
+            if not year_custom:
+                self.add_error('year_produced_custom', 'Please specify the year when selecting "Other".')
+            else:
+                # Validate the custom year's range
+                current_year = datetime.now().year
+                if not (1900 <= year_custom <= current_year):
+                    self.add_error('year_produced_custom',
+                                  f'Year must be between 1900 and {current_year}.')
+                else:
+                    # Use the custom year as the final value
+                    cleaned_data['year_produced'] = year_custom
+
+        elif year_produced:
+            # User selected from the dropdown, validate that it is a valid year
+            try:
+                year_int = int(year_produced)
+                current_year = datetime.now().year
+                # Assuming the dropdown years start from 2000
+                if not (2000 <= year_int <= current_year):
+                    self.add_error('year_produced',
+                                  f'Please select a valid year.')
+                else:
+                    cleaned_data['year_produced'] = year_int
+            except (ValueError, TypeError):
+                self.add_error('year_produced', 'Please select a valid year.')
+
+        # --- Validation for 'Restricted' media state ---
         state = cleaned_data.get("state", False)
         password = cleaned_data.get("password", False)
         featured = cleaned_data.get("featured", False)
+
         if state == "restricted" and not password:
             error = "Password has to be set when state is Restricted"
             self.add_error("password", error)
+
         if state == "restricted" and featured:
             error = "This video cannot be featured as it is Restricted."
             self.add_error("featured", error)
+
+        # Always return the full cleaned_data dictionary
+        return cleaned_data
 
     def save(self, *args, **kwargs):
         data = self.cleaned_data

--- a/files/forms.py
+++ b/files/forms.py
@@ -43,7 +43,6 @@ class MediaForm(forms.ModelForm):
             'class': 'year-custom-input',
             'placeholder': 'Enter year (e.g. 1995)',
             'min': '1900',
-            'max': '2030',
             'style': 'display: none;'
             })
     )
@@ -88,6 +87,7 @@ class MediaForm(forms.ModelForm):
         # Update Year Choices Generation
         # Generate year choices with "other" option
         current_year = datetime.now().year
+        self.fields["year_produced_custom"].widget.attrs["max"] = str(current_year)
         year_choices = [('', '-- Select Year --')]
 
         # Add years from current down to 2000
@@ -222,7 +222,7 @@ class MediaForm(forms.ModelForm):
                 current_year = datetime.now().year
                 if not (1900 <= year_custom <= current_year):
                     self.add_error('year_produced_custom',
-                                  f'Year must be between 1900 and {current_year}.')
+                                  'Year must be between 1900 and {current_year}.')
                 else:
                     # Use the custom year as the final value
                     cleaned_data['year_produced'] = year_custom

--- a/files/forms.py
+++ b/files/forms.py
@@ -222,7 +222,7 @@ class MediaForm(forms.ModelForm):
                 current_year = datetime.now().year
                 if not (1900 <= year_custom <= current_year):
                     self.add_error('year_produced_custom',
-                                  'Year must be between 1900 and {current_year}.')
+                                  f'Year must be between 1900 and {current_year}.')
                 else:
                     # Use the custom year as the final value
                     cleaned_data['year_produced'] = year_custom
@@ -235,7 +235,7 @@ class MediaForm(forms.ModelForm):
                 # Assuming the dropdown years start from 2000
                 if not (2000 <= year_int <= current_year):
                     self.add_error('year_produced',
-                                  f'Please select a valid year.')
+                                  'Please select a valid year.')
                 else:
                     cleaned_data['year_produced'] = year_int
             except (ValueError, TypeError):

--- a/files/forms.py
+++ b/files/forms.py
@@ -208,8 +208,10 @@ class MediaForm(forms.ModelForm):
         and validation for the 'restricted' media state.
         """
         cleaned_data = super().clean()
-
+        
         # --- Year Validation Logic ---
+        current_year = datetime.now().year
+
         # Check if year_produced exists and is not empty
         if 'year_produced' in self.cleaned_data and self.cleaned_data.get('year_produced'):
             year_produced = self.cleaned_data.get('year_produced')
@@ -217,9 +219,9 @@ class MediaForm(forms.ModelForm):
             if year_produced == 'other':
                 year_produced_custom = self.cleaned_data.get('year_produced_custom')
                 if not year_produced_custom:
-                    self.add_error('year_produced_custom', 'Please specify a year.')
+                    if not self.has_error('year_produced_custom'):
+                        self.add_error('year_produced_custom', 'Please specify a year.')
                 else:
-                    current_year = datetime.now().year
                     if not (1900 <= year_produced_custom <= current_year):
                         self.add_error('year_produced_custom', f'Please enter a year between 1900 and {current_year}.')
                     else:
@@ -227,22 +229,17 @@ class MediaForm(forms.ModelForm):
             elif year_produced:
                 try:
                     year_int = int(year_produced)
-                    current_year = datetime.now().year
                     if not (2000 <= year_int <= current_year):
-                        # FIX 1: The f-string has been removed
                         self.add_error('year_produced',
-                                      'Please select a valid year.') 
+                                      'Please select a valid year.')
                     else:
                         cleaned_data['year_produced'] = year_int
                 except (ValueError, TypeError):
                     self.add_error('year_produced', 'Please select a valid year.')
-        
         else:
-            # This case is triggered if the user provides no selection (empty string/None)
-            # `has_error` prevents adding a duplicate error if one already exists
             if not self.has_error('year_produced'):
                 self.add_error('year_produced', 'Please select a year.')
-
+                
         # --- Validation for 'Restricted' media state ---
         state = cleaned_data.get("state", False)
         password = cleaned_data.get("password", False)

--- a/templates/cms/edit_media.html
+++ b/templates/cms/edit_media.html
@@ -1592,6 +1592,42 @@
 			}
 		});
 		</script>
+		<script>
+		document.addEventListener('DOMContentLoaded', function() {
+			const yearSelect = document.querySelector('#id_year_produced');
+			const customInput = document.querySelector('#id_year_produced_custom');
+			const customWrapper = customInput ? customInput.closest('.fieldWrapper') : null;
+			
+			function toggleCustomYear() {
+				if (!yearSelect || !customInput || !customWrapper) return;
+				
+				if (yearSelect.value === 'other') {
+					customWrapper.style.display = 'block';
+					customInput.style.display = 'block';
+					customInput.required = true;
+					customInput.focus();
+				} else {
+					customWrapper.style.display = 'none';
+					customInput.style.display = 'none';
+					customInput.required = false;
+					customInput.value = '';
+				}
+			}
+			
+			if (yearSelect) {
+				yearSelect.addEventListener('change', toggleCustomYear);
+				toggleCustomYear(); // Initialize on page load
+			}
+			
+			// Add styling to custom input
+			if (customInput) {
+				customInput.style.marginTop = '10px';
+				customInput.style.padding = '8px';
+				customInput.style.border = '2px solid #007cba';
+				customInput.style.borderRadius = '4px';
+			}
+		});
+		</script>
 
 {% endblock innercontent %}
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This Pull Request implements an "Other (specify year)" option as the last selection in the year dropdown for media creation/editing forms.
Selecting the "Other" option dynamically reveals a custom text input field, allowing users to manually enter years before 2000 (down to 1900). This provides necessary flexibility for rare edge cases involving older media while maintaining a clean, validated dropdown UX for the majority of users (years 2000 to current).
It involves changes to the form fields, custom initialization logic to handle existing old media, new validation logic in the clean() method, and simple inline JavaScript to manage the field visibility.

## Related Issue
<!--- Please link to the issue here: -->
Fixes #126 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The existing year dropdown is limited to years 2000 to the current year, which is sufficient for approximately 99% of content. This limitation creates an issue when attempting to log older media (pre-2000). This feature provides a professional and user-friendly solution to handle these occasional older records without resorting to text input for all cases, which improves data integrity and prevents typos for the common use case.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The changes were tested locally by running the application and simulating all intended user flows.
Test Scenarios Covered:
1. **Normal Selection**: Selecting a year from the dropdown (2000-current) submits successfully.
2. **Custom Input**: Selecting "Other," entering a valid pre-2000 year (e.g., 1987), and submitting successfully saves the custom year.
3. **Validation**: Tested error states for:
   - Selecting "Other" but leaving the custom input empty.
   - Entering years outside the 1900-current range (e.g., 1891 or 2027).
4. **Existing Media**:
    - Editing a media item with a year > 2000 loads with the year correctly selected in the dropdown.
    - Editing a media item with a year < 2000 (e.g., 1995) loads with "Other" selected in the dropdown and "1995" pre-filled in the custom input field.
5. **Toggling**: Verified the custom input field hides when a normal year is selected and reappears when "Other" is selected.

## Screenshots (if appropriate):
**Scenario 1**: Normal Usage 
Edit form and selects year from 2000-2025
<img width="898" height="247" alt="scenario 1 1" src="https://github.com/user-attachments/assets/2facd787-b261-4000-b265-b588589d8cfd" />
<img width="883" height="605" alt="scenario 1 2" src="https://github.com/user-attachments/assets/306676c1-0ad9-4b46-a727-fc79b81e28db" />

**Scenario 2**: Custom Year Usage
Edit form, selects "Other (specify year)", and input "1987"
<img width="856" height="460" alt="scenario 2 1" src="https://github.com/user-attachments/assets/8c21db62-3290-49b2-9313-78399d2de9dc" />
<img width="717" height="383" alt="scenario 2 2" src="https://github.com/user-attachments/assets/e49a3fc5-ef3a-4e0a-ad1b-bc557126f43d" />

**Scenario 3**: Validation Testing
Select "Other" but leave input empty
<img width="773" height="252" alt="scenario 3 1" src="https://github.com/user-attachments/assets/5a1f439a-a7ff-42ce-b419-a8f090e73b94" />
<img width="702" height="157" alt="scenario 3 2" src="https://github.com/user-attachments/assets/6d4be9d1-44a9-443a-b8b3-13a2f3cb237c" />

Enter year before 1900
<img width="791" height="252" alt="scenario 3 3" src="https://github.com/user-attachments/assets/7b0427c2-de36-4304-9d1f-5d85d3ab0e30" />

Enter year after current year
<img width="770" height="226" alt="scenario 3 4" src="https://github.com/user-attachments/assets/c4294494-f54e-4df9-a695-28c9acc3e709" />

Enter non-numeric value 
<img width="720" height="174" alt="scenario 3 5" src="https://github.com/user-attachments/assets/45940cbc-bc50-4740-aa14-01b5d9bbceff" />
<img width="647" height="151" alt="scenario 3 6" src="https://github.com/user-attachments/assets/3bd1ce9a-4e8b-49b2-87d6-9f4262ae3ab7" />

**Scenario 4**: Existing Media
Media with year 2020 → Shows "2020" selected in dropdown
<img width="740" height="610" alt="scenario 4 1" src="https://github.com/user-attachments/assets/87ccf0d2-26b9-4130-8d62-98a1b2b68045" />
<img width="865" height="540" alt="scenario 4 2" src="https://github.com/user-attachments/assets/1294b7ab-3dbd-4277-acaa-269718f07658" />

Media with year 1995 → Shows "Other" selected + "1995" in input
<img width="668" height="611" alt="scenario 4 3" src="https://github.com/user-attachments/assets/bbf63604-8440-43d7-9610-0376dc6f0474" />
<img width="937" height="499" alt="scenario 4 4" src="https://github.com/user-attachments/assets/8de333fe-348c-4b92-96ca-668950ac345b" />



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add year selection: choose from a dropdown or enter a custom year (dynamic range to current year). Unified validation combines the two inputs, prepopulates values when editing, ensures a single final year, and preserves existing state/password/featured checks.

* **Bug Fixes**
  * Removed duplicate initialization in the media edit form that caused redundant toggle/styling and potential double invocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->