### PR TITLE
Fix: restrict anonymous actions to only allow watching media

### DIFF
--- a/cms/settings.py
+++ b/cms/settings.py
@@ -358,7 +358,7 @@ FFMPEG_COMMAND = "ffmpeg"  # this is the path
 FFPROBE_COMMAND = "ffprobe"  # this is the path
 MP4HLS = "mp4hls"
 
-ALLOW_ANONYMOUS_ACTIONS = ["report", "like", "dislike", "watch"]  # need be a list
+ALLOW_ANONYMOUS_ACTIONS = ["watch"]  # need be a list - only watching allowed for anonymous users
 MASK_IPS_FOR_ACTIONS = True
 # how many seconds a process in running state without reporting progress is
 # considered as stale...unfortunately v9 seems to not include time

--- a/frontend/src/static/js/components/-NEW-/MediaDislikeIcon.js
+++ b/frontend/src/static/js/components/-NEW-/MediaDislikeIcon.js
@@ -1,6 +1,9 @@
 import React, { useState, useRef, useEffect } from 'react';
 
 import TextsContext from '../../contexts/TextsContext';
+import LinksContext from '../../contexts/LinksContext';
+import UserContext from '../../contexts/UserContext';
+import SiteContext from '../../contexts/SiteContext';
 
 import * as PageActions from '../../pages/_PageActions.js';
 
@@ -41,6 +44,15 @@ export function MediaDislikeIcon(props){
 	function toggleDislike(ev){
 		ev.preventDefault();
 		ev.stopPropagation();
+
+		// Redirect anonymous users to sign-in page
+		if (UserContext._currentValue.is.anonymous) {
+			const currentPath = window.location.href.replace(SiteContext._currentValue.url, '').replace(/^\//g, '');
+			const loginUrl = LinksContext._currentValue.signin + '?next=/' + currentPath;
+			window.location.href = loginUrl;
+			return;
+		}
+
 		MediaPageActions[ dislikedMedia ? 'undislikeMedia' : 'dislikeMedia' ]();
 	}
 

--- a/frontend/src/static/js/components/-NEW-/MediaLikeIcon.js
+++ b/frontend/src/static/js/components/-NEW-/MediaLikeIcon.js
@@ -1,6 +1,9 @@
 import React, { useState, useRef, useEffect } from 'react';
 
 import TextsContext from '../../contexts/TextsContext';
+import LinksContext from '../../contexts/LinksContext';
+import UserContext from '../../contexts/UserContext';
+import SiteContext from '../../contexts/SiteContext';
 
 import * as PageActions from '../../pages/_PageActions.js';
 
@@ -41,6 +44,15 @@ export function MediaLikeIcon(props){
 	function toggleLike(ev){
 		ev.preventDefault();
 		ev.stopPropagation();
+
+		// Redirect anonymous users to sign-in page
+		if (UserContext._currentValue.is.anonymous) {
+			const currentPath = window.location.href.replace(SiteContext._currentValue.url, '').replace(/^\//g, '');
+			const loginUrl = LinksContext._currentValue.signin + '?next=/' + currentPath;
+			window.location.href = loginUrl;
+			return;
+		}
+
 		MediaPageActions[ likedMedia ? 'unlikeMedia' : 'likeMedia' ]();
 	}
 

--- a/frontend/src/static/js/components/-NEW-/MediaMoreOptionsIcon.js
+++ b/frontend/src/static/js/components/-NEW-/MediaMoreOptionsIcon.js
@@ -154,15 +154,26 @@ function optionsItems(mediaData, allowDownload, downloadLink, mediaReported){
 				},
 			});
 		}
+		else if( user.is.anonymous ){
+			// Anonymous users: redirect to sign-in page
+			const currentPath = window.location.href.replace(site.url, '').replace(/^\//g, '');
+			const loginUrl = LinksContext._currentValue.signin + '?next=/' + currentPath;
+			items.push({
+				itemType: "link",
+				link: loginUrl,
+				text: "Report",
+				icon: "flag",
+			});
+		}
 		else{
+			// Authenticated users: open report form
 			items.push({
 				itemType: "open-subpage",
 				text: "Report",
 				icon: "flag",
 				buttonAttr: {
 					className: 'change-page' + ( mediaReportedTimes ? ' loggedin-media-reported' : '' ),
-					// 'data-page-id': ! UserContext._currentValue.is.anonymous ? 'loggedInReportMedia' : 'reportMediaSignIn',
-					'data-page-id': 'loggedInReportMedia',	// @note: Disabled 'is logged in' condition and enabled report form even for not registered users. It could be set by an option managed by admin.
+					'data-page-id': 'loggedInReportMedia',
 				},
 			});
 		}


### PR DESCRIPTION
## Description
Adjust allowed actions for anonymous users.

## Related Issue
https://github.com/EngageMedia-video/cinemata-mediacms-handover/issues/25

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Authentication & Permissions**
  * Anonymous users are now restricted to watching content only.
  * Like, dislike, and report features require user sign-in.
  * Anonymous users attempting these actions are automatically redirected to sign-in while preserving their original path.
  * Authenticated users continue accessing all features unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->