### PR TITLE
fix: Normalize absolute paths in SecureMediaView and fix_media_paths command

### DIFF
--- a/files/management/commands/fix_media_paths.py
+++ b/files/management/commands/fix_media_paths.py
@@ -152,7 +152,7 @@ class Command(BaseCommand):
                 self.stdout.write(self.style.SUCCESS('  All fields clean — no absolute paths remain.'))
 
         # Summary
-        self.stdout.write(self.style.SUCCESS(f'\n=== Summary ==='))
+        self.stdout.write(self.style.SUCCESS('\n=== Summary ==='))
         action = 'would be fixed' if dry_run else 'fixed'
         self.stdout.write(f'Total rows {action}: {total_fixed}')
 

--- a/files/management/commands/fix_media_paths.py
+++ b/files/management/commands/fix_media_paths.py
@@ -18,7 +18,7 @@ import os
 from django.conf import settings
 from django.db.models import F, Value
 from django.db.models.functions import Replace
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 
 from files.models import Encoding, Media, Subtitle
 
@@ -73,7 +73,7 @@ class Command(BaseCommand):
         """Return MEDIA_ROOT as a string with a trailing slash."""
         media_root = getattr(settings, 'MEDIA_ROOT', '')
         if not media_root:
-            return '/home/cinemata/cinematacms/media_files/'
+            raise CommandError('MEDIA_ROOT is not configured. Set MEDIA_ROOT in your Django settings.')
         media_root = os.fspath(media_root) if hasattr(media_root, '__fspath__') else str(media_root)
         if not media_root.endswith('/'):
             media_root += '/'

--- a/files/management/commands/fix_media_paths.py
+++ b/files/management/commands/fix_media_paths.py
@@ -1,236 +1,160 @@
 """
-Django management command to fix absolute file paths in Media and Encoding objects.
+Django management command to fix absolute file paths in the database.
 
-This command converts absolute filesystem paths to relative paths for:
-- Media.preview_file_path
-- Encoding.chunk_file_path
+Converts absolute filesystem paths (e.g., /home/cinemata/cinematacms/media_files/original/...)
+to relative paths (e.g., original/...) across all file-path fields in Media, Encoding,
+and Subtitle models.
 
 Usage:
-    python manage.py fix_media_paths
-    python manage.py fix_media_paths --dry-run
-    python manage.py fix_media_paths --batch-size=500
-    python manage.py fix_media_paths --media-only
-    python manage.py fix_media_paths --encoding-only
+    python manage.py fix_media_paths --dry-run          # Preview changes
+    python manage.py fix_media_paths                    # Apply fixes
+    python manage.py fix_media_paths --media-only       # Only fix Media fields
+    python manage.py fix_media_paths --encoding-only    # Only fix Encoding fields
+    python manage.py fix_media_paths --subtitle-only    # Only fix Subtitle fields
 """
 
-import logging
 import os
-from django.core.management.base import BaseCommand
+
 from django.conf import settings
-from files.models import Media, Encoding
+from django.db.models import F, Value
+from django.db.models.functions import Replace
+from django.core.management.base import BaseCommand
+
+from files.models import Encoding, Media, Subtitle
 
 
-logger = logging.getLogger(__name__)
+# Each entry: (Model, field_name)
+MEDIA_FIELDS = [
+    (Media, 'thumbnail'),
+    (Media, 'poster'),
+    (Media, 'uploaded_thumbnail'),
+    (Media, 'uploaded_poster'),
+    (Media, 'sprites'),
+    (Media, 'media_file'),
+    (Media, 'preview_file_path'),
+]
+
+ENCODING_FIELDS = [
+    (Encoding, 'media_file'),
+    (Encoding, 'chunk_file_path'),
+]
+
+SUBTITLE_FIELDS = [
+    (Subtitle, 'subtitle_file'),
+]
 
 
 class Command(BaseCommand):
-    help = 'Fix absolute file paths in Media and Encoding preview/chunk paths'
+    help = 'Fix absolute file paths stored in Media, Encoding, and Subtitle models'
 
     def add_arguments(self, parser):
         parser.add_argument(
             '--dry-run',
             action='store_true',
-            help='Run without actually updating the database',
-        )
-        parser.add_argument(
-            '--batch-size',
-            type=int,
-            default=1000,
-            help='Number of records to process in each batch (default: 1000)',
+            help='Show what would be changed without modifying the database',
         )
         parser.add_argument(
             '--media-only',
             action='store_true',
-            help='Only process Media objects',
+            help='Only process Media model fields',
         )
         parser.add_argument(
             '--encoding-only',
             action='store_true',
-            help='Only process Encoding objects',
+            help='Only process Encoding model fields',
         )
+        parser.add_argument(
+            '--subtitle-only',
+            action='store_true',
+            help='Only process Subtitle model fields',
+        )
+
+    def _get_media_root(self):
+        """Return MEDIA_ROOT as a string with a trailing slash."""
+        media_root = getattr(settings, 'MEDIA_ROOT', '')
+        if not media_root:
+            return '/home/cinemata/cinematacms/media_files/'
+        media_root = os.fspath(media_root) if hasattr(media_root, '__fspath__') else str(media_root)
+        if not media_root.endswith('/'):
+            media_root += '/'
+        return media_root
+
+    def _fix_field(self, model, field_name, media_root, dry_run):
+        """Fix absolute paths in a single model field. Returns the number of rows affected."""
+        affected = model.objects.filter(**{f'{field_name}__startswith': media_root}).count()
+
+        if affected == 0:
+            self.stdout.write(f'  {model.__name__}.{field_name}: 0 rows (already clean)')
+            return 0
+
+        if dry_run:
+            self.stdout.write(self.style.WARNING(
+                f'  {model.__name__}.{field_name}: {affected} rows would be fixed'
+            ))
+            return affected
+
+        updated = model.objects.filter(
+            **{f'{field_name}__startswith': media_root}
+        ).update(
+            **{field_name: Replace(F(field_name), Value(media_root), Value(''))}
+        )
+        self.stdout.write(self.style.SUCCESS(
+            f'  {model.__name__}.{field_name}: {updated} rows fixed'
+        ))
+        return updated
+
+    def _verify_field(self, model, field_name, media_root):
+        """Check that no absolute paths remain in a field."""
+        remaining = model.objects.filter(**{f'{field_name}__startswith': media_root}).count()
+        if remaining > 0:
+            self.stdout.write(self.style.ERROR(
+                f'  {model.__name__}.{field_name}: {remaining} absolute paths still remain!'
+            ))
+        return remaining
 
     def handle(self, **options):
         dry_run = options['dry_run']
-        batch_size = options['batch_size']
         media_only = options['media_only']
         encoding_only = options['encoding_only']
+        subtitle_only = options['subtitle_only']
+
+        # If no filter specified, process everything
+        process_all = not (media_only or encoding_only or subtitle_only)
+
+        media_root = self._get_media_root()
 
         if dry_run:
-            self.stdout.write(self.style.WARNING('\n=== DRY RUN MODE - No changes will be made ===\n'))
+            self.stdout.write(self.style.WARNING('=== DRY RUN MODE ===\n'))
+        self.stdout.write(f'MEDIA_ROOT prefix to strip: {media_root}\n')
 
-        # Get common root paths for path normalization
-        common_roots = self._get_common_roots()
-        self.stdout.write(f'Using root paths: {common_roots}\n')
+        fields_to_process = []
+        if process_all or media_only:
+            fields_to_process.extend(MEDIA_FIELDS)
+        if process_all or encoding_only:
+            fields_to_process.extend(ENCODING_FIELDS)
+        if process_all or subtitle_only:
+            fields_to_process.extend(SUBTITLE_FIELDS)
 
-        # Process Media objects (unless --encoding-only)
-        media_fixed = 0
-        media_errors = 0
-        if not encoding_only:
-            self.stdout.write(self.style.SUCCESS('\n=== Processing Media.preview_file_path ==='))
-            media_fixed, media_errors = self.process_media(batch_size, dry_run, common_roots)
+        # Fix paths
+        total_fixed = 0
+        self.stdout.write(self.style.SUCCESS('=== Fixing absolute paths ==='))
+        for model, field_name in fields_to_process:
+            total_fixed += self._fix_field(model, field_name, media_root, dry_run)
 
-        # Process Encoding objects (unless --media-only)
-        encoding_fixed = 0
-        encoding_errors = 0
-        if not media_only:
-            self.stdout.write(self.style.SUCCESS('\n=== Processing Encoding.chunk_file_path ==='))
-            encoding_fixed, encoding_errors = self.process_encoding(batch_size, dry_run, common_roots)
+        # Verification (skip in dry-run since nothing changed)
+        if not dry_run:
+            self.stdout.write(self.style.SUCCESS('\n=== Verification ==='))
+            total_remaining = 0
+            for model, field_name in fields_to_process:
+                total_remaining += self._verify_field(model, field_name, media_root)
+
+            if total_remaining == 0:
+                self.stdout.write(self.style.SUCCESS('  All fields clean — no absolute paths remain.'))
 
         # Summary
-        self.stdout.write(self.style.SUCCESS('\n=== Summary ==='))
-        self.stdout.write(f'Media paths fixed: {media_fixed} (errors: {media_errors})')
-        self.stdout.write(f'Encoding paths fixed: {encoding_fixed} (errors: {encoding_errors})')
-        self.stdout.write(f'Total fixed: {media_fixed + encoding_fixed}')
-        self.stdout.write(f'Total errors: {media_errors + encoding_errors}')
+        self.stdout.write(self.style.SUCCESS(f'\n=== Summary ==='))
+        action = 'would be fixed' if dry_run else 'fixed'
+        self.stdout.write(f'Total rows {action}: {total_fixed}')
 
         if dry_run:
-            self.stdout.write(self.style.WARNING('\nDRY RUN - No actual changes were made'))
-        else:
-            self.stdout.write(self.style.SUCCESS('\n✓ Path fixing completed!'))
-
-    def _get_common_roots(self):
-        """Get list of common root paths to strip from absolute paths."""
-        media_root = getattr(settings, 'MEDIA_ROOT', '')
-        if not media_root:
-            # Fallback pattern for fixing paths from production deployments
-            return ['/home/cinemata/cinematacms/media_files/']
-        else:
-            # Convert pathlib.Path to string if needed
-            media_root = os.fspath(media_root) if hasattr(media_root, '__fspath__') else str(media_root)
-            # Ensure trailing slash for consistent prefix removal
-            media_root = media_root if media_root.endswith('/') else media_root + '/'
-            return [media_root]
-
-    def _normalize_path(self, old_path, common_roots):
-        """
-        Normalize an absolute path to a relative path.
-
-        Args:
-            old_path: The absolute path to normalize
-            common_roots: List of root paths to strip
-
-        Returns:
-            Normalized relative path
-        """
-        new_path = old_path
-
-        # Remove any of the common root paths
-        for root in common_roots:
-            if old_path.startswith(root):
-                new_path = old_path.replace(root, '', 1)
-                break
-
-        # Also handle paths that start with just /
-        if new_path.startswith('/') and '/' in new_path[1:]:
-            # Find where the actual media path starts (e.g., after encoded/, original/, etc.)
-            for prefix in ['encoded/', 'original/', 'hls/', 'videos/']:
-                if prefix in new_path:
-                    idx = new_path.find(prefix)
-                    new_path = new_path[idx:]
-                    break
-
-        return new_path
-
-    def process_media(self, batch_size, dry_run, common_roots):
-        """Process Media objects and fix preview_file_path."""
-        # Count total records to process
-        queryset = Media.objects.filter(
-            preview_file_path__isnull=False
-        ).exclude(preview_file_path='')
-
-        total = queryset.count()
-        self.stdout.write(f'Found {total} Media objects with preview_file_path set')
-
-        if total == 0:
-            self.stdout.write(self.style.SUCCESS('✓ No Media objects to process'))
-            return 0, 0
-
-        fixed_count = 0
-        error_count = 0
-        batch_count = 0
-
-        # Process in batches
-        for i in range(0, total, batch_size):
-            batch_count += 1
-            media_batch = list(queryset[i:i + batch_size])
-
-            for media in media_batch:
-                old_path = media.preview_file_path
-                new_path = self._normalize_path(old_path, common_roots)
-
-                if new_path != old_path:
-                    if dry_run:
-                        self.stdout.write(
-                            self.style.WARNING(f'  Would fix Media {media.pk}: {old_path} → {new_path}')
-                        )
-                        fixed_count += 1
-                    else:
-                        try:
-                            media.preview_file_path = new_path
-                            media.save(update_fields=['preview_file_path'])
-                            fixed_count += 1
-                        except Exception as e:
-                            error_count += 1
-                            self.stdout.write(
-                                self.style.ERROR(f'  Error updating Media {media.pk}: {e}')
-                            )
-
-            # Progress update
-            self.stdout.write(
-                f'  Batch {batch_count}: Processed {min(i + batch_size, total)}/{total} records '
-                f'(Fixed: {fixed_count}, Errors: {error_count})'
-            )
-
-        return fixed_count, error_count
-
-    def process_encoding(self, batch_size, dry_run, common_roots):
-        """Process Encoding objects and fix chunk_file_path."""
-        # Count total records to process
-        queryset = Encoding.objects.filter(
-            chunk_file_path__isnull=False
-        ).exclude(chunk_file_path='')
-
-        total = queryset.count()
-        self.stdout.write(f'Found {total} Encoding objects with chunk_file_path set')
-
-        if total == 0:
-            self.stdout.write(self.style.SUCCESS('✓ No Encoding objects to process'))
-            return 0, 0
-
-        fixed_count = 0
-        error_count = 0
-        batch_count = 0
-
-        # Process in batches
-        for i in range(0, total, batch_size):
-            batch_count += 1
-            encoding_batch = list(queryset[i:i + batch_size])
-
-            for encoding in encoding_batch:
-                old_path = encoding.chunk_file_path
-                new_path = self._normalize_path(old_path, common_roots)
-
-                if new_path != old_path:
-                    if dry_run:
-                        self.stdout.write(
-                            self.style.WARNING(f'  Would fix Encoding {encoding.pk}: {old_path} → {new_path}')
-                        )
-                        fixed_count += 1
-                    else:
-                        try:
-                            encoding.chunk_file_path = new_path
-                            encoding.save(update_fields=['chunk_file_path'])
-                            fixed_count += 1
-                        except Exception as e:
-                            error_count += 1
-                            self.stdout.write(
-                                self.style.ERROR(f'  Error updating Encoding {encoding.pk}: {e}')
-                            )
-
-            # Progress update
-            self.stdout.write(
-                f'  Batch {batch_count}: Processed {min(i + batch_size, total)}/{total} records '
-                f'(Fixed: {fixed_count}, Errors: {error_count})'
-            )
-
-        return fixed_count, error_count
+            self.stdout.write(self.style.WARNING('\nDRY RUN — no changes were made. Re-run without --dry-run to apply.'))

--- a/files/secure_media_views.py
+++ b/files/secure_media_views.py
@@ -253,7 +253,7 @@ class SecureMediaView(View):
     INVALID_PATH_PATTERNS = re.compile(r'\.\.|\\|\x00|[\x01-\x1f\x7f]')
 
     @staticmethod
-    def _normalize_to_relative(path: str) -> str:
+    def _normalize_to_relative(path: Optional[str]) -> Optional[str]:
         """Normalize a database path to a relative path by stripping the MEDIA_ROOT prefix.
 
         The database may store absolute paths (e.g., /home/.../media_files/original/...)


### PR DESCRIPTION
## Description
Fix SecureMediaView rejecting legitimate media requests when the database stores absolute
file paths instead of relative paths. Also rewrite the `fix_media_paths` management command
to bulk-fix all affected fields as a proper data cleanup tool — replacing the standalone
`fix_absolute_paths_migration.sql` file.

## Related Issue
Fixes absolute path mismatch causing 403 errors on ~87% of thumbnails, subtitles, and encoded GIFs.

## Motivation and Context
The database stores absolute paths (e.g., `/home/cinemata/cinematacms/media_files/original/thumbnails/...`)
in FileField columns, but SecureMediaView's X-Accel-Redirect authorization logic expects relative paths
(e.g., `original/thumbnails/...`). This mismatch causes path verification to silently fail, returning
403 Forbidden for legitimate media requests.

This PR provides two complementary fixes:
1. **Runtime fix** — `SecureMediaView._normalize_to_relative()` strips the `MEDIA_ROOT` prefix
   before comparing paths, so requests work regardless of how the DB stores paths.
2. **Data fix** — `fix_media_paths` management command rewritten to bulk-update all 10 affected
   fields across Media, Encoding, and Subtitle models using efficient `Replace()` DB queries.

## How Has This Been Tested?
- Unit tests added for `_normalize_to_relative()` covering:
  - Stripping MEDIA_ROOT prefix from absolute paths
  - Preserving already-relative paths
  - Handling MEDIA_ROOT with/without trailing slash
  - Empty/None path edge cases
  - Different absolute prefixes that should not be stripped
- Integration test for `_verify_media_owns_thumbnail_path` with absolute DB paths vs relative request paths

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Command-line tool now supports subtitle paths and a per-field processing mode with clearer dry-run summaries.

* **Bug Fixes**
  * Broader and more consistent normalization of media paths (handles relative and absolute variants).
  * Improved ownership verification and thumbnail/subtitle lookups for legacy and normalized paths.
  * Ensures served file paths are compatible with X-Accel-Redirect.

* **Tests**
  * Added tests covering path normalization and ownership verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->