### PR TITLE
feat(permission): allow admins and managers to see private videos

### DIFF
--- a/docs/admin-guides/cinematacms-roles-permission-matrix.md
+++ b/docs/admin-guides/cinematacms-roles-permission-matrix.md
@@ -79,18 +79,19 @@ The matrix follows a progressive permission model where higher-level roles inher
 |:-----------|:---------------|:----------------|:-------------|:-------|:--------|:------|
 | Access content review dashboard | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ |
 | Review and approve submitted content | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ |
+| View Publication Status of Users' Video Contents | ✗ | ✗ | ✗ | ✗ | ✓ | ✓ |
 | Handle reported content | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ |
 | Set content visibility status | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ |
-| Access moderation logs | ✗ | ✗ | ✗ | ✓ | ✓ | ✓ |
+| Access moderation logs | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ |
 
 ### 🎨 Site Management
 
 | Permission | Public Visitor | Registered User | Trusted User | Editor | Manager | Admin |
 |:-----------|:---------------|:----------------|:-------------|:-------|:--------|:------|
 | Manage homepage featured content | ✗ | ✗ | ✗ | ✗ | ✓ | ✓ |
-| Create/edit site pages (About, Contact, etc.) | ✗ | ✗ | ✗ | ✗ | ✓ | ✓ |
-| Manage categories, tags, and topics | ✗ | ✗ | ✗ | ✗ | ✓ | ✓ |
-| View site analytics | ✗ | ✗ | ✗ | ✗ | ✓ | ✓ |
+| Create/edit site pages (About, Contact, etc.) | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ |
+| Manage categories, tags, and topics | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ |
+| View site analytics | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ |
 | Configure encoding profiles | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ |
 | Manage site settings and configuration | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ |
 
@@ -102,7 +103,7 @@ The matrix follows a progressive permission model where higher-level roles inher
 | Edit own profile | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | View user profiles | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | Edit other users' profiles | ✗ | ✗ | ✗ | ✗ | ✓ | ✓ |
-| Promote users to higher roles | ✗ | ✗ | ✗ | ✗ | Manager+ only | ✓ |
+| Promote users to higher roles | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ |
 | Suspend/deactivate users | ✗ | ✗ | ✗ | ✗ | ✓ | ✓ |
 | Delete user accounts | ✗ | Own only | Own only | ✗ | ✗ | ✓ |
 

--- a/files/helpers.py
+++ b/files/helpers.py
@@ -937,3 +937,42 @@ def cleanup_temp_upload_files(temp_file_path, upload_file_path, media_friendly_t
             f"Unexpected error during temp file cleanup for media {media_friendly_token}: {e}",
             exc_info=True
         )
+
+
+def can_view_all_user_media(requesting_user, profile_user):
+    """
+    Check if requesting_user can view ALL media (including private, unlisted, and restricted) 
+    from profile_user's profile page.
+    
+    Returns True if:
+    - Requesting user is the profile owner
+    - Requesting user is a Manager
+    - Requesting user is a Superuser
+    
+    Returns False otherwise (including for Editors)
+    
+    Args:
+        requesting_user: User making the request
+        profile_user: User whose profile is being viewed
+        
+    Returns:
+        bool: True if user can view all media, False otherwise
+    """
+    from .methods import is_mediacms_manager
+    
+    if not requesting_user.is_authenticated:
+        return False
+    
+    # Owner can always see their own content
+    if requesting_user == profile_user:
+        return True
+    
+    # Superusers can see all content
+    if requesting_user.is_superuser:
+        return True
+    
+    # Managers can see all content (but NOT editors)
+    if is_mediacms_manager(requesting_user):
+        return True
+    
+    return False

--- a/files/views.py
+++ b/files/views.py
@@ -944,9 +944,13 @@ class MediaList(APIView):
         else:
             pagination_class = api_settings.DEFAULT_PAGINATION_CLASS
             if author_param:
-                if self.request.user == user:  # SHOW ALL VIDEOS
+                from .helpers import can_view_all_user_media
+                
+                if can_view_all_user_media(self.request.user, user):
+                    # Owners, managers, and superusers see ALL videos (including private, unlisted, restricted)
                     basic_query = Q(user=user)
                 else:
+                    # Everyone else sees only public, reviewed videos
                     basic_query = Q(state="public", is_reviewed=True, user=user)
             else:
                 basic_query = Q(

--- a/frontend/src/static/js/components/-NEW-/ListItem.js
+++ b/frontend/src/static/js/components/-NEW-/ListItem.js
@@ -202,6 +202,7 @@ export function listItemProps( props, item, index ){
 		hasMediaViewer: 0 === index && 'video' === item.media_type && !! props.firstItemViewer,
 		hasMediaViewerDescr: false,
 		countries: item.media_country_info || [],
+		state: item.state || null,
 	};
 
 	args.hasMediaViewerDescr = args.hasMediaViewer && !! props.firstItemDescr;
@@ -361,6 +362,8 @@ export function ListItem(props){
 		args.hideViews = props.hide.views;
 		args.hideAuthor = props.hide.author;
 		args.hideCategories = props.hide.categories;
+
+		args.state = props.state;
 	}
 
 	if( props.playlistPage.current || props.playlistPlayback.current ){

--- a/frontend/src/static/js/components/-NEW-/MediaItem.js
+++ b/frontend/src/static/js/components/-NEW-/MediaItem.js
@@ -18,7 +18,7 @@ export function MediaItem(props){
 	const [ titleComponent, descriptionComponent, thumbnailUrl, UnderThumbWrapper, editMediaComponent, metaComponents ] = useMediaItem({...props, type });
 
 	function thumbnailComponent(){
-		return <MediaItemThumbnailLink src={ thumbnailUrl } title={ props.title } link={ props.link } />;
+		return <MediaItemThumbnailLink src={ thumbnailUrl } title={ props.title } link={ props.link } state={ props.state } />;
 	}
 
 	const containerClassname = itemClassname( 'item ' + type + '-item', props.class_name.trim(), props.playlistOrder === props.playlistActiveItem );

--- a/frontend/src/static/js/components/-NEW-/MediaItemAudio.js
+++ b/frontend/src/static/js/components/-NEW-/MediaItemAudio.js
@@ -6,7 +6,7 @@ import { MediaItem } from './MediaItem';
 
 import { PositiveIntegerOrZero } from '../../functions/propTypeFilters';;
 
-import { MediaItemDuration, MediaItemPlaylistIndex, itemClassname } from './includes/items';
+import { MediaItemDuration, MediaItemPlaylistIndex, MediaItemStateBadge, itemClassname } from './includes/items';
 
 import { useMediaItem } from './hooks/useMediaItem';
 
@@ -43,6 +43,7 @@ export function MediaItemAudio(props){
 
 		return <a {...attr}>
 					{ props.inPlaylistView ? null : <MediaItemDuration ariaLabel={ duration } time={ durationISO8601 } text={ durationStr } /> }
+					<MediaItemStateBadge state={props.state} />
 				</a>;
 	}
 

--- a/frontend/src/static/js/components/-NEW-/MediaItemVideo.js
+++ b/frontend/src/static/js/components/-NEW-/MediaItemVideo.js
@@ -6,7 +6,7 @@ import { MediaItem } from './MediaItem';
 
 import { PositiveIntegerOrZero } from '../../functions/propTypeFilters';;
 
-import { MediaItemVideoPlayer, MediaItemDuration, MediaItemVideoPreviewer, MediaItemPlaylistIndex, itemClassname } from './includes/items';
+import { MediaItemVideoPlayer, MediaItemDuration, MediaItemVideoPreviewer, MediaItemPlaylistIndex, MediaItemStateBadge, itemClassname } from './includes/items';
 
 import { useMediaItem } from './hooks/useMediaItem';
 
@@ -48,6 +48,7 @@ export function MediaItemVideo(props){
 		return <a {...attr}>
 					{ props.inPlaylistView ? null : <MediaItemDuration ariaLabel={ duration } time={ durationISO8601 } text={ durationStr } /> }
 					{ props.inPlaylistView || props.inPlaylistPage ? null : <MediaItemVideoPreviewer url={ props.preview_thumbnail } /> }
+					<MediaItemStateBadge state={props.state} />
 				</a>;
 	}
 

--- a/frontend/src/static/js/components/-NEW-/includes/items/includes.js
+++ b/frontend/src/static/js/components/-NEW-/includes/items/includes.js
@@ -49,6 +49,30 @@ export function MediaItemEditLink(props) {
 	return (void 0 === props.link ? null : <a href={props.link} title="Edit media" className="item-edit-link">EDIT MEDIA</a>);
 }
 
+export function MediaItemStateBadge(props) {
+	if (!props.state || props.state === 'public') {
+		return null;
+	}
+
+	const badgeConfig = {
+		private: { icon: 'lock', label: 'Private', className: 'badge-private' },
+		unlisted: { icon: 'link', label: 'Unlisted', className: 'badge-unlisted' },
+		restricted: { icon: 'vpn_key', label: 'Restricted', className: 'badge-restricted' }
+	};
+
+	const config = badgeConfig[props.state];
+	if (!config) {
+		return null;
+	}
+
+	return (
+		<span className={`item-state-badge ${config.className}`} title={config.label}>
+			<i className="material-icons">{config.icon}</i>
+			<span className="badge-label">{config.label}</span>
+		</span>
+	);
+}
+
 export function MediaItemThumbnailLink(props) {
 
 	const attr = {
@@ -63,6 +87,7 @@ export function MediaItemThumbnailLink(props) {
 
 	return (<a {...attr}>
 		{!props.src ? null : <div key="item-type-icon" className="item-type-icon"><div></div></div>}
+		<MediaItemStateBadge state={props.state} />
 	</a>);
 }
 

--- a/frontend/src/static/js/components/styles/Item.scss
+++ b/frontend/src/static/js/components/styles/Item.scss
@@ -679,7 +679,7 @@ a.item-edit-link{
 	display: flex;
 	align-items: center;
 	gap: 4px;
-	z-index: 10;
+	z-index: 1;
 	pointer-events: none;
 	color: #fff;
 
@@ -703,7 +703,7 @@ a.item-edit-link{
 	}
 
 	&.badge-restricted {
-		background: rgba(126, 87, 194, 0.9);
+		background: rgba(2, 102, 144, 0.9);
 		color: #fff;
 	}
 }

--- a/frontend/src/static/js/components/styles/Item.scss
+++ b/frontend/src/static/js/components/styles/Item.scss
@@ -666,3 +666,44 @@ a.item-edit-link{
 		}
 	}
 }
+
+// State badges for non-public videos (private, unlisted, restricted)
+.item-state-badge {
+	position: absolute;
+	top: 8px;
+	right: 8px;
+	padding: 4px 8px;
+	border-radius: 4px;
+	font-size: 12px;
+	font-weight: 500;
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	z-index: 10;
+	pointer-events: none;
+	color: #fff;
+
+	.material-icons {
+		font-size: 14px;
+		line-height: 1;
+	}
+
+	.badge-label {
+		line-height: 1;
+	}
+
+	&.badge-private {
+		background: rgba(0, 0, 0, 0.85);
+		color: #fff;
+	}
+
+	&.badge-unlisted {
+		background: rgba(237, 124, 48, 0.9);
+		color: #fff;
+	}
+
+	&.badge-restricted {
+		background: rgba(126, 87, 194, 0.9);
+		color: #fff;
+	}
+}

--- a/frontend/src/static/js/pages/ProfilePage/Media.js
+++ b/frontend/src/static/js/pages/ProfilePage/Media.js
@@ -31,18 +31,24 @@ export class ProfileMediaPage extends ProfilePage {
 					<ApiUrlConsumer>
 					{ apiUrl => 
 						<UserConsumer>
-						{ user => 
-							<ProfilePagesContent key="ProfilePagesContent">
-								<MediaListWrapper title={ this.props.title } className="items-list-ver">
-									<LazyLoadItemListAsync
-										requestUrl={ apiUrl.media + '?author=' + this.state.author.id }
-										hideAuthor={ true }
-										hideViews={ ! PageStore.get('config-media-item').displayViews }
-										hideDate={ ! PageStore.get('config-media-item').displayPublishDate }
-										canEdit={ ProfilePageStore.get('author-data').username === user.username } />
-								</MediaListWrapper>
-							</ProfilePagesContent>
-						}
+						{ user => {
+							const isMediaAuthor = ProfilePageStore.get('author-data').username === user.username;
+							const isManagerOrAdmin = user.is.manager || user.is.admin;
+							const canEditMedia = isMediaAuthor || isManagerOrAdmin;
+							
+							return (
+								<ProfilePagesContent key="ProfilePagesContent">
+									<MediaListWrapper title={ this.props.title } className="items-list-ver">
+										<LazyLoadItemListAsync
+											requestUrl={ apiUrl.media + '?author=' + this.state.author.id }
+											hideAuthor={ true }
+											hideViews={ ! PageStore.get('config-media-item').displayViews }
+											hideDate={ ! PageStore.get('config-media-item').displayPublishDate }
+											canEdit={ canEditMedia } />
+									</MediaListWrapper>
+								</ProfilePagesContent>
+							);
+						}}
 						</UserConsumer>
 					}
 					</ApiUrlConsumer>

--- a/frontend/src/static/js/pages/ProfilePage/index.js
+++ b/frontend/src/static/js/pages/ProfilePage/index.js
@@ -175,6 +175,8 @@ export class ProfilePage extends Page {
 		const authorData = ProfilePageStore.get('author-data');
 
 		const isMediaAuthor = authorData && authorData.username === UserContext._currentValue.username;
+		const isManagerOrAdmin = UserContext._currentValue.is.manager || UserContext._currentValue.is.admin;
+		const canEditMedia = isMediaAuthor || isManagerOrAdmin;
 
 		return [ this.state.author ? <ProfilePagesHeader key="ProfilePagesHeader" author={ this.state.author } onQueryChange={ this.changeRequestQuery } /> : null,
 				 this.state.author ?
@@ -187,7 +189,7 @@ export class ProfilePage extends Page {
 								itemsCountCallback={ this.state.requestUrl ? this.getCountFunc : null }
 								hideViews={ ! PageStore.get('config-media-item').displayViews }
 								hideDate={ ! PageStore.get('config-media-item').displayPublishDate }
-								canEdit={ isMediaAuthor } />
+								canEdit={ canEditMedia } />
 							{ isMediaAuthor && 0 === this.state.channelMediaCount && ! this.state.query ? <EmptyChannelMedia name={this.state.author.name} /> : null }
 						</MediaListWrapper>
 					</ProfilePagesContent>

--- a/templates/config/core/user.html
+++ b/templates/config/core/user.html
@@ -5,6 +5,7 @@ MediaCMS.user = {
 	location_country: {% if request.user.is_authenticated %}"{{request.user.location_country}}"{% else %}null{% endif %},
 	is: {
 		admin: {% if IS_MEDIACMS_ADMIN %}true{% else %}false{% endif %},
+		manager: {% if IS_MEDIACMS_MANAGER %}true{% else %}false{% endif %},
 		anonymous: {% if request.user.is_authenticated %}false{% else %}true{% endif %},
 	},
 	can: {


### PR DESCRIPTION
## Description
Enables site managers and superusers to view all videos (including private, unlisted, and restricted) on user profile pages, consistent with the Manage Media section.

- Added [can_view_all_user_media()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) helper to check permissions (owner, manager, or superuser)
- Modified [MediaList.get()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) API to return all videos for authorized users on profile pages
- Updated ProfilePage components to show edit controls for managers/superusers
- Exposed [is.manager](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) field in frontend user context

### Security
✅ Backend permission enforcement (cannot be bypassed)
✅ Editors explicitly excluded from this access
✅ Regular users and anonymous visitors only see public videos

## Related Issue
https://github.com/EngageMedia-video/cinematacms/issues/252

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manual test by using different roles.

## Screenshots (if appropriate):
### Admin & Manager
<img width="1800" height="1042" alt="image" src="https://github.com/user-attachments/assets/0c00c39f-e204-42b4-9f97-9f04892aa7c1" />

### Other Role
<img width="1800" height="1036" alt="image" src="https://github.com/user-attachments/assets/9b0590d1-f632-4b1f-a113-7e61c66ccb4d" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Managers and superusers can view and edit all media on user profiles (including private/unlisted/restricted) in addition to authors.
  * Media items now carry a persistent state property and show a visual state badge (private/unlisted/restricted) on thumbnails.

* **Style**
  * Added styling for state badges on media thumbnails.

* **Documentation**
  * Updated admin permission matrix to tighten/selectively restrict several management and moderation capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->