### PR TITLE
fix: resolve mobile header overlap with notification bar

### DIFF
--- a/frontend/src/static/css/_extra.css
+++ b/frontend/src/static/css/_extra.css
@@ -3537,15 +3537,14 @@ body .items-list-ver .feat-first-item.hw-most-recent-videos .item:nth-child(2) {
 	}
 }
 
-/* When the top bar is displayed, give margin to logo navbar. */
-.top-message-body .page-header,
-.top-message-body #app-sidebar,
-.top-message-body .page-sidebar-inner {
-	margin-top: 43px;
+/* When the top bar is displayed, offset header and sidebar below it. */
+.top-message-body .page-header {
+	top: var(--top-message-height, 43px);
 }
 
-.top-message-body {
-	--top-message-height: 43px;
+.top-message-body #app-sidebar,
+.top-message-body .page-sidebar-inner {
+	margin-top: var(--top-message-height, 43px);
 }
 
 .top-message--text {

--- a/frontend/src/static/js/components/-NEW-/PageHeader/index.js
+++ b/frontend/src/static/js/components/-NEW-/PageHeader/index.js
@@ -187,12 +187,23 @@ export function PageHeader(props){
 	}, []);
 
 	useEffect(() => {
+		const updateHeight = () => {
+			const el = document.querySelector('.top-message');
+			if (el) {
+				document.body.style.setProperty('--top-message-height', el.offsetHeight + 'px');
+			}
+		};
+
 		if (topMessageHasBeenDisplayed === "false") {
 			document.body.classList.add("top-message-body");
+			requestAnimationFrame(updateHeight);
+			window.addEventListener('resize', updateHeight);
 		} else {
 			document.body.classList.remove("top-message-body");
+			document.body.style.setProperty('--top-message-height', '0px');
 		}
 
+		return () => window.removeEventListener('resize', updateHeight);
 	}, [topMessageHasBeenDisplayed, topMessageText]);
 
 	return (


### PR DESCRIPTION
## Description
Fix mobile header being cropped/overlapped by the orange notification bar (TopMessage). The header now correctly positions itself below the notification bar on all viewport sizes.

**Root cause:** `margin-top: 43px` was used to offset the fixed-position header, but `margin-top` has no effect on `position: fixed` elements. The header stayed at `top: 0` while the notification bar (z-index: 1000) rendered on top of it.

**Fix:**
- Changed `margin-top` to `top` for `.page-header` so the fixed-position offset actually works
- Replaced hardcoded `43px` with a dynamic CSS variable (`--top-message-height`) that measures the actual notification bar height via JS
- Added a resize listener so the offset adapts on orientation change or viewport resize

## Related Issue
Fixes #403

## Motivation and Context
On mobile, the notification bar text wraps to multiple lines, making it taller than the hardcoded 43px. Combined with `margin-top` having no effect on fixed elements, the header was completely hidden behind the notification bar on narrow viewports.

## How Has This Been Tested?
- Tested locally with Chrome DevTools responsive mode (iPhone 14 Pro Max, 430x932)
- Verified header renders below notification bar with no overlap
- Verified header returns to `top: 0` after dismissing notification
- Verified sidebar offset still works correctly

## Screenshots (if appropriate):
<img width="674" height="1047" alt="image" src="https://github.com/user-attachments/assets/6bc942b1-4714-4a59-801c-11fdff6a9da0" />

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):
- [x] I have not imported `flux` in a new component
- [x] If adding a new feature, I used Modern Track patterns
- [x] New features do not create new SCSS files (use Tailwind instead)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved dynamic layout adjustment for header and sidebars to adapt when content appears in the top message area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->