### PR TITLE
feat: add Prometheus queue wait time monitoring for encoding tasks

### DIFF
--- a/cms/settings.py
+++ b/cms/settings.py
@@ -432,6 +432,7 @@ MINIMUM_RESOLUTIONS_TO_ENCODE = [240, 360]
 MAX_ENCODING_QUEUE_DEPTH = 50  # max pending+running encodings globally
 MAX_USER_CONCURRENT_ENCODES = 5  # max pending+running encodings per user
 ENCODING_DRAIN_LOCK_TIMEOUT = 120  # seconds before drain lock auto-expires
+MAX_QUEUE_WAIT_SECONDS = 60  # warn when a task waited longer than this in queue
 
 # NOTIFICATIONS
 USERS_NOTIFICATIONS = {

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -1,8 +1,16 @@
 from django.conf import settings
 from django.contrib import admin
+from django.http import HttpResponse
 from django.urls import include, path
+from prometheus_client import generate_latest
+
+
+def metrics_view(request):
+    return HttpResponse(generate_latest(), content_type="text/plain; version=0.0.4; charset=utf-8")
+
 
 urlpatterns = [
+    path("metrics", metrics_view),
     path(settings.DJANGO_ADMIN_URL, admin.site.urls),
     path("", include("files.urls")),
     path("", include("users.urls")),

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -1,8 +1,11 @@
+import os
+
 from django.conf import settings
 from django.contrib import admin
 from django.http import HttpResponse
 from django.urls import include, path
-from prometheus_client import generate_latest
+from prometheus_client import CollectorRegistry, generate_latest
+from prometheus_client import multiprocess as prom_multiprocess
 
 
 def metrics_view(request):
@@ -12,7 +15,17 @@ def metrics_view(request):
         from django.http import HttpResponseForbidden
 
         return HttpResponseForbidden()
-    return HttpResponse(generate_latest(), content_type="text/plain; version=0.0.4; charset=utf-8")
+
+    # Use multiprocess registry when PROMETHEUS_MULTIPROC_DIR is set (production),
+    # fall back to default in-process registry (dev with CELERY_TASK_ALWAYS_EAGER)
+    if os.environ.get("PROMETHEUS_MULTIPROC_DIR"):
+        registry = CollectorRegistry()
+        prom_multiprocess.MultiProcessCollector(registry)
+        data = generate_latest(registry)
+    else:
+        data = generate_latest()
+
+    return HttpResponse(data, content_type="text/plain; version=0.0.4; charset=utf-8")
 
 
 urlpatterns = [

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -6,6 +6,12 @@ from prometheus_client import generate_latest
 
 
 def metrics_view(request):
+    # Allow localhost (Prometheus scraper) or authenticated staff
+    remote_ip = request.META.get("REMOTE_ADDR", "")
+    if remote_ip not in ("127.0.0.1", "::1") and not (hasattr(request, "user") and request.user.is_staff):
+        from django.http import HttpResponseForbidden
+
+        return HttpResponseForbidden()
     return HttpResponse(generate_latest(), content_type="text/plain; version=0.0.4; charset=utf-8")
 
 

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -9,9 +9,16 @@ from prometheus_client import multiprocess as prom_multiprocess
 
 
 def metrics_view(request):
-    # Allow localhost (Prometheus scraper) or authenticated staff
-    remote_ip = request.META.get("REMOTE_ADDR", "")
-    if remote_ip not in ("127.0.0.1", "::1") and not (hasattr(request, "user") and request.user.is_staff):
+    # Primary access control: nginx should restrict /metrics to localhost.
+    # This Django check is defense-in-depth using the real client IP
+    # (X-Forwarded-For set by nginx) rather than REMOTE_ADDR which is
+    # always 127.0.0.1 behind a reverse proxy.
+    client_ip = request.META.get("HTTP_X_FORWARDED_FOR", "").split(",")[0].strip()
+    if not client_ip:
+        client_ip = request.META.get("REMOTE_ADDR", "")
+    is_localhost = client_ip in ("127.0.0.1", "::1")
+    is_staff = hasattr(request, "user") and request.user.is_staff
+    if not is_localhost and not is_staff:
         from django.http import HttpResponseForbidden
 
         return HttpResponseForbidden()

--- a/deploy/celery_long.service
+++ b/deploy/celery_long.service
@@ -18,6 +18,7 @@ Environment=CELERYD_LOG_FILE="/home/cinemata/cinematacms/logs/%N.log"
 Environment=CELERYD_LOG_LEVEL="INFO"
 Environment=APP_DIR="/home/cinemata/cinematacms"
 Environment=PYTHONPATH="/home/cinemata/cinematacms:$PYTHONPATH"
+Environment=PROMETHEUS_MULTIPROC_DIR="/tmp/prometheus_multiproc"
 WorkingDirectory=/home/cinemata/cinematacms
 
 ExecStart=/bin/sh -c '${CELERY_BIN} -A ${CELERY_APP} worker -n long@%H --pidfile=${CELERYD_PID_FILE} --logfile=${CELERYD_LOG_FILE} --loglevel=${CELERYD_LOG_LEVEL} ${CELERYD_OPTS} -Q ${CELERY_QUEUE}'

--- a/deploy/celery_short.service
+++ b/deploy/celery_short.service
@@ -27,6 +27,7 @@ Environment=CELERYD_LOG_FILE="/home/cinemata/cinematacms/logs/%N.log"
 Environment=CELERYD_LOG_LEVEL="INFO"
 Environment=APP_DIR="/home/cinemata/cinematacms"
 Environment=PYTHONPATH="/home/cinemata/cinematacms"
+Environment=PROMETHEUS_MULTIPROC_DIR="/tmp/prometheus_multiproc"
 WorkingDirectory=/home/cinemata/cinematacms
 
 ExecStart=/bin/sh -c '${CELERY_BIN} -A ${CELERY_APP} worker -n short@%H --pidfile=${CELERYD_PID_FILE} --logfile=${CELERYD_LOG_FILE} --loglevel=${CELERYD_LOG_LEVEL} ${CELERYD_OPTS} -Q ${CELERY_QUEUE}'

--- a/deploy/celery_whisper.service
+++ b/deploy/celery_whisper.service
@@ -18,6 +18,7 @@ Environment=CELERYD_LOG_FILE="/home/cinemata/cinematacms/logs/%N.log"
 Environment=CELERYD_LOG_LEVEL="INFO"
 Environment=APP_DIR="/home/cinemata/cinematacms"
 Environment=PYTHONPATH="/home/cinemata/cinematacms"
+Environment=PROMETHEUS_MULTIPROC_DIR="/tmp/prometheus_multiproc"
 WorkingDirectory=/home/cinemata/cinematacms
 
 ExecStart=/bin/sh -c '${CELERY_BIN} -A ${CELERY_APP} worker -n whisper@%H --pidfile=${CELERYD_PID_FILE} --logfile=${CELERYD_LOG_FILE} --loglevel=${CELERYD_LOG_LEVEL} ${CELERYD_OPTS} -Q ${CELERY_QUEUE}'

--- a/deploy/grafana-encoding-queue-wait.json
+++ b/deploy/grafana-encoding-queue-wait.json
@@ -1,0 +1,76 @@
+{
+  "dashboard": {
+    "title": "Cinemata - Encoding Queue Wait Time",
+    "uid": "encoding-queue-wait",
+    "panels": [
+      {
+        "title": "Encoding Queue Wait Time (p50 / p95 / p99)",
+        "type": "timeseries",
+        "gridPos": { "h": 10, "w": 24, "x": 0, "y": 0 },
+        "targets": [
+          {
+            "expr": "histogram_quantile(0.50, rate(cinemata_encoding_queue_wait_seconds_bucket[5m]))",
+            "legendFormat": "p50"
+          },
+          {
+            "expr": "histogram_quantile(0.95, rate(cinemata_encoding_queue_wait_seconds_bucket[5m]))",
+            "legendFormat": "p95"
+          },
+          {
+            "expr": "histogram_quantile(0.99, rate(cinemata_encoding_queue_wait_seconds_bucket[5m]))",
+            "legendFormat": "p99"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "s",
+            "thresholds": {
+              "steps": [
+                { "color": "green", "value": null },
+                { "color": "yellow", "value": 30 },
+                { "color": "red", "value": 60 }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "title": "Tasks Processed (rate)",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 0, "y": 10 },
+        "targets": [
+          {
+            "expr": "rate(cinemata_encoding_queue_wait_seconds_count[5m])",
+            "legendFormat": "tasks/sec"
+          }
+        ]
+      },
+      {
+        "title": "Average Queue Wait Time",
+        "type": "stat",
+        "gridPos": { "h": 8, "w": 12, "x": 12, "y": 10 },
+        "targets": [
+          {
+            "expr": "rate(cinemata_encoding_queue_wait_seconds_sum[5m]) / rate(cinemata_encoding_queue_wait_seconds_count[5m])",
+            "legendFormat": "avg wait"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "s",
+            "thresholds": {
+              "steps": [
+                { "color": "green", "value": null },
+                { "color": "yellow", "value": 30 },
+                { "color": "red", "value": 60 }
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "time": { "from": "now-6h", "to": "now" },
+    "refresh": "30s"
+  },
+  "overwrite": true
+}

--- a/deploy/grafana-encoding-queue-wait.json
+++ b/deploy/grafana-encoding-queue-wait.json
@@ -9,15 +9,15 @@
         "gridPos": { "h": 10, "w": 24, "x": 0, "y": 0 },
         "targets": [
           {
-            "expr": "histogram_quantile(0.50, rate(cinemata_encoding_queue_wait_seconds_bucket[5m]))",
+            "expr": "histogram_quantile(0.50, sum by (le)(rate(cinemata_encoding_queue_wait_seconds_bucket[5m])))",
             "legendFormat": "p50"
           },
           {
-            "expr": "histogram_quantile(0.95, rate(cinemata_encoding_queue_wait_seconds_bucket[5m]))",
+            "expr": "histogram_quantile(0.95, sum by (le)(rate(cinemata_encoding_queue_wait_seconds_bucket[5m])))",
             "legendFormat": "p95"
           },
           {
-            "expr": "histogram_quantile(0.99, rate(cinemata_encoding_queue_wait_seconds_bucket[5m]))",
+            "expr": "histogram_quantile(0.99, sum by (le)(rate(cinemata_encoding_queue_wait_seconds_bucket[5m])))",
             "legendFormat": "p99"
           }
         ],

--- a/deploy/mediacms.service
+++ b/deploy/mediacms.service
@@ -2,6 +2,8 @@
 Description=uwsgi cinemata
 
 [Service]
+Environment=PROMETHEUS_MULTIPROC_DIR="/tmp/prometheus_multiproc"
+ExecStartPre=/bin/bash -c "rm -rf /tmp/prometheus_multiproc && mkdir -p /tmp/prometheus_multiproc"
 ExecStart=/home/cinemata/bin/uwsgi --ini /home/cinemata/cinematacms/uwsgi.ini
 ExecStop=/usr/bin/killall -9 uwsgi
 RestartSec=3

--- a/deploy/mediacms.service
+++ b/deploy/mediacms.service
@@ -3,7 +3,7 @@ Description=uwsgi cinemata
 
 [Service]
 Environment=PROMETHEUS_MULTIPROC_DIR="/tmp/prometheus_multiproc"
-ExecStartPre=/bin/bash -c "mkdir -p /tmp/prometheus_multiproc"
+ExecStartPre=/bin/bash -c "mkdir -p /tmp/prometheus_multiproc && chown www-data:www-data /tmp/prometheus_multiproc"
 ExecStart=/home/cinemata/bin/uwsgi --ini /home/cinemata/cinematacms/uwsgi.ini
 ExecStop=/usr/bin/killall -9 uwsgi
 RestartSec=3

--- a/deploy/mediacms.service
+++ b/deploy/mediacms.service
@@ -3,7 +3,7 @@ Description=uwsgi cinemata
 
 [Service]
 Environment=PROMETHEUS_MULTIPROC_DIR="/tmp/prometheus_multiproc"
-ExecStartPre=/bin/bash -c "rm -rf /tmp/prometheus_multiproc && mkdir -p /tmp/prometheus_multiproc"
+ExecStartPre=/bin/bash -c "mkdir -p /tmp/prometheus_multiproc"
 ExecStart=/home/cinemata/bin/uwsgi --ini /home/cinemata/cinematacms/uwsgi.ini
 ExecStop=/usr/bin/killall -9 uwsgi
 RestartSec=3

--- a/files/apps.py
+++ b/files/apps.py
@@ -3,3 +3,6 @@ from django.apps import AppConfig
 
 class FilesConfig(AppConfig):
     name = "files"
+
+    def ready(self):
+        import files.metrics  # noqa: F401 — register Prometheus metrics at startup

--- a/files/metrics.py
+++ b/files/metrics.py
@@ -1,0 +1,7 @@
+from prometheus_client import Histogram
+
+ENCODING_QUEUE_WAIT_SECONDS = Histogram(
+    "cinemata_encoding_queue_wait_seconds",
+    "Time an encoding task waited in the Celery queue before execution",
+    buckets=(1, 5, 10, 30, 60, 120, 300, 600, 1800, 3600),
+)

--- a/files/models.py
+++ b/files/models.py
@@ -5,6 +5,7 @@ import random
 import re
 import shutil
 import tempfile
+import time
 import uuid
 
 import m3u8
@@ -650,6 +651,7 @@ class Media(models.Model):
                 args=[self.friendly_token, profile.id, encoding.id, enc_url],
                 kwargs=task_kwargs,
                 priority=priority,
+                headers={"enqueued_at": time.time()},
             )
         except Exception:
             logger.exception(

--- a/files/tasks.py
+++ b/files/tasks.py
@@ -242,6 +242,20 @@ def encode_media(
     chunk_file_path="",
 ):
     logger.info(f"Encode Media started, friendly token {friendly_token}, profile id {profile_id}, force {force}")
+
+    # Track queue wait time for monitoring
+    enqueued_at = (self.request.headers or {}).get("enqueued_at")
+    if enqueued_at:
+        from .metrics import ENCODING_QUEUE_WAIT_SECONDS
+
+        queue_wait = time.time() - enqueued_at
+        ENCODING_QUEUE_WAIT_SECONDS.observe(queue_wait)
+        if queue_wait > settings.MAX_QUEUE_WAIT_SECONDS:
+            logger.warning(
+                "Task for %s (profile %s) waited %.1fs in queue (threshold: %ds)",
+                friendly_token, profile_id, queue_wait, settings.MAX_QUEUE_WAIT_SECONDS,
+            )
+
     # TODO: if called as function, not as task, what is the value for this?
     task_id = self.request.id or None
     try:
@@ -1564,6 +1578,7 @@ def _dispatch_deferred_encodings_inner():
                 args=[encoding.media.friendly_token, encoding.profile.id, encoding.id, enc_url],
                 kwargs=task_kwargs,
                 priority=priority,
+                headers={"enqueued_at": time.time()},
             )
         except Exception:
             logger.exception(

--- a/files/tasks.py
+++ b/files/tasks.py
@@ -249,7 +249,10 @@ def encode_media(
         from .metrics import ENCODING_QUEUE_WAIT_SECONDS
 
         queue_wait = time.time() - enqueued_at
-        ENCODING_QUEUE_WAIT_SECONDS.observe(queue_wait)
+        try:
+            ENCODING_QUEUE_WAIT_SECONDS.observe(queue_wait)
+        except Exception:
+            logger.warning("Failed to record queue wait metric (metrics dir may have been recycled)")
         if queue_wait > settings.MAX_QUEUE_WAIT_SECONDS:
             logger.warning(
                 "Task for %s (profile %s) waited %.1fs in queue (threshold: %ds)",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "django-tinymce==4.1.0",
     "django-maintenance-mode==0.22.0",
     "django-vite>=3.1.0",
+    "prometheus-client>=0.21.0",
 ]
 
 [dependency-groups]

--- a/requirements.txt
+++ b/requirements.txt
@@ -148,6 +148,8 @@ pillow==12.1.1
     # via
     #   cinemata
     #   pilkit
+prometheus-client==0.24.1
+    # via cinemata
 prompt-toolkit==3.0.52
     # via
     #   click-repl

--- a/restart_script.sh
+++ b/restart_script.sh
@@ -41,6 +41,10 @@ python manage.py migrate
 echo "Updating ownership..."
 chown -R www-data. /home/cinemata/
 
+# Reload systemd unit files in case service definitions changed
+echo "Reloading systemd daemon..."
+systemctl daemon-reload
+
 # Restart services
 echo "Restarting services..."
 systemctl restart celery_long

--- a/uv.lock
+++ b/uv.lock
@@ -340,6 +340,7 @@ dependencies = [
     { name = "markdown" },
     { name = "pep8" },
     { name = "pillow" },
+    { name = "prometheus-client" },
     { name = "psycopg2-binary" },
     { name = "python-dotenv" },
     { name = "qrcode" },
@@ -391,6 +392,7 @@ requires-dist = [
     { name = "markdown", specifier = "==3.10.2" },
     { name = "pep8", specifier = "==1.7.1" },
     { name = "pillow", specifier = "==12.1.1" },
+    { name = "prometheus-client", specifier = ">=0.21.0" },
     { name = "psycopg2-binary", specifier = "==2.9.11" },
     { name = "python-dotenv", specifier = "==1.2.1" },
     { name = "qrcode", specifier = "==8.2" },
@@ -1262,6 +1264,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/40/f1/6d86a29246dfd2e9b6237f0b5823717f60cad94d47ddc26afa916d21f525/pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61", size = 198232, upload-time = "2025-12-16T21:14:33.552Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77", size = 226437, upload-time = "2025-12-16T21:14:32.409Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.24.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/58/a794d23feb6b00fc0c72787d7e87d872a6730dd9ed7c7b3e954637d8f280/prometheus_client-0.24.1.tar.gz", hash = "sha256:7e0ced7fbbd40f7b84962d5d2ab6f17ef88a72504dcf7c0b40737b43b2a461f9", size = 85616, upload-time = "2026-01-14T15:26:26.965Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/c3/24a2f845e3917201628ecaba4f18bab4d18a337834c1df2a159ee9d22a42/prometheus_client-0.24.1-py3-none-any.whl", hash = "sha256:150db128af71a5c2482b36e588fc8a6b95e498750da4b17065947c16070f4055", size = 64057, upload-time = "2026-01-14T15:26:24.42Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Add Prometheus-based queue wait time monitoring for encoding tasks. Tracks how long each encoding task waits in the Celery queue before execution, exposes the data via a `/metrics` endpoint, and includes a Grafana dashboard for visualization.

Changes:
- New `cinemata_encoding_queue_wait_seconds` Prometheus histogram metric
- `enqueued_at` timestamp header attached to task dispatch (both `Media.encode()` and `_dispatch_deferred_encodings_inner`)
- `encode_media` reads the header on execution and records the wait duration
- Warning log emitted when wait exceeds `MAX_QUEUE_WAIT_SECONDS` (default 60s)
- `/metrics` endpoint exposing all Prometheus metrics
- Grafana dashboard JSON with p50/p95/p99 percentiles, task rate, and average wait panels
- `prometheus-client` added as dependency

## Related Issue

Fixes #455 (Task Queue Wait Time Monitoring portion)

## Motivation and Context

During the Dec 12 incident, peak was 40 tasks/minute with no visibility into queue backlog. This monitoring provides early warning when the queue is backing up, supports capacity planning, and enables triggering throttling before the queue explodes.

## How Has This Been Tested?

- Verified metrics module imports and Django settings load correctly
- Confirmed `/metrics` endpoint returns the histogram after app startup (via `apps.py` `ready()` eager import)
- Simulated queue wait observations (2s and 90s) and verified correct bucket distribution
- Confirmed threshold warning logic triggers for waits exceeding `MAX_QUEUE_WAIT_SECONDS`
- Full end-to-end server testing (upload + Celery workers + Prometheus scrape + Grafana) to be done on staging

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Dev Testing
<img width="1006" height="493" alt="image" src="https://github.com/user-attachments/assets/b199c4d3-846c-486c-a19d-571d914a51ea" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a restricted metrics endpoint for scraping system metrics.
  * Instrumented the encoding queue to record enqueue timestamps, emit wait-time histograms, and warn when waits exceed a configured threshold.
  * App startup now registers metrics; Grafana dashboard added showing queue percentiles, throughput, and averages with alert thresholds.

* **Chores**
  * Added monitoring-related dependencies and service environment configuration for Prometheus multiprocessing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->