### PR TITLE
fix: use timezone-aware datetime and validate contact form inputs (#401)

### DIFF
--- a/users/views.py
+++ b/users/views.py
@@ -4,6 +4,7 @@ from django.core.mail import EmailMessage
 from django.db.models import Case, Q, Value, When
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
+from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
 from rest_framework import permissions, status
 from rest_framework.decorators import api_view
@@ -160,30 +161,52 @@ def contact_user(request, username):
         )
     user = User.objects.filter(username=username).first()
     if user and (user.allow_contact or is_mediacms_editor(request.user)):
-        form_subject = request.data.get("subject")
-        from_email = request.user.email
-        subject = f"[{settings.PORTAL_NAME}] - Message from {from_email}"
-        body = request.data.get("body")
-        body = """
-You have received a message through the contact form\n
-Sender name: %s
-Sender email: %s\n
-\n %s
-\n %s
-""" % (
-            request.user.name,
-            from_email,
-            form_subject,
-            body,
+        sender = request.user
+        recipient = user
+        sender_display_name = sender.name or sender.username
+        recipient_display_name = recipient.name or recipient.username
+        form_subject = request.data.get("subject", "")
+        form_body = request.data.get("body", "")
+
+        if not form_subject or not form_body:
+            return Response(
+                {"detail": "Subject and body are required"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # Email to recipient
+        recipient_email = EmailMessage(
+            subject=f"[{settings.PORTAL_NAME}] Message from {sender.username}: {form_subject}",
+            body=(
+                f"You have received a message from {sender_display_name} ({sender.email}) on {settings.PORTAL_NAME}.\n\n"
+                f"Subject: {form_subject}\n\n"
+                f"---\n{form_body}\n---\n\n"
+                f"Reply to this email to reach {sender_display_name} directly.\n\n"
+                f"--\nThis message was sent via {settings.PORTAL_NAME}\n"
+            ),
+            from_email=settings.DEFAULT_FROM_EMAIL,
+            to=[recipient.email],
+            reply_to=[sender.email],
         )
-        email = EmailMessage(
-            subject,
-            body,
-            settings.DEFAULT_FROM_EMAIL,
-            [user.email],
-            reply_to=[from_email],
+        recipient_email.send(fail_silently=True)
+
+        # Copy to sender
+        timestamp = timezone.now().strftime("%B %d, %Y at %I:%M %p")
+        sender_copy = EmailMessage(
+            subject=f"[{settings.PORTAL_NAME}] Copy of your message to {recipient_display_name}",
+            body=(
+                f"This is a copy of the message you sent on {settings.PORTAL_NAME}.\n\n"
+                f"To: {recipient_display_name}\n"
+                f"Date: {timestamp}\n"
+                f"Subject: {form_subject}\n\n"
+                f"---\n{form_body}\n---\n\n"
+                f"This is a confirmation copy for your records.\n\n"
+                f"--\nThis message was sent via {settings.PORTAL_NAME}\n"
+            ),
+            from_email=settings.DEFAULT_FROM_EMAIL,
+            to=[sender.email],
         )
-        email.send(fail_silently=True)
+        sender_copy.send(fail_silently=True)
 
     return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/users/views.py
+++ b/users/views.py
@@ -165,8 +165,8 @@ def contact_user(request, username):
         recipient = user
         sender_display_name = sender.name or sender.username
         recipient_display_name = recipient.name or recipient.username
-        form_subject = request.data.get("subject", "")
-        form_body = request.data.get("body", "")
+        form_subject = request.data.get("subject", "").strip()
+        form_body = request.data.get("body", "").strip()
 
         if not form_subject or not form_body:
             return Response(


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Send a copy of contact form messages to the sender's email, so they have a record of what they sent. Also improves the existing recipient email formatting and adds input validation.

Changes to `users/views.py`:
- **Sender CC email**: After sending the contact email to the recipient, a confirmation copy is sent to the sender with the recipient name, timestamp, subject, and full message body.
- **Input validation**: Reject empty subject/body with 400 Bad Request before sending any emails.
- **Timezone-aware datetime**: Use `django.utils.timezone.now()` instead of `datetime.now()` for the sender copy timestamp, respecting Django's `TIME_ZONE` and `USE_TZ` settings.
- **Improved recipient email**: Clearer formatting with sender display name, structured body, and "Reply to this email to reach [sender] directly" guidance.

## Related Issue
<!--- Please link to the issue here: -->
Fixes [#401](https://github.com/EngageMedia-video/cinematacms/issues/401)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The contact form is one-way — senders have no record of their message, making follow-up difficult. Sending a CC copy is standard practice for contact forms. The validation and timezone fixes address review feedback on the initial implementation.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally using Django's console email backend (`django.core.mail.backends.console.EmailBackend`). Logged in as `testuser2`, sent a contact message to another user's profile. Verified:
- Recipient email printed to console with correct subject, body, and `Reply-To` header
- Sender copy printed to console with correct subject, recipient name, timestamp, and body
- Both emails use `settings.PORTAL_NAME` and `settings.DEFAULT_FROM_EMAIL` correctly

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Modern Track Checklist (for new features):
- [x] I have not imported `flux` in a new component
- [x] If adding a new feature, I used Modern Track patterns
- [x] New features do not create new SCSS files (use Tailwind instead)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced contact form validation to ensure subject and body fields are provided
  * Improved sender confirmation process with automatic timestamp
  * Refined email delivery workflow for contact submissions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->