### PR TITLE
feat(user): add role upgrade email notifications 

### DIFF
--- a/files/methods.py
+++ b/files/methods.py
@@ -549,12 +549,13 @@ The {portal_name} Team
             f"Role update notification sent to {user.username} ({user.email}) "
             f"for roles: {', '.join(upgraded_roles)}"
         )
+        return True 
     else:
         logger.warning(
             f"Role update notification failed to send to {user.username} ({user.email}) "
             f"for roles: {', '.join(upgraded_roles)}"
         )
-    return True
+        return False
 
 def is_mediacms_editor(user):
     # helper function

--- a/files/methods.py
+++ b/files/methods.py
@@ -511,7 +511,7 @@ def notify_user_on_role_update(user, upgraded_roles):
     msg = f"""
 Hello {user_name},
 
-We are pleased to inform you that your account privileges on {portal_name} have been updated by a superuser. You now have access to new capabilities!
+We are pleased to inform you that your account privileges on {portal_name} have been updated. You now have access to new capabilities!
 
 The following role(s) have been granted to your account:
 
@@ -522,14 +522,13 @@ The following role(s) have been granted to your account:
 
 ---
 
-We encourage you to log in and explore your new capabilities and features.
+We encourage you to log in and explore your new features. For guidance on using your new capabilities, visit our Help page:
 
-Explore the platform here:
-{platform_link}
+{platform_link}/help
 
-If you have any questions regarding your new privileges or the platform, please do not hesitate to contact our support team.
+If you have any questions about your new privileges or the platform, please contact our support team.
 
-Thank you for your valuable contribution to the platform.
+Thank you for your valuable contributions to {portal_name}.
 
 Best regards,
 

--- a/files/methods.py
+++ b/files/methods.py
@@ -11,6 +11,7 @@ from django.utils import timezone
 
 from cms import celery_app
 
+
 from . import models
 from .helpers import mask_ip
 
@@ -435,6 +436,103 @@ View it on %s
         email.send(fail_silently=True)
     return True
 
+# Define role mappings for display name and capability description
+ROLE_MAP = {
+    'advancedUser': {
+        'display_name': 'Trusted User',
+        'capability': 'You can now upload or publish content (videos/articles) that will bypass the standard review process, allowing for faster publication.'
+    },
+    'is_editor': {
+        'display_name': 'Editor',
+        'capability': 'You now have the rights to edit, verify, and publish content submitted by other users on the platform.'
+    },
+    'is_manager': {
+        'display_name': 'Manager',
+        'capability': 'You now have managerial access rights, which include Editor capabilities, as well as the ability to manage several aspects of platform configuration and/or other user roles (excluding superusers).'
+    },
+}
+
+def notify_user_on_role_update(user, upgraded_roles):
+    """
+    Send email notification when a user's role is updated to a privileged role.
+    upgraded_roles is a list of internal role field names (e.g., ['is_editor', 'advancedUser']).
+    
+    Follows existing email patterns (EmailMessage, fail_silently=True).
+    """
+    if not user.email:
+        # Graceful failure: No email address (as per acceptance criteria)
+        logger.error(
+            f"Role update notification skipped for user {user.username}: no email address."
+        )
+        return False
+
+    # 1. Prepare dynamic content
+    role_summary_list = []
+    role_details_block = ""
+
+    for role_name in upgraded_roles:
+        role_info = ROLE_MAP.get(role_name)
+        if role_info:
+            role_summary_list.append(role_info['display_name'])
+            # Create the detailed block
+            role_details_block += f"**{role_info['display_name']}**\n"
+            role_details_block += f"{role_info['capability']}\n\n"
+
+    # If the roles list is unexpectedly empty
+    if not role_summary_list:
+        return False
+
+    # 2. Prepare email context / variables
+    user_name = user.get_full_name() or user.username
+    portal_name = settings.PORTAL_NAME
+    platform_link = settings.SSL_FRONTEND_HOST
+    
+    # 3. Construct the email body
+    granted_roles_summary = "\n".join([f"- {name}" for name in role_summary_list])
+    role_details_block = role_details_block.strip()
+    
+    # Clear subject line indicating privilege update (Acceptance Criteria)
+    subject = f"[{portal_name}] - Your account privileges have been updated"
+    
+    # Friendly message explaining new capabilities (Acceptance Criteria)
+    msg = f"""
+Hello {user_name},
+
+We are pleased to inform you that your account privileges on {portal_name} have been updated by a superuser. You now have access to new capabilities!
+
+The following role(s) have been granted to your account:
+
+{granted_roles_summary}
+---
+
+{role_details_block}
+
+---
+
+We encourage you to log in and explore your new capabilities and features.
+
+Explore the platform here:
+{platform_link}
+
+If you have any questions regarding your new privileges or the platform, please do not hesitate to contact our support team.
+
+Thank you for your valuable contribution to the platform.
+
+Best regards,
+
+The {portal_name} Team
+"""
+
+    # 4. Send the email
+    email = EmailMessage(
+        subject,
+        msg,
+        settings.DEFAULT_FROM_EMAIL,
+        [user.email],
+    )
+    # Follow existing email patterns (fail_silently=True)
+    email.send(fail_silently=True)
+    return True
 
 def is_mediacms_editor(user):
     # helper function

--- a/files/methods.py
+++ b/files/methods.py
@@ -459,6 +459,17 @@ def notify_user_on_role_update(user, upgraded_roles):
     
     Follows existing email patterns (EmailMessage, fail_silently=True).
     """
+    # Validate inputs
+    if not user:
+        logger.error("Role update notification failed: user is None.")
+        return False
+    
+    if not upgraded_roles or not isinstance(upgraded_roles, (list, tuple)):
+        logger.error(
+            f"Role update notification failed for user {user.username}: invalid upgraded_roles parameter."
+        )
+        return False
+    
     if not user.email:
         # Graceful failure: No email address (as per acceptance criteria)
         logger.error(

--- a/files/methods.py
+++ b/files/methods.py
@@ -440,15 +440,15 @@ View it on %s
 ROLE_MAP = {
     'advancedUser': {
         'display_name': 'Trusted User',
-        'capability': 'You can now upload or publish content (videos/articles) that will bypass the standard review process, allowing for faster publication.'
+        'capability': 'You can now upload and publish videos, and enjoy all platform features without content review.'
     },
     'is_editor': {
         'display_name': 'Editor',
-        'capability': 'You now have the rights to edit, verify, and publish content submitted by other users on the platform.'
+        'capability': 'You can now moderate, edit, and publish content submitted by other users on the platform.'
     },
     'is_manager': {
         'display_name': 'Manager',
-        'capability': 'You now have managerial access rights, which include Editor capabilities, as well as the ability to manage several aspects of platform configuration and/or other user roles (excluding superusers).'
+        'capability': 'You can now manage site content, user accounts, and comments to help oversee platform operations.'
     },
 }
 

--- a/files/methods.py
+++ b/files/methods.py
@@ -536,18 +536,24 @@ The {portal_name} Team
 """
 
     # 4. Send the email
-    email = EmailMessage(
+    email_message = EmailMessage(
         subject,
         msg,
         settings.DEFAULT_FROM_EMAIL,
         [user.email],
     )
     # Follow existing email patterns (fail_silently=True)
-    email.send(fail_silently=True)
-    logger.info(
-        f"Role update notification sent to {user.username} ({user.email}) "
-        f"for roles: {', '.join(upgraded_roles)}"
-    )
+    sent_count = email_message.send(fail_silently=True)
+    if sent_count:
+        logger.info(
+            f"Role update notification sent to {user.username} ({user.email}) "
+            f"for roles: {', '.join(upgraded_roles)}"
+        )
+    else:
+        logger.warning(
+            f"Role update notification failed to send to {user.username} ({user.email}) "
+            f"for roles: {', '.join(upgraded_roles)}"
+        )
     return True
 
 def is_mediacms_editor(user):

--- a/files/methods.py
+++ b/files/methods.py
@@ -475,7 +475,7 @@ def notify_user_on_role_update(user, upgraded_roles):
         if role_info:
             role_summary_list.append(role_info['display_name'])
             # Create the detailed block
-            role_details_block += f"**{role_info['display_name']}**\n"
+            role_details_block += f"{role_info['display_name']}\n"
             role_details_block += f"{role_info['capability']}\n\n"
 
     # If the roles list is unexpectedly empty

--- a/files/methods.py
+++ b/files/methods.py
@@ -477,6 +477,8 @@ def notify_user_on_role_update(user, upgraded_roles):
             # Create the detailed block
             role_details_block += f"{role_info['display_name']}\n"
             role_details_block += f"{role_info['capability']}\n\n"
+        else:
+            logger.warning(f"Unrecognized role '{role_name}' in notification for user {user.username}.")
 
     # If the roles list is unexpectedly empty
     if not role_summary_list:
@@ -532,6 +534,10 @@ The {portal_name} Team
     )
     # Follow existing email patterns (fail_silently=True)
     email.send(fail_silently=True)
+    logger.info(
+        f"Role update notification sent to {user.username} ({user.email}) "
+        f"for roles: {', '.join(upgraded_roles)}"
+    )
     return True
 
 def is_mediacms_editor(user):

--- a/users/admin.py
+++ b/users/admin.py
@@ -147,7 +147,6 @@ class CustomAuthenticatorAdmin(admin.ModelAdmin):
 
         elif obj.type == obj.Type.RECOVERY_CODES:
             # For recovery codes, show count and usage status
-            used_mask = obj.data.get("used_mask", 0)
             seed = obj.data.get("seed", None)
             unused_count = len(obj.wrap().get_unused_codes())
             total_count = 0

--- a/users/admin.py
+++ b/users/admin.py
@@ -65,6 +65,42 @@ class UserAdmin(admin.ModelAdmin):
     def mfa_created_at(self, obj):
         return obj.mfa_created
 
+
+    # ROLE UPDATE NOTIFICATION (ADDED)
+    def save_model(self, request, obj, form, change):
+        """
+        Detects when a superuser upgrades user roles (advancedUser, is_editor, is_manager)
+        and sends an email notification.
+        """
+
+        from files.methods import notify_user_on_role_update  # imported here to avoid circular import
+
+        upgraded_roles = []
+
+        # Only superusers trigger notifications AND only on existing users (change=True)
+        if change and request.user.is_superuser:
+            ROLE_FIELDS = ["advancedUser", "is_editor", "is_manager"]
+
+            # Fetch old user data
+            old_obj = User.objects.filter(pk=obj.pk).first()
+
+            if old_obj:
+                for role in ROLE_FIELDS:
+                    old_val = getattr(old_obj, role)
+                    new_val = getattr(obj, role)
+
+                    # Trigger only when role becomes True (upgrade)
+                    if old_val is False and new_val is True:
+                        upgraded_roles.append(role)
+
+        # Save first
+        super().save_model(request, obj, form, change)
+
+        # Send notification after saving
+        if upgraded_roles:
+            notify_user_on_role_update(obj, upgraded_roles)
+
+
 # unregister regular authenticator model
 admin.site.unregister(Authenticator)
 
@@ -74,14 +110,14 @@ class CustomAuthenticatorAdmin(admin.ModelAdmin):
     list_filter = ('type', 'created_at', 'last_used_at')
     readonly_fields = ('type', 'user', 'data_masked', 'created_at', 'last_used_at')
     exclude = ('data',)  # Hide the raw data field
-    
+
     def get_fields(self, request, obj=None):
         """Ensure 'data' field is not directly editable"""
         fields = super().get_fields(request, obj)
         if 'data' in fields:
             fields.remove('data')
         return fields
-    
+
     def auth_description(self, obj):
         """Display a meaningful name for the authenticator without revealing secrets"""
         if obj.type == obj.Type.WEBAUTHN:
@@ -93,9 +129,9 @@ class CustomAuthenticatorAdmin(admin.ModelAdmin):
             unused_count = len(obj.wrap().get_unused_codes())
             return f"Recovery Codes ({unused_count} remaining)"
         return obj.get_type_display()
-    
+
     auth_description.short_description = "Authentication Method"
-    
+
     def data_masked(self, obj):
         """Display a masked version of the data"""
         if obj.type == obj.Type.WEBAUTHN:
@@ -103,36 +139,36 @@ class CustomAuthenticatorAdmin(admin.ModelAdmin):
             name = obj.wrap().name
             has_credential = "credential" in obj.data
             return f"Name: {name}, Has credential data: {'Yes' if has_credential else 'No'}"
-            
+
         elif obj.type == obj.Type.TOTP:
             # For TOTP, just indicate secret exists but don't show it
             has_secret = "secret" in obj.data
             return f"TOTP secret: {'[ENCRYPTED]' if has_secret else 'None'}"
-            
+
         elif obj.type == obj.Type.RECOVERY_CODES:
             # For recovery codes, show count and usage status
             used_mask = obj.data.get("used_mask", 0)
             seed = obj.data.get("seed", None)
             unused_count = len(obj.wrap().get_unused_codes())
             total_count = 0
-            
+
             # Try to determine total recovery code count
             from allauth.mfa import app_settings as mfa_settings
             total_count = mfa_settings.RECOVERY_CODE_COUNT
-            
+
             return (
                 f"Unused codes: {unused_count}/{total_count}\n"
                 f"Seed: {'[ENCRYPTED]' if seed else 'None'}"
             )
-        
+
         # Generic fallback
         data_keys = list(obj.data.keys())
         return f"Keys: {', '.join(data_keys)}"
-    
+
     data_masked.short_description = "Protected Data"
 
 
-# TODO: is_superuser: global site administrator
-# SHOW IF EDITOR, also next in list filter TODO
+# is_superuser: global site administrator
+# TODO: Show 'is_editor' in the list filter as well
 admin.site.register(User, UserAdmin)
 admin.site.register(BlackListedEmail, BlackListedEmailAdmin)

--- a/users/models.py
+++ b/users/models.py
@@ -66,7 +66,9 @@ class User(AbstractUser):
     )
     last_published_video_datetime = models.DateTimeField(
         "datetime of the last video that was published",
-        default=timezone.now,
+        null=True,
+        blank=True,
+        default=None,
         db_index=True,
     )
 

--- a/users/models.py
+++ b/users/models.py
@@ -66,7 +66,8 @@ class User(AbstractUser):
     )
     last_published_video_datetime = models.DateTimeField(
         "datetime of the last video that was published",
-        default="2008-1-1",
+        # gunakan function timezone.now sebagai default, bukan string
+        default=timezone.now,
         db_index=True,
     )
 
@@ -274,3 +275,4 @@ class BlackListedEmail(models.Model):
 
     def __str__(self):
         return self.email
+

--- a/users/models.py
+++ b/users/models.py
@@ -66,9 +66,7 @@ class User(AbstractUser):
     )
     last_published_video_datetime = models.DateTimeField(
         "datetime of the last video that was published",
-        null=True,
-        blank=True,
-        default=None,
+        default="2008-1-1",
         db_index=True,
     )
 

--- a/users/models.py
+++ b/users/models.py
@@ -66,7 +66,6 @@ class User(AbstractUser):
     )
     last_published_video_datetime = models.DateTimeField(
         "datetime of the last video that was published",
-        # gunakan function timezone.now sebagai default, bukan string
         default=timezone.now,
         db_index=True,
     )


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR introduces two improvements related to user management in CinemataCMS:

Email notifications for user role upgrades
  When a superuser updates a user's privileged roles (Trusted User, Editor, Manager) via the Django Admin panel, the affected user now receives an automatic email notification.
This ensures users are informed when new capabilities become available to them.

## Related Issue
<!--- Please link to the issue here: -->
Fixes #137 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

- Users were not informed when their account privileges changed, leading to confusion and reduced transparency.
- This PR resolves both issues and aligns the system with best practices for notification management.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested role upgrades for:
- Trusted User (advancedUser)
- Editor (is_editor)
- Manager (is_manager)

Verified:
- Email sent only on False → True transitions
- Email not sent on role downgrade
- Email not sent when editing fields unrelated to roles
- Email not sent when user has no email (graceful logging)
- Multiple role upgrades produce one email

## Screenshots (if appropriate):
Superuser promotes regular user to Trusted User → Email sent
<img width="805" height="656" alt="Superuser promotes regular user to Trusted User 1 0" src="https://github.com/user-attachments/assets/9215e72e-2016-469a-9ba6-2c82cd697a5d" />
<img width="786" height="490" alt="Superuser promotes regular user to Trusted User 1 1" src="https://github.com/user-attachments/assets/78bf2fce-0774-4916-96d4-2aa411601c14" />
Superuser promotes user to Editor → Email sent
<img width="595" height="349" alt="Superuser promotes user to Editor 1 0" src="https://github.com/user-attachments/assets/f7d135ee-9abf-424f-95d9-f97808f9ef30" />
<img width="844" height="507" alt="Superuser promotes user to Editor 1 1" src="https://github.com/user-attachments/assets/365ad5fc-a2fb-4c77-9845-10c35b2a4b16" />
Superuser promotes user to Manager → Email sent
<img width="643" height="354" alt="Superuser promotes user to Manager 1 0" src="https://github.com/user-attachments/assets/a60502ef-c2a2-4f55-8e49-91cca27efad3" />
<img width="997" height="524" alt="Superuser promotes user to Manager 1 1" src="https://github.com/user-attachments/assets/b6827fe1-406b-492a-a1c0-d71d36a7d767" />
Multiple roles granted simultaneously → Single email with all roles
<img width="652" height="480" alt="Multiple roles granted simultaneously 1 0" src="https://github.com/user-attachments/assets/d2e7fe23-3f76-4b87-b76f-06223a8d928b" />
<img width="1123" height="578" alt="Multiple roles granted simultaneously 1 1" src="https://github.com/user-attachments/assets/925dfc96-3855-49e5-a76a-c06120771af7" />
Role downgrade (True → False) → No email sent
<img width="756" height="477" alt="Role downgrade (True → False) 1 0" src="https://github.com/user-attachments/assets/42192ef1-261d-45a1-965a-e95c67d6bd07" />
<img width="836" height="481" alt="Role downgrade (True → False) 1 1" src="https://github.com/user-attachments/assets/3f235c6f-32cf-4e45-b5f2-3144242adbfc" />
<img width="552" height="173" alt="Role downgrade (True → False) 1 2" src="https://github.com/user-attachments/assets/b058756f-9865-4917-874d-3cf227ae07e6" />
Non-superuser makes changes → No email sent
<img width="819" height="536" alt="Non-superuser makes changes 1 0" src="https://github.com/user-attachments/assets/a20e1701-c0ed-4ba7-afbc-7b3ae386f804" />
<img width="185" height="216" alt="Non-superuser makes changes 1 1" src="https://github.com/user-attachments/assets/851724fb-8c14-40e8-b3a2-7d12ad2c1719" />
User with no email address → Graceful failure
<img width="733" height="646" alt="User with no email address 1 0" src="https://github.com/user-attachments/assets/5cd0c7b7-2615-488b-a816-a1d03bcf0787" />
<img width="478" height="302" alt="User with no email address 1 1" src="https://github.com/user-attachments/assets/7ddd5890-bcc9-4bbb-b077-926e285362e8" />
<img width="642" height="194" alt="User with no email address 1 2" src="https://github.com/user-attachments/assets/4f073f5e-4ee4-4b3f-8bf6-50a81903d5ad" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users receive email notifications when their account gains new roles via the admin interface.
  * Notifications summarize only newly granted roles, include human‑readable capability descriptions and relevant portal links.
  * Notifications are sent only for actual role elevations; unrecognized role keys are ignored and logged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->