### PR TITLE
Fix search results showing credits instead of summary snippet

### DIFF
--- a/files/serializers.py
+++ b/files/serializers.py
@@ -205,7 +205,6 @@ class MediaSearchSerializer(serializers.ModelSerializer):
             "thumbnail_url",
             "add_date",
             "views",
-            "description",
             "friendly_token",
             "duration",
             "url",

--- a/frontend/src/static/js/components/-NEW-/ItemList.js
+++ b/frontend/src/static/js/components/-NEW-/ItemList.js
@@ -30,15 +30,18 @@ export function ItemList(props) {
 	] = useItemListSync(props);
 
 	useEffect(() => {
-		setListHandler(
-			new ItemsStaticListHandler(props.items, props.pageItems, props.maxItems, onItemsCount, onItemsLoad)
+		const handler = new ItemsStaticListHandler(
+			props.items,
+			props.pageItems,
+			props.maxItems,
+			onItemsCount,
+			onItemsLoad
 		);
+		setListHandler(handler);
 
 		return () => {
-			if (listHandler) {
-				listHandler.cancelAll();
-				setListHandler(null);
-			}
+			handler.cancelAll();
+			setListHandler(null);
 		};
 	}, []);
 	return !countedItems ? (
@@ -102,8 +105,7 @@ ItemList.defaults = {
 	playlistId: void 0,
 	/* ################################################## */
 	maxItems: 99999,
-	pageItems: 48,
-	pageItems: 24, // TODO: Is this override ok?
+	pageItems: 24,
 	horizontalItemsOrientation: false,
 	singleLinkContent: false,
 	inTagsList: false,

--- a/frontend/src/static/js/components/-NEW-/ItemList.js
+++ b/frontend/src/static/js/components/-NEW-/ItemList.js
@@ -8,95 +8,107 @@ import PageStore from '../../pages/_PageStore.js';
 import { PendingItemsList } from './PendingItemsList';
 import { ListItem, listItemProps } from './ListItem';
 
-import { ItemsStaticListHandler } from "./includes/itemLists/ItemsStaticListHandler";
+import { ItemsStaticListHandler } from './includes/itemLists/ItemsStaticListHandler';
 
 import { PositiveIntegerOrZero } from '../../functions/propTypeFilters';
 
-export function ItemList(props){
-    props = { ...ItemList.defaults, ...props };
+export function ItemList(props) {
+	props = { ...ItemList.defaults, ...props };
 
-    const [ countedItems, items, listHandler, setListHandler, classname, itemsListWrapperRef, itemsListRef, onItemsCount, onItemsLoad, renderBeforeListWrap, renderAfterListWrap ] = useItemListSync(props);
+	const [
+		countedItems,
+		items,
+		listHandler,
+		setListHandler,
+		classname,
+		itemsListWrapperRef,
+		itemsListRef,
+		onItemsCount,
+		onItemsLoad,
+		renderBeforeListWrap,
+		renderAfterListWrap,
+	] = useItemListSync(props);
 
-    useEffect(() => {
+	useEffect(() => {
+		setListHandler(
+			new ItemsStaticListHandler(props.items, props.pageItems, props.maxItems, onItemsCount, onItemsLoad)
+		);
 
-        setListHandler( new ItemsStaticListHandler(props.items, props.pageItems, props.maxItems, onItemsCount, onItemsLoad) );
+		return () => {
+			if (listHandler) {
+				listHandler.cancelAll();
+				setListHandler(null);
+			}
+		};
+	}, []);
+	return !countedItems ? (
+		<PendingItemsList className={classname.listOuter} />
+	) : !items.length ? null : (
+		<div className={classname.listOuter}>
+			{renderBeforeListWrap()}
 
-        return () => {
-            if( listHandler ){
-                listHandler.cancelAll();
-                setListHandler(null);
-            }
-        };
-    }, []);
-    return ( ! countedItems ?
-            <PendingItemsList className={ classname.listOuter } /> :
-            ( ! items.length ? null : <div className={ classname.listOuter }>
+			<div ref={itemsListWrapperRef} className="items-list-wrap">
+				<div ref={itemsListRef} className={classname.list}>
+					{items.map((itm, index) => (
+						<ListItem key={index} {...listItemProps(props, itm, index)} />
+					))}
+				</div>
+			</div>
 
-                { renderBeforeListWrap() }
-
-                <div ref={ itemsListWrapperRef } className="items-list-wrap">
-                    <div ref={ itemsListRef } className={ classname.list }>
-                    { items.map( ( itm, index ) => <ListItem key={ index } { ...listItemProps( props, itm, index ) } /> ) }
-                    </div>
-                </div>
-
-                { renderAfterListWrap() }
-
-            </div> )
-           );
+			{renderAfterListWrap()}
+		</div>
+	);
 }
 
 ItemList.propTypes = {
-    items: PropTypes.array.isRequired,
-    className: PropTypes.string,
-    hideCategories: PropTypes.bool,
-    hideDate: PropTypes.bool,
-    hideViews: PropTypes.bool,
-    hideAuthor: PropTypes.bool,
-    hidePlaylistOptions: PropTypes.bool,
-    hidePlaylistOrderNumber: PropTypes.bool,
-    hideAllMeta: PropTypes.bool,
-    preferSummary: PropTypes.bool,
-    inPlaylistView: PropTypes.bool,
-    inPlaylistPage: PropTypes.bool,
-    playlistActiveItem: PositiveIntegerOrZero,
-    playlistId: PropTypes.string,
-    /* ################################################## */
-    maxItems: PropTypes.number.isRequired,
-    pageItems: PropTypes.number.isRequired,
-    horizontalItemsOrientation: PropTypes.bool.isRequired,
-    singleLinkContent: PropTypes.bool.isRequired,
-    inTagsList: PropTypes.bool,
-    inCategoriesList: PropTypes.bool,
-    itemsCountCallback: PropTypes.func,
-    itemsLoadCallback: PropTypes.func,
-    firstItemViewer: PropTypes.bool,
-    firstItemDescr: PropTypes.bool,
-    canEdit: PropTypes.bool,
+	items: PropTypes.array.isRequired,
+	className: PropTypes.string,
+	hideCategories: PropTypes.bool,
+	hideDate: PropTypes.bool,
+	hideViews: PropTypes.bool,
+	hideAuthor: PropTypes.bool,
+	hidePlaylistOptions: PropTypes.bool,
+	hidePlaylistOrderNumber: PropTypes.bool,
+	hideAllMeta: PropTypes.bool,
+	inPlaylistView: PropTypes.bool,
+	inPlaylistPage: PropTypes.bool,
+	playlistActiveItem: PositiveIntegerOrZero,
+	playlistId: PropTypes.string,
+	/* ################################################## */
+	maxItems: PropTypes.number.isRequired,
+	pageItems: PropTypes.number.isRequired,
+	horizontalItemsOrientation: PropTypes.bool.isRequired,
+	singleLinkContent: PropTypes.bool.isRequired,
+	inTagsList: PropTypes.bool,
+	inCategoriesList: PropTypes.bool,
+	itemsCountCallback: PropTypes.func,
+	itemsLoadCallback: PropTypes.func,
+	firstItemViewer: PropTypes.bool,
+	firstItemDescr: PropTypes.bool,
+	canEdit: PropTypes.bool,
 };
 
 ItemList.defaults = {
-    hideCategories: !PageStore.get('config-media-item')?.displayCategories,
-    hideDate: false,
-    hideViews: false,
-    hideAuthor: false,
-    hidePlaylistOptions: true,
-    hidePlaylistOrderNumber: true,
-    hideAllMeta: false,
-    preferSummary: false,
-    inPlaylistView: false,
-    inPlaylistPage: false,
-    playlistActiveItem: 1,
-    playlistId: void 0,
-    /* ################################################## */
-    maxItems: 99999,
-    pageItems: 48,
-    pageItems: 24,    // TODO: Is this override ok?
-    horizontalItemsOrientation: false,
-    singleLinkContent: false,
-    inTagsList: false,
-    inCategoriesList: false,
-    firstItemViewer: false,
-    firstItemDescr: false,
-    canEdit: false,
+	hideCategories: !PageStore.get('config-media-item')?.displayCategories,
+	hideDate: false,
+	hideViews: false,
+	hideAuthor: false,
+	hidePlaylistOptions: true,
+	hidePlaylistOrderNumber: true,
+	hideAllMeta: false,
+	inPlaylistView: false,
+	inPlaylistPage: false,
+	playlistActiveItem: 1,
+	playlistId: void 0,
+	/* ################################################## */
+	maxItems: 99999,
+	pageItems: 48,
+	pageItems: 24, // TODO: Is this override ok?
+	horizontalItemsOrientation: false,
+	singleLinkContent: false,
+	inTagsList: false,
+	inCategoriesList: false,
+	firstItemViewer: false,
+	firstItemDescr: false,
+	canEdit: false,
 };

--- a/frontend/src/static/js/components/-NEW-/ListItem.js
+++ b/frontend/src/static/js/components/-NEW-/ListItem.js
@@ -222,7 +222,13 @@ export function listItemProps(props, item, index) {
 		}
 	} else {
 		if (!!props.firstItemViewer) {
-			description = 'string' === typeof props.summary ? props.summary.trim() : null;
+			description = isSearchItem
+				? 'string' === typeof item.summary
+					? item.summary.trim()
+					: null
+				: 'string' === typeof props.summary
+					? props.summary.trim()
+					: null;
 		} else {
 			description = 'string' === typeof item.description ? item.description.trim() : null;
 		}
@@ -231,8 +237,10 @@ export function listItemProps(props, item, index) {
 
 		args.description = description;
 
-		// TODO: Continue here...
-		if (props.summary) {
+		if (isSearchItem) {
+			meta_description = description;
+			args.meta_description = meta_description;
+		} else if (props.summary) {
 			meta_description = props.summary.trim();
 			meta_description =
 				null === meta_description ? meta_description : meta_description.replace(/(<([^>]+)>)/gi, '');

--- a/frontend/src/static/js/components/-NEW-/ListItem.js
+++ b/frontend/src/static/js/components/-NEW-/ListItem.js
@@ -9,123 +9,128 @@ import { PlaylistItem } from './PlaylistItem';
 import { TaxonomyItem } from './TaxonomyItem';
 import { MediaItem as ImageItem } from './MediaItem';
 import { MediaItem as PdfItem } from './MediaItem';
-import { MediaItem as AttachmentItem  } from './MediaItem';
+import { MediaItem as AttachmentItem } from './MediaItem';
 import { MediaItemAudio as AudioItem } from './MediaItemAudio';
 import { MediaItemVideo as VideoItem } from './MediaItemVideo';
 
-function extractPlaylistId(){
+function extractPlaylistId() {
+	let playlistId = null;
 
-    let playlistId = null;
+	const getParamsString = window.location.search;
 
-    const getParamsString = window.location.search;
+	if ('' !== getParamsString) {
+		let tmp = getParamsString.split('?');
 
-    if( '' !== getParamsString ){
+		if (2 === tmp.length) {
+			tmp = tmp[1].split('&');
 
-        let tmp = getParamsString.split('?');
+			let x;
 
-        if( 2 === tmp.length ){
+			let i = 0;
+			while (i < tmp.length) {
+				x = tmp[i].split('=');
 
-            tmp = tmp[1].split('&');
+				if ('pl' === x[0]) {
+					if (2 === x.length) {
+						playlistId = x[1];
+					}
 
-            let x;
+					break;
+				}
 
-            let i = 0;
-            while(i < tmp.length){
+				i += 1;
+			}
+		}
+	}
 
-                x = tmp[i].split('=');
-
-                if( 'pl' === x[0] ){
-
-                    if( 2 === x.length ){
-                        playlistId = x[1];
-                    }
-
-                    break;
-                }
-
-                i += 1;
-            }
-        }
-    }
-
-    return playlistId;
+	return playlistId;
 }
 
-function itemPageLink( props, item ){
-
-	if( props.inCategoriesList ){
-		return LinksContext._currentValue.search.category + item.title.replace( " ", "%20" );
+function itemPageLink(props, item) {
+	if (props.inCategoriesList) {
+		return LinksContext._currentValue.search.category + item.title.replace(' ', '%20');
 	}
 
-	if( props.inTagsList ){
-		return LinksContext._currentValue.search.tag + item.title.replace( " ", "%20" );
+	if (props.inTagsList) {
+		return LinksContext._currentValue.search.tag + item.title.replace(' ', '%20');
 	}
 
-	if( props.inTopicsList ){
-		return LinksContext._currentValue.search.topic + item.title.replace( " ", "%20" );
+	if (props.inTopicsList) {
+		return LinksContext._currentValue.search.topic + item.title.replace(' ', '%20');
 	}
 
-	if( props.inLanguagesList ){
-		return LinksContext._currentValue.search.language + item.title.replace( " ", "%20" );
+	if (props.inLanguagesList) {
+		return LinksContext._currentValue.search.language + item.title.replace(' ', '%20');
 	}
 
-	if( props.inCountriesList ){
-		return LinksContext._currentValue.search.country + item.title.replace( " ", "%20" );
+	if (props.inCountriesList) {
+		return LinksContext._currentValue.search.country + item.title.replace(' ', '%20');
 	}
 
 	const playlistId = extractPlaylistId();
 
-	if( props.inPlaylistView && playlistId ){
+	if (props.inPlaylistView && playlistId) {
 		return item.url + '&pl=' + playlistId;
 	}
 
-	if( void 0 !== props.playlistId && null !== props.playlistId ){
+	if (void 0 !== props.playlistId && null !== props.playlistId) {
 		return item.url + '&pl=' + props.playlistId;
 	}
 
 	return item.url;
 }
 
-export function listItemProps( props, item, index ){
-	const isArchiveItem = props.inCategoriesList || props.inTagsList || props.inTopicsList || props.inLanguagesList || props.inCountriesList;
-	const isUserItem = ! isArchiveItem && void 0 !== item.username;
-	const isPlaylistItem = ! isArchiveItem && ! isUserItem && ( "playlist" === item.media_type || ( void 0 !== item.url && -1 < item.url.indexOf('playlists') ) );	// TODO: Re-check this.
-	const isMediaItem = ! isArchiveItem && ! isUserItem && ! isPlaylistItem;
-	const isSearchItem = 'search-results' === PageStore.get('current-page');	// TODO: Re-check this.
+export function listItemProps(props, item, index) {
+	const isArchiveItem =
+		props.inCategoriesList ||
+		props.inTagsList ||
+		props.inTopicsList ||
+		props.inLanguagesList ||
+		props.inCountriesList;
+	const isUserItem = !isArchiveItem && void 0 !== item.username;
+	const isPlaylistItem =
+		!isArchiveItem &&
+		!isUserItem &&
+		('playlist' === item.media_type || (void 0 !== item.url && -1 < item.url.indexOf('playlists'))); // TODO: Re-check this.
+	const isMediaItem = !isArchiveItem && !isUserItem && !isPlaylistItem;
+	const isSearchItem = 'search-results' === PageStore.get('current-page'); // TODO: Re-check this.
 
 	const url = {
-		view: itemPageLink( props, item ),
+		view: itemPageLink(props, item),
 		edit: props.canEdit ? item.url.replace('view?m=', 'edit?m=') : null,
 	};
 
 	const taxonomies = {
-		categories: Array.isArray( item.categories_info ) && item.categories_info.length ? item.categories_info : null,
+		categories: Array.isArray(item.categories_info) && item.categories_info.length ? item.categories_info : null,
 	};
 
-	const thumbnail = item.thumbnail_url || "";
-	const previewThumbnail = item.preview_url || "";
+	const thumbnail = item.thumbnail_url || '';
+	const previewThumbnail = item.preview_url || '';
 
 	let type, taxonomyType, title, date, description, meta_description;
 
 	// For user items, use name field if available, otherwise username
 	if (void 0 !== item.username && 'string' === typeof item.username) {
-		title = (void 0 !== item.name && 'string' === typeof item.name && item.name.trim()) ? item.name : item.username;
+		title = void 0 !== item.name && 'string' === typeof item.name && item.name.trim() ? item.name : item.username;
 	} else {
 		title = void 0 !== item.title && 'string' === typeof item.title ? item.title : null;
 	}
 
-	date = void 0 !== item.date_added && 'string' === typeof item.date_added ? item.date_added : ( void 0 !== item.add_date && 'string' === typeof item.add_date ? item.add_date : null );
+	date =
+		void 0 !== item.date_added && 'string' === typeof item.date_added
+			? item.date_added
+			: void 0 !== item.add_date && 'string' === typeof item.add_date
+				? item.add_date
+				: null;
 
 	// description = props.preferSummary && 'string' === typeof props.summary ? props.summary.trim() : ( 'string' === typeof item.description ? item.description.trim() : null );
 	// description = null === description ? description : description.replace(/(<([^>]+)>)/ig,"");
 
-	if( isUserItem ){
+	if (isUserItem) {
 		type = 'user';
-	}
-	else if( isPlaylistItem ){
+	} else if (isPlaylistItem) {
 		type = 'playlist';
-	}
-	else if( isMediaItem ){
+	} else if (isMediaItem) {
 		type = item.media_type;
 	}
 
@@ -148,32 +153,27 @@ export function listItemProps( props, item, index ){
 		hideOrderNumber: props.hidePlaylistOrderNumber || false,
 	};
 
-	if( isArchiveItem ){
-
-		if( props.inCategoriesList ){
+	if (isArchiveItem) {
+		if (props.inCategoriesList) {
 			taxonomyPage.type = 'categories';
-		}
-		else if( props.inTagsList ){
+		} else if (props.inTagsList) {
 			taxonomyPage.type = 'tags';
-		}
-		else if( props.inTopicsList ){
+		} else if (props.inTopicsList) {
 			taxonomyPage.type = 'topics';
-		}
-		else if( props.inLanguagesList ){
+		} else if (props.inLanguagesList) {
 			taxonomyPage.type = 'languages';
-		}
-		else if( props.inCountriesList ){
+		} else if (props.inCountriesList) {
 			taxonomyPage.type = 'countries';
 		}
 
-		if( null !== taxonomyPage.type ){
+		if (null !== taxonomyPage.type) {
 			taxonomyPage.current = true;
 		}
 	}
 
 	const author = {
 		name: item.author_name || item.user,
-		url: item.author_profile ? item.author_profile.replace( " ", "%20" ) : null,
+		url: item.author_profile ? item.author_profile.replace(' ', '%20') : null,
 	};
 
 	const stats = {
@@ -199,61 +199,61 @@ export function listItemProps( props, item, index ){
 		playlistPlayback,
 		canEdit: null !== url.edit,
 		singleLinkContent: props.singleLinkContent || false,
-		hasMediaViewer: 0 === index && 'video' === item.media_type && !! props.firstItemViewer,
+		hasMediaViewer: 0 === index && 'video' === item.media_type && !!props.firstItemViewer,
 		hasMediaViewerDescr: false,
 		countries: item.media_country_info || [],
 		state: item.state || null,
 	};
 
-	args.hasMediaViewerDescr = args.hasMediaViewer && !! props.firstItemDescr;
+	args.hasMediaViewerDescr = args.hasMediaViewer && !!props.firstItemDescr;
 
-	if( ! args.hasMediaViewerDescr ){
-
-		description = props.preferSummary && 'string' === typeof props.summary ? props.summary.trim() : ( 'string' === typeof item.description ? item.description.trim() : null );
-		description = null === description ? description : description.replace(/(<([^>]+)>)/ig,"");
-
-		if( isSearchItem || props.inCategoriesList || 'user' === type ){
-			args.description = description;
+	if (!args.hasMediaViewerDescr) {
+		if (isSearchItem) {
+			description = 'string' === typeof item.summary ? item.summary.trim() : null;
+		} else {
+			description = 'string' === typeof item.description ? item.description.trim() : null;
 		}
-		else{
+		description = null === description ? description : description.replace(/(<([^>]+)>)/gi, '');
+
+		if (isSearchItem || props.inCategoriesList || 'user' === type) {
+			args.description = description;
+		} else {
 			args.meta_description = description;
 		}
-	}
-	else{
-
-		if( !! props.firstItemViewer ){
-			description = 'string' === typeof props.summary ? props.summary.trim() : null ;
-		}
-		else{
+	} else {
+		if (!!props.firstItemViewer) {
+			description = 'string' === typeof props.summary ? props.summary.trim() : null;
+		} else {
 			description = 'string' === typeof item.description ? item.description.trim() : null;
 		}
 
-		description = null === description ? description : description.replace(/(<([^>]+)>)/ig,"");
+		description = null === description ? description : description.replace(/(<([^>]+)>)/gi, '');
 
 		args.description = description;
 
 		// TODO: Continue here...
-		if( props.summary ){
+		if (props.summary) {
 			meta_description = props.summary.trim();
-			meta_description = null === meta_description ? meta_description : meta_description.replace(/(<([^>]+)>)/ig,"");
+			meta_description =
+				null === meta_description ? meta_description : meta_description.replace(/(<([^>]+)>)/gi, '');
 			args.meta_description = meta_description;
 		}
 	}
 
-	if( 'video' === type ){
+	if ('video' === type) {
 		args.previewThumbnail = previewThumbnail;
 	}
 
-	if( 'video' === type || 'audio' === type ){
+	if ('video' === type || 'audio' === type) {
 		args.duration = item.duration;
 	}
 
-	if( ( isArchiveItem || isPlaylistItem || isUserItem ) && ! isNaN( item.media_count ) ){
-		args.media_count = parseInt( item.media_count, 10 );
+	if ((isArchiveItem || isPlaylistItem || isUserItem) && !isNaN(item.media_count)) {
+		args.media_count = parseInt(item.media_count, 10);
 	}
 
 	// Pass user-specific fields
-	if( isUserItem ){
+	if (isUserItem) {
 		args.username = item.username;
 		args.name = item.name;
 		args.location = item.location;
@@ -264,14 +264,13 @@ export function listItemProps( props, item, index ){
 		args.is_manager = item.is_manager;
 	}
 
-	if( isMediaItem ){
-
-		hide.date = index === 0 ? true : (props.hideDate || false);
-		hide.views = index === 0 ? false : (props.hideViews || false);
+	if (isMediaItem) {
+		hide.date = index === 0 ? true : props.hideDate || false;
+		hide.views = index === 0 ? false : props.hideViews || false;
 		hide.author = props.hideAuthor || false;
 		hide.categories = props.hideCategories || false;
 
-		if( hide.categories ){
+		if (hide.categories) {
 			taxonomies.categories = null;
 		}
 	}
@@ -285,8 +284,7 @@ export function listItemProps( props, item, index ){
 	return args;
 }
 
-export function ListItem(props){
-
+export function ListItem(props) {
 	let isMediaItem = false;
 
 	const args = {
@@ -301,7 +299,7 @@ export function ListItem(props){
 		countries: props.countries,
 	};
 
-	switch( props.type ){
+	switch (props.type) {
 		case 'user':
 			// Pass user-specific props
 			args.username = props.username;
@@ -333,26 +331,25 @@ export function ListItem(props){
 			break;
 	}
 
-	if( void 0 !== props.description ){
+	if (void 0 !== props.description) {
 		args.description = props.description;
 	}
 
-	if( void 0 !== props.meta_description ){
+	if (void 0 !== props.meta_description) {
 		args.meta_description = props.meta_description;
 	}
 
-	if( ( props.taxonomyPage.current || 'playlist' === props.type ) && ! isNaN( props.media_count ) ){
+	if ((props.taxonomyPage.current || 'playlist' === props.type) && !isNaN(props.media_count)) {
 		args.media_count = props.media_count;
 	}
 
-	if( null !== props.taxonomies.categories ){
+	if (null !== props.taxonomies.categories) {
 		args.categories = props.taxonomies.categories;
 	}
 
 	args.hideAllMeta = props.hide.allMeta;
 
-	if( isMediaItem ){
-
+	if (isMediaItem) {
 		args.views = props.stats.views;
 
 		args.author_name = props.author.name;
@@ -366,45 +363,42 @@ export function ListItem(props){
 		args.state = props.state;
 	}
 
-	if( props.playlistPage.current || props.playlistPlayback.current ){
-
+	if (props.playlistPage.current || props.playlistPlayback.current) {
 		args.playlistOrder = props.order;
 
-		if( props.playlistPlayback.current ){
+		if (props.playlistPlayback.current) {
 			args.playlist_id = props.playlistPlayback.id;
 			args.playlistActiveItem = props.playlistPlayback.activeItem;
 			args.hidePlaylistOrderNumber = props.playlistPlayback.hideOrderNumber;
-		}
-		else{
+		} else {
 			args.playlist_id = props.playlistPage.id;
 			args.hidePlaylistOptions = props.playlistPage.hideOptions;
 			args.hidePlaylistOrderNumber = props.playlistPage.hideOrderNumber;
 		}
 	}
 
-	if( props.canEdit ){
+	if (props.canEdit) {
 		args.editLink = props.url.edit;
 	}
 
 	// console.log( args );
 
-	if( props.taxonomyPage.current ){
-
-		switch( props.taxonomyPage.type ){
+	if (props.taxonomyPage.current) {
+		switch (props.taxonomyPage.type) {
 			case 'categories':
-				return <TaxonomyItem {...args} type='category' />;
+				return <TaxonomyItem {...args} type="category" />;
 			case 'tags':
-				return <TaxonomyItem {...args} type='tag' />;
+				return <TaxonomyItem {...args} type="tag" />;
 			case 'topics':
-				return <TaxonomyItem {...args} type='topic' />;
+				return <TaxonomyItem {...args} type="topic" />;
 			case 'languages':
-				return <TaxonomyItem {...args} type='language' />;
+				return <TaxonomyItem {...args} type="language" />;
 			case 'countries':
-				return <TaxonomyItem {...args} type='country' />;
+				return <TaxonomyItem {...args} type="country" />;
 		}
 	}
 
-	switch( props.type ){
+	switch (props.type) {
 		case 'user':
 			return <UserItem {...args} />;
 		case 'playlist':
@@ -414,10 +408,10 @@ export function ListItem(props){
 		case 'audio':
 			return <AudioItem {...args} />;
 		case 'image':
-			return <ImageItem {...args} type='image' />;
+			return <ImageItem {...args} type="image" />;
 		case 'pdf':
-			return <PdfItem {...args} type='pdf' />;
+			return <PdfItem {...args} type="pdf" />;
 	}
 
-	return <AttachmentItem {...args} type='attachment' />;
+	return <AttachmentItem {...args} type="attachment" />;
 }

--- a/frontend/src/static/js/components/-NEW-/ListItem.js
+++ b/frontend/src/static/js/components/-NEW-/ListItem.js
@@ -123,9 +123,6 @@ export function listItemProps(props, item, index) {
 				? item.add_date
 				: null;
 
-	// description = props.preferSummary && 'string' === typeof props.summary ? props.summary.trim() : ( 'string' === typeof item.description ? item.description.trim() : null );
-	// description = null === description ? description : description.replace(/(<([^>]+)>)/ig,"");
-
 	if (isUserItem) {
 		type = 'user';
 	} else if (isPlaylistItem) {
@@ -173,7 +170,12 @@ export function listItemProps(props, item, index) {
 
 	const author = {
 		name: item.author_name || item.user,
-		url: item.author_profile ? item.author_profile.replaceAll(' ', '%20') : null,
+		url: item.author_profile
+			? item.author_profile
+					.split('/')
+					.map((s) => encodeURIComponent(s))
+					.join('/')
+			: null,
 	};
 
 	const stats = {
@@ -221,6 +223,9 @@ export function listItemProps(props, item, index) {
 			args.meta_description = description;
 		}
 	} else {
+		// Note: hasMediaViewerDescr is currently unreachable for search items
+		// (SearchPage doesn't pass firstItemViewer/firstItemDescr).
+		// The isSearchItem branches below are kept for defensive completeness.
 		if (!!props.firstItemViewer) {
 			description = isSearchItem
 				? 'string' === typeof item.summary

--- a/frontend/src/static/js/components/-NEW-/ListItem.js
+++ b/frontend/src/static/js/components/-NEW-/ListItem.js
@@ -48,23 +48,23 @@ function extractPlaylistId() {
 
 function itemPageLink(props, item) {
 	if (props.inCategoriesList) {
-		return LinksContext._currentValue.search.category + item.title.replace(' ', '%20');
+		return LinksContext._currentValue.search.category + encodeURIComponent(item.title);
 	}
 
 	if (props.inTagsList) {
-		return LinksContext._currentValue.search.tag + item.title.replace(' ', '%20');
+		return LinksContext._currentValue.search.tag + encodeURIComponent(item.title);
 	}
 
 	if (props.inTopicsList) {
-		return LinksContext._currentValue.search.topic + item.title.replace(' ', '%20');
+		return LinksContext._currentValue.search.topic + encodeURIComponent(item.title);
 	}
 
 	if (props.inLanguagesList) {
-		return LinksContext._currentValue.search.language + item.title.replace(' ', '%20');
+		return LinksContext._currentValue.search.language + encodeURIComponent(item.title);
 	}
 
 	if (props.inCountriesList) {
-		return LinksContext._currentValue.search.country + item.title.replace(' ', '%20');
+		return LinksContext._currentValue.search.country + encodeURIComponent(item.title);
 	}
 
 	const playlistId = extractPlaylistId();
@@ -173,7 +173,7 @@ export function listItemProps(props, item, index) {
 
 	const author = {
 		name: item.author_name || item.user,
-		url: item.author_profile ? item.author_profile.replace(' ', '%20') : null,
+		url: item.author_profile ? item.author_profile.replaceAll(' ', '%20') : null,
 	};
 
 	const stats = {

--- a/frontend/src/static/js/pages/SearchPage.js
+++ b/frontend/src/static/js/pages/SearchPage.js
@@ -18,9 +18,7 @@ import { SearchResultsFilters } from '../components/-NEW-/SearchResultsFilters.j
 import { FiltersToggleButton } from '../components/-NEW-/FiltersToggleButton.js';
 
 export class SearchPage extends Page {
-
 	constructor(props) {
-
 		super(props, 'search-results');
 
 		this.state = {
@@ -43,10 +41,8 @@ export class SearchPage extends Page {
 		this.updateRequestUrl = this.updateRequestUrl.bind(this);
 		this.onFilterArgsUpdate = this.onFilterArgsUpdate.bind(this);
 
-
 		this.onToggleFiltersClick = this.onToggleFiltersClick.bind(this);
 		this.onFiltersUpdate = this.onFiltersUpdate.bind(this);
-
 
 		this.didMount = false;
 
@@ -57,14 +53,13 @@ export class SearchPage extends Page {
 		this.didMount = true;
 	}
 
-    onToggleFiltersClick(){
+	onToggleFiltersClick() {
 		this.setState({
-			hiddenFilters: ! this.state.hiddenFilters,
-		});    	
-    }
+			hiddenFilters: !this.state.hiddenFilters,
+		});
+	}
 
-	onFiltersUpdate( updatedArgs ){
-
+	onFiltersUpdate(updatedArgs) {
 		const args = {
 			media_type: null,
 			upload_date: null,
@@ -73,25 +68,25 @@ export class SearchPage extends Page {
 			ordering: null,
 		};
 
-		switch( updatedArgs.media_type ){
+		switch (updatedArgs.media_type) {
 			case 'video':
 			case 'audio':
 			case 'image':
 			case 'pdf':
 				args.media_type = updatedArgs.media_type;
-			break;
+				break;
 		}
 
-		switch( updatedArgs.upload_date ){
+		switch (updatedArgs.upload_date) {
 			case 'today':
 			case 'this_week':
 			case 'this_month':
 			case 'this_year':
 				args.upload_date = updatedArgs.upload_date;
-			break;
+				break;
 		}
 
-		switch( updatedArgs.license ){
+		switch (updatedArgs.license) {
 			case '5':
 			case '6':
 			case '7':
@@ -100,81 +95,107 @@ export class SearchPage extends Page {
 			case '10':
 			case 'no_license':
 				args.license = updatedArgs.license;
-			break;
+				break;
 		}
 
-		switch( updatedArgs.sort_by ){
+		switch (updatedArgs.sort_by) {
 			case 'most_views':
 				args.sort_by = 'views';
-			break;
+				break;
 			case 'most_likes':
 				args.sort_by = 'likes';
-			break;
+				break;
 			case 'date_added_asc':
 				args.ordering = 'asc';
-			break;
+				break;
 		}
 
 		const newArgs = [];
-		
-		for(let arg in args){
 
-			if(null !== args[arg]){
-				newArgs.push( arg + '=' + args[arg] );
+		for (let arg in args) {
+			if (null !== args[arg]) {
+				newArgs.push(arg + '=' + args[arg]);
 			}
 		}
 
-		this.setState({
-			filterArgs: newArgs.length ? '&' + newArgs.join('&') : '',
-		}, function() {
-			this.updateRequestUrl();
-		});
+		this.setState(
+			{
+				filterArgs: newArgs.length ? '&' + newArgs.join('&') : '',
+			},
+			function () {
+				this.updateRequestUrl();
+			}
+		);
 	}
 
 	updateRequestUrl() {
-
-		const validQuery = this.state.searchQuery || this.state.searchCategories || this.state.searchTags || this.state.searchCountries || this.state.searchLanguages || this.state.searchTopics;
+		const validQuery =
+			this.state.searchQuery ||
+			this.state.searchCategories ||
+			this.state.searchTags ||
+			this.state.searchCountries ||
+			this.state.searchLanguages ||
+			this.state.searchTopics;
 
 		let title = null;
 
 		if (null !== this.state.resultsCount) {
-
 			if (!validQuery) {
 				title = 'No results for "' + this.state.searchQuery + '"';
 			} else {
-
 				if (this.state.searchCategories) {
-					title = null === this.state.resultsCount || 0 === this.state.resultsCount ? 'No' : this.state.resultsCount;
+					title =
+						null === this.state.resultsCount || 0 === this.state.resultsCount
+							? 'No'
+							: this.state.resultsCount;
 					title += ' media in category "' + this.state.searchCategories + '"';
 				} else if (this.state.searchTags) {
-					title = null === this.state.resultsCount || 0 === this.state.resultsCount ? 'No' : this.state.resultsCount;
+					title =
+						null === this.state.resultsCount || 0 === this.state.resultsCount
+							? 'No'
+							: this.state.resultsCount;
 					title += ' media in tag "' + this.state.searchTags + '"';
 				} else if (this.state.searchTopics) {
-					title = null === this.state.resultsCount || 0 === this.state.resultsCount ? 'No' : this.state.resultsCount;
+					title =
+						null === this.state.resultsCount || 0 === this.state.resultsCount
+							? 'No'
+							: this.state.resultsCount;
 					title += ' media in topic "' + this.state.searchTopics + '"';
 				} else if (this.state.searchCountries) {
-					title = null === this.state.resultsCount || 0 === this.state.resultsCount ? 'No' : this.state.resultsCount;
+					title =
+						null === this.state.resultsCount || 0 === this.state.resultsCount
+							? 'No'
+							: this.state.resultsCount;
 					title += ' media in country "' + this.state.searchCountries + '"';
 				} else if (this.state.searchLanguages) {
-					title = null === this.state.resultsCount || 0 === this.state.resultsCount ? 'No' : this.state.resultsCount;
+					title =
+						null === this.state.resultsCount || 0 === this.state.resultsCount
+							? 'No'
+							: this.state.resultsCount;
 					title += ' media in language "' + this.state.searchLanguages + '"';
 				} else {
-
 					if (null === this.state.resultsCount || 0 === this.state.resultsCount) {
 						title = 'No results for "' + this.state.searchQuery + '"';
 					} else {
-						title = this.state.resultsCount + ' result' + (1 < this.state.resultsCount ? 's' : '') + ' for "' + this.state.searchQuery + '"';
+						title =
+							this.state.resultsCount +
+							' result' +
+							(1 < this.state.resultsCount ? 's' : '') +
+							' for "' +
+							this.state.searchQuery +
+							'"';
 					}
 				}
 			}
 		}
 
-		const api_url_postfix = (this.state.searchQuery || "") +
-			(this.state.searchTags ? "&t=" + this.state.searchTags : "") +
-			(this.state.searchCategories ? "&c=" + this.state.searchCategories : "") +
-			(this.state.searchTopics ? "&topic=" + this.state.searchTopics : "") +
-			(this.state.searchLanguages ? "&language=" + this.state.searchLanguages : "") +
-			(this.state.searchCountries ? "&country=" + this.state.searchCountries : "");
+		const api_url_postfix =
+			(this.state.searchQuery || '') +
+			(this.state.searchTags ? '&t=' + this.state.searchTags : '') +
+			(this.state.searchCategories ? '&c=' + this.state.searchCategories : '') +
+			(this.state.searchTopics ? '&topic=' + this.state.searchTopics : '') +
+			(this.state.searchLanguages ? '&language=' + this.state.searchLanguages : '') +
+			(this.state.searchCountries ? '&country=' + this.state.searchCountries : '');
 
 		const url = ApiUrlContext._currentValue.search.query + api_url_postfix + this.state.filterArgs;
 
@@ -192,54 +213,63 @@ export class SearchPage extends Page {
 	}
 
 	onFilterArgsUpdate(updatedArgs) {
-
 		const newArgs = [];
 
 		for (let arg in updatedArgs) {
-
 			if (null !== updatedArgs[arg]) {
 				newArgs.push(arg + '=' + updatedArgs[arg]);
 			}
 		}
 
-		this.setState({
-			filterArgs: newArgs.length ? '&' + newArgs.join('&') : '',
-		}, function() {
-			this.updateRequestUrl();
-		});
+		this.setState(
+			{
+				filterArgs: newArgs.length ? '&' + newArgs.join('&') : '',
+			},
+			function () {
+				this.updateRequestUrl();
+			}
+		);
 	}
 
 	getCountFunc(resultsCount) {
-		this.setState({
-			resultsCount: resultsCount,
-		}, function() {
-			this.updateRequestUrl();
-		});
+		this.setState(
+			{
+				resultsCount: resultsCount,
+			},
+			function () {
+				this.updateRequestUrl();
+			}
+		);
 	}
 
 	pageContent() {
-
 		const advancedFilters = PageStore.get('config-options').pages.search.advancedFilters;
 
-		return <MediaListWrapper className="search-results-wrap items-list-hor" title={ null === this.state.resultsTitle ? null : this.state.resultsTitle }>
+		return (
+			<MediaListWrapper
+				className="search-results-wrap items-list-hor"
+				title={null === this.state.resultsTitle ? null : this.state.resultsTitle}
+			>
+				{advancedFilters ? <FiltersToggleButton onClick={this.onToggleFiltersClick} /> : null}
+				{advancedFilters ? (
+					<SearchResultsFilters hidden={this.state.hiddenFilters} onFiltersUpdate={this.onFiltersUpdate} />
+				) : null}
 
-					{ advancedFilters ? <FiltersToggleButton onClick={ this.onToggleFiltersClick } /> : null }
-					{ advancedFilters ? <SearchResultsFilters hidden={ this.state.hiddenFilters } onFiltersUpdate={ this.onFiltersUpdate } /> : null }
+				{advancedFilters ? null : <SearchMediaFiltersRow onFiltersUpdate={this.onFilterArgsUpdate} />}
 
-					{ advancedFilters ? null : <SearchMediaFiltersRow onFiltersUpdate={ this.onFilterArgsUpdate } /> }
-
-					{ ! this.state.validQuery ? null : 
-						<LazyLoadItemListAsync
-							key={ this.state.requestUrl }
-							singleLinkContent={ false }
-							horizontalItemsOrientation={true}
-							itemsCountCallback={ this.getCountFunc }
-							requestUrl={ this.state.requestUrl }
-							preferSummary={true}
-							hideViews={ ! PageStore.get('config-media-item').displayViews }
-							hideAuthor={ ! PageStore.get('config-media-item').displayAuthor }
-							hideDate={ ! PageStore.get('config-media-item').displayPublishDate } /> }
-
-				</MediaListWrapper>;
+				{!this.state.validQuery ? null : (
+					<LazyLoadItemListAsync
+						key={this.state.requestUrl}
+						singleLinkContent={false}
+						horizontalItemsOrientation={true}
+						itemsCountCallback={this.getCountFunc}
+						requestUrl={this.state.requestUrl}
+						hideViews={!PageStore.get('config-media-item').displayViews}
+						hideAuthor={!PageStore.get('config-media-item').displayAuthor}
+						hideDate={!PageStore.get('config-media-item').displayPublishDate}
+					/>
+				)}
+			</MediaListWrapper>
+		);
 	}
 }


### PR DESCRIPTION
## Description
Search results displayed the "More Information and Credits" field (`description`) as the text snippet beneath each result, instead of the short summary/logline. This was caused by a logic error in `ListItem.js` where `props.summary` (never passed) was checked instead of `item.summary` (the actual API data).

## Related Issue
Fixes #473

## Motivation and Context
Users expect to see the short summary/logline in search results, not the full credits text. The broken logic always fell through to `item.description` since `props.summary` was always undefined.

## How Has This Been Tested?
- Verified `MediaSearchSerializer` still returns `summary` field
- Confirmed `description` field is not consumed anywhere in search context after the frontend fix

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized item rendering, metadata handling, and link construction for more consistent URL encoding, string normalization, and null checks, improving reliability of item links and display.
  * Playlist ID extraction and related parsing logic made more robust.

* **Changes**
  * Media descriptions removed from certain API responses and search result listings; descriptions may no longer appear in some lists or search views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->