### PR TITLE
feat(newsletter): reactivate newsletter feature

### DIFF
--- a/cms/settings.py
+++ b/cms/settings.py
@@ -576,6 +576,12 @@ RECAPTCHA_PUBLIC_KEY = ""
 
 CRISPY_TEMPLATE_PACK = "bootstrap"
 
+# WordPress Newsletter Plugin API Configuration
+# Public subscribe endpoint (no API key required)
+NEWSLETTER_API_URL = "https://mailer.cinemata.org/wp-json/newsletter/v1/subscribe"
+# Newsletter list ID(s) to subscribe users to (Cinemata Newsletter = list 2)
+NEWSLETTER_LIST_IDS = [2]
+
 from .local_settings import *
 
 # Add debug_toolbar to INSTALLED_APPS if DEBUG is True

--- a/files/context_processors.py
+++ b/files/context_processors.py
@@ -1,7 +1,9 @@
 from django.conf import settings
+import json
 
 from .methods import can_upload_media, is_mediacms_editor, is_mediacms_manager
 from .models import HomepagePopup, TopMessage
+from .lists import UNUSUAL_COUNTRIES
 
 # NOTE: context_processors.py can be considered as a dumping ground of sorts for 
 # multiple variables that, as declared, are then instantiated to be referenced
@@ -65,4 +67,5 @@ def stuff(request):
     if request.user.is_superuser:
         ret["DJANGO_ADMIN_URL"] = settings.DJANGO_ADMIN_URL
     ret["MFA_REQ_DATE"] = 'April 21, 2025'
+    ret["UNUSUAL_COUNTRIES_JSON"] = json.dumps(UNUSUAL_COUNTRIES)
     return ret

--- a/files/lists.py
+++ b/files/lists.py
@@ -25,16 +25,16 @@ video_topics = (
     ("civillib", "Civil Liberties"),
 )
 
+# Reorganized country list - Asia-Pacific first, then rest alphabetically
 video_countries = (
-    ("AQ", "Antarctica"),
+    # Asia-Pacific Region (Primary)
     ("AU", "Australia"),
     ("BD", "Bangladesh"),
     ("BT", "Bhutan"),
-    ("BU", "Bougainville"),
     ("BN", "Brunei Darussalam"),
+    ("BU", "Bougainville"),
     ("KH", "Cambodia"),
     ("CN", "China"),
-    ("EG", "Egypt"),
     ("FJ", "Fiji"),
     ("PF", "French Polynesia"),
     ("GU", "Guam"),
@@ -42,10 +42,10 @@ video_countries = (
     ("HK", "Hong Kong"),
     ("IN", "India"),
     ("ID", "Indonesia"),
-    ("XX", "International"),
     ("JP", "Japan"),
     ("KI", "Kiribati"),
     ("KP", "Korea, Democratic People's Republic Of"),
+    ("KR", "South Korea"),
     ("LA", "Laos"),
     ("MY", "Malaysia"),
     ("MV", "Maldives"),
@@ -77,8 +77,15 @@ video_countries = (
     ("VU", "Vanuatu"),
     ("VN", "Viet Nam"),
     ("WP", "West Papua"),
-    ("KR", "South Korea"),
+    
+    # Other Countries (Alphabetically)
+    ("AQ", "Antarctica"),
+    ("EG", "Egypt"),
+    ("XX", "International"),
 )
+
+# Add this constant for validation
+UNUSUAL_COUNTRIES = ["AQ"]  # Countries that should trigger confirmation
 license_options = (
     ("Yes", "Yes"),
     ("No", "No"),

--- a/files/tasks.py
+++ b/files/tasks.py
@@ -1418,6 +1418,7 @@ def subscribe_user(email, name, country=None):
         "name": name,
         "lists": getattr(settings, 'NEWSLETTER_LIST_IDS', [2]),
         "attribute004": country if country else "",
+        "send_emails": True,  # Trigger confirmation email
     }
 
     headers = {

--- a/templates/account/signup.html
+++ b/templates/account/signup.html
@@ -15,16 +15,48 @@
 			{{ form.as_p }}
 			{% if redirect_field_value %}
 				<input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
-			  {% endif %}
+			{% endif %}
 
-			  {% comment %}
-			  <p><input type="checkbox" name="subscribe" id="id_subscribe">Subscribe to the<a href="https://mailer.cinemata.org/" target="_blank">Cinemata newsletter</a></p>
 
-			  {% endcomment %}
-			  <button type="submit">Sign Up &raquo;</button>
-		</form>
-
+		{# Newsletter subscription checkbox - NOW ENABLED #}
+		<p style="margin-top: 20px;">
+			<input type="checkbox" name="subscribe" id="id_subscribe">
+			<label for="id_subscribe" style="display: inline; font-weight: normal;">
+				Subscribe to the <a href="https://mailer.cinemata.org/" target="_blank" rel="noopener noreferrer">Cinemata newsletter</a> 
+				for updates on social justice films from the Asia-Pacific region. 
+				Read our <a href="/privacy-policy" target="_blank" rel="noopener noreferrer">privacy policy</a>.
+			</label>
+		</p>
+		
+		<button type="submit">Sign Up &raquo;</button>
+	</form>
     </div>
 </div>
+
+<script>
+// Country validation - warn about unusual selections
+document.addEventListener('DOMContentLoaded', function() {
+    const countrySelect = document.querySelector('select[name="location_country"]');
+    if (countrySelect) {
+        countrySelect.addEventListener('change', function() {
+            // eslint-disable-next-line
+            const unusualCountries = {{ UNUSUAL_COUNTRIES_JSON|safe }};
+            const selectedValue = this.value;
+            const selectedText = this.options[this.selectedIndex].text;
+            
+            if (unusualCountries.includes(selectedValue)) {
+                const confirmed = confirm(
+                    'Are you sure you are located in ' + selectedText + '?\n\n' +
+                    'Please select your actual location for accurate newsletter delivery and content recommendations.'
+                );
+                
+                if (!confirmed) {
+                    this.value = '';
+                }
+            }
+        });
+    }
+});
+</script>
 {% endblock innercontent %}
 


### PR DESCRIPTION
## Description
Re-implements the newsletter subscription feature that was disabled in 2024, with improvements to prevent data quality issues (particularly Antarctica misselections).

**Key Changes:**
- ✅ Re-enabled newsletter subscription checkbox on signup form with opt-in mechanism
- ✅ Added required country selection field to signup form
- ✅ Reorganized country list to prioritize Asia-Pacific countries at the top
- ✅ Implemented JavaScript validation warning when Antarctica is selected
- ✅ Enhanced Celery task for PHPList subscription with proper error handling and logging
- ✅ Country tracking now captured in PHPList attribute4 for analytics

**Files Modified:**
- `files/lists.py` - Reorganized video_countries list, moved Antarctica to bottom
- `templates/account/signup.html` - Added newsletter checkbox and Antarctica validation
- `files/tasks.py` - Updated subscribe_user task with country parameter and error handling
- `users/forms.py` - Added location_country field to SignupForm, integrated newsletter subscription

**Technical Details:**
- Newsletter subscription runs asynchronously via Celery (doesn't block signup)
- Uses existing User.location_country field (no migrations required)
- Graceful error handling ensures signup succeeds even if PHPList API fails
- Country data sent to PHPList as attribute4 for tracking

## Related Issue
Fixes https://github.com/EngageMedia-video/cinematacms/issues/245

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
**Local Development:**
- ✅ Tested signup flow with newsletter subscription enabled
- ✅ Verified Celery task execution in logs: `Newsletter subscription successful for jeremy@test.com (Country: PH)`
- ✅ Confirmed user created in database with correct country code
- ✅ Tested Antarctica selection warning dialog
- ✅ Verified signup works without newsletter checkbox (optional opt-in)
- ✅ Tested error handling when PHPList endpoint unreachable

**Database Verification:**
- User record created with `location_country: PH`
- Timestamp matches Celery log entries

**Celery Logs:**
```
Task subscribe_user received
Newsletter subscription successful for jeremy@test.com (Country: PH)
Task subscribe_user succeeded in 0.28s: True
```

## Screenshots (if appropriate):
<img width="875" height="138" alt="image" src="https://github.com/user-attachments/assets/dbc138b3-6f0b-4d23-a152-07670649ad29" />
<img width="1797" height="1087" alt="image" src="https://github.com/user-attachments/assets/5dc99690-572b-4e45-bdb7-380d9029b905" />
<img width="1159" height="593" alt="image" src="https://github.com/user-attachments/assets/f567ab10-0876-4b7f-9a11-58cf416460f0" />




## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Newsletter signup option enabled on the account form; subscription queued in background.
  * Country/Region is now a required field with expanded Asia‑Pacific entries.
  * Client-side confirmation prompt for select unusual countries with a privacy note.

* **Bug Fixes**
  * Newsletter failures are handled without blocking account creation; background queuing logs success/failure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->