### PR TITLE
feat(whisper): make ASR model configurable via WHISPER_MODEL_SIZE env var (Issue #481)

### DIFF
--- a/cms/settings.py
+++ b/cms/settings.py
@@ -584,7 +584,7 @@ MFA_EXCLUDE_PATHS = ["/fu/", "/api/", "/manage/", "/accounts/"]
 
 # Whisper ASR model selection. See VALID_WHISPER_MODELS in settings_utils.py for accepted values.
 # Can be set via WHISPER_MODEL_SIZE environment variable for container deployments.
-_whisper_model_requested = os.getenv("WHISPER_MODEL_SIZE", "base")
+_whisper_model_requested = os.getenv("WHISPER_MODEL_SIZE", "base").strip()
 WHISPER_CPP_DIR, WHISPER_CPP_COMMAND, WHISPER_CPP_MODEL, WHISPER_MODEL = get_whisper_cpp_paths(_whisper_model_requested)
 
 # django-maintenance-mode settings

--- a/cms/settings.py
+++ b/cms/settings.py
@@ -582,7 +582,10 @@ MFA_REQUIRED_ROLES = ["superuser", "manager", "curator"]
 MFA_ENFORCE_ON_PATHS = [f"/{DJANGO_ADMIN_URL}"]
 MFA_EXCLUDE_PATHS = ["/fu/", "/api/", "/manage/", "/accounts/"]
 
-WHISPER_CPP_DIR, WHISPER_CPP_COMMAND, WHISPER_CPP_MODEL = get_whisper_cpp_paths()
+# Whisper ASR model selection. See VALID_WHISPER_MODELS in settings_utils.py for accepted values.
+# Can be set via WHISPER_MODEL_SIZE environment variable for container deployments.
+_whisper_model_requested = os.getenv("WHISPER_MODEL_SIZE", "base")
+WHISPER_CPP_DIR, WHISPER_CPP_COMMAND, WHISPER_CPP_MODEL, WHISPER_MODEL = get_whisper_cpp_paths(_whisper_model_requested)
 
 # django-maintenance-mode settings
 MAINTENANCE_MODE = None  # None/False/True
@@ -608,7 +611,6 @@ MAINTENANCE_MODE_IGNORE_URLS = (
 
 
 ALLOWED_HOSTS.append(FRONTEND_HOST.replace("http://", "").replace("https://", ""))
-WHISPER_SIZE = "base"
 
 
 ALLOWED_MEDIA_UPLOAD_TYPES = ["video"]

--- a/cms/settings_utils.py
+++ b/cms/settings_utils.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-VALID_WHISPER_MODELS = ("tiny", "base", "small", "medium", "large-v3")
+VALID_WHISPER_MODELS = ("tiny", "base", "small", "medium", "large", "large-v1", "large-v2", "large-v3")
 
 
 def get_whisper_cpp_paths(model_name="base"):
@@ -11,7 +11,7 @@ def get_whisper_cpp_paths(model_name="base"):
     Dynamically determine whisper.cpp paths relative to cinematacms directory.
 
     Args:
-        model_name: Whisper model to use. Valid values: tiny, base, small, medium, large-v3.
+        model_name: Whisper model to use. Valid values: tiny, base, small, medium, large, large-v1, large-v2, large-v3.
                     Falls back to 'base' if invalid or model file not found.
 
     Returns:

--- a/cms/settings_utils.py
+++ b/cms/settings_utils.py
@@ -1,10 +1,31 @@
+import logging
 from pathlib import Path
 
+logger = logging.getLogger(__name__)
 
-def get_whisper_cpp_paths():
+VALID_WHISPER_MODELS = ("tiny", "base", "small", "medium", "large-v3")
+
+
+def get_whisper_cpp_paths(model_name="base"):
     """
     Dynamically determine whisper.cpp paths relative to cinematacms directory.
+
+    Args:
+        model_name: Whisper model to use. Valid values: tiny, base, small, medium, large-v3.
+                    Falls back to 'base' if invalid or model file not found.
+
+    Returns:
+        Tuple of (whisper_cpp_dir, whisper_cpp_command, whisper_cpp_model, resolved_model_name)
     """
+
+    # Validate model name
+    if model_name not in VALID_WHISPER_MODELS:
+        logger.warning(
+            "Invalid WHISPER_MODEL '%s'. Valid options: %s. Falling back to 'base'.",
+            model_name,
+            ", ".join(VALID_WHISPER_MODELS),
+        )
+        model_name = "base"
 
     # Get the absolute path of the current settings file
     current_file_path = Path(__file__).resolve()
@@ -37,8 +58,21 @@ def get_whisper_cpp_paths():
         whisper_cpp_command = str(whisper_cpp_main_paths[0])
 
     # Define model path
-    # NOTE: to change models, make sure that the replacement model is installed within the /whisper.cpp repo
-    # before updating the .bin file associated with this variable
-    whisper_cpp_model = str(whisper_cpp_dir / "models" / "ggml-base.bin")
+    whisper_cpp_model_path = whisper_cpp_dir / "models" / f"ggml-{model_name}.bin"
 
-    return (str(whisper_cpp_dir), whisper_cpp_command, whisper_cpp_model)
+    # If the requested model file doesn't exist and it's not the default, fall back to base
+    if not whisper_cpp_model_path.exists() and model_name != "base":
+        logger.warning(
+            "Whisper model file not found at '%s'. Falling back to 'base'.",
+            whisper_cpp_model_path,
+        )
+        model_name = "base"
+        whisper_cpp_model_path = whisper_cpp_dir / "models" / "ggml-base.bin"
+
+    if not whisper_cpp_model_path.exists():
+        logger.error(
+            "Whisper base model file not found at '%s'. Transcription will fail.",
+            whisper_cpp_model_path,
+        )
+
+    return (str(whisper_cpp_dir), whisper_cpp_command, str(whisper_cpp_model_path), model_name)

--- a/cms/settings_utils.py
+++ b/cms/settings_utils.py
@@ -61,7 +61,7 @@ def get_whisper_cpp_paths(model_name="base"):
     whisper_cpp_model_path = whisper_cpp_dir / "models" / f"ggml-{model_name}.bin"
 
     # If the requested model file doesn't exist and it's not the default, fall back to base
-    if not whisper_cpp_model_path.exists() and model_name != "base":
+    if not whisper_cpp_model_path.is_file() and model_name != "base":
         logger.warning(
             "Whisper model file not found at '%s'. Falling back to 'base'.",
             whisper_cpp_model_path,
@@ -69,7 +69,7 @@ def get_whisper_cpp_paths(model_name="base"):
         model_name = "base"
         whisper_cpp_model_path = whisper_cpp_dir / "models" / "ggml-base.bin"
 
-    if not whisper_cpp_model_path.exists():
+    if not whisper_cpp_model_path.is_file():
         logger.error(
             "Whisper base model file not found at '%s'. Transcription will fail.",
             whisper_cpp_model_path,

--- a/cms/tests.py
+++ b/cms/tests.py
@@ -1,10 +1,11 @@
-# TODO: insert test for checking if the whisper.cpp directory exists
 import logging
 import os
 from pathlib import Path
 
 from django.conf import settings
 from django.test import TestCase
+
+from .settings_utils import VALID_WHISPER_MODELS, get_whisper_cpp_paths
 
 
 class WhisperCPPDirectoryTestCase(TestCase):
@@ -41,6 +42,49 @@ class WhisperCPPDirectoryTestCase(TestCase):
             )
         else:
             self.fail(f"WHISPER_CPP_MODEL does not exist: {model_path}")
+
+
+class WhisperModelConfigTestCase(TestCase):
+    """Tests for configurable Whisper model selection."""
+
+    def test_whisper_model_setting_is_valid(self):
+        """WHISPER_MODEL setting should be one of the valid model names."""
+        self.assertIn(
+            settings.WHISPER_MODEL,
+            VALID_WHISPER_MODELS,
+            f"WHISPER_MODEL '{settings.WHISPER_MODEL}' is not a valid model. "
+            f"Valid options: {', '.join(VALID_WHISPER_MODELS)}",
+        )
+
+    def test_get_whisper_cpp_paths_default(self):
+        """Calling with no args should default to 'base'."""
+        _, _, model_path, resolved_name = get_whisper_cpp_paths()
+        self.assertEqual(resolved_name, "base")
+        self.assertTrue(model_path.endswith("ggml-base.bin"))
+
+    def test_get_whisper_cpp_paths_with_valid_model(self):
+        """Calling with a valid model name should construct the correct path."""
+        for model in VALID_WHISPER_MODELS:
+            with self.subTest(model=model):
+                _, _, model_path, resolved_name = get_whisper_cpp_paths(model)
+                # If the model file exists, resolved_name should match the requested model.
+                # If it doesn't exist and isn't 'base', the function falls back to 'base'.
+                if resolved_name == model:
+                    self.assertTrue(model_path.endswith(f"ggml-{model}.bin"))
+                else:
+                    self.assertEqual(resolved_name, "base")
+                    self.assertTrue(model_path.endswith("ggml-base.bin"))
+
+    def test_get_whisper_cpp_paths_with_invalid_model(self):
+        """Calling with an invalid model name should fall back to 'base'."""
+        _, _, model_path, resolved_name = get_whisper_cpp_paths("nonexistent")
+        self.assertEqual(resolved_name, "base")
+        self.assertTrue(model_path.endswith("ggml-base.bin"))
+
+    def test_get_whisper_cpp_paths_rejects_path_traversal(self):
+        """Path traversal attempts should be rejected by validation."""
+        _, _, _, resolved_name = get_whisper_cpp_paths("../../etc/passwd")
+        self.assertEqual(resolved_name, "base")
 
 
 class WhisperCPPIntegrationTestCase(TestCase):


### PR DESCRIPTION
## Description
Make the Whisper ASR model configurable via a `WHISPER_MODEL_SIZE` environment variable instead of being hardcoded to `ggml-base.bin`. The setting supports `tiny`, `base`, `small`, `medium`, and `large-v3` models with automatic validation and fallback to `base` when the requested model is invalid or its file is missing.

### Changes
- **`cms/settings_utils.py`**: Updated `get_whisper_cpp_paths()` to accept a `model_name` parameter, validate it against `VALID_WHISPER_MODELS`, check file existence, and return a 4-tuple including the resolved model name. Added `logger.error` when the base model file is also missing.
- **`cms/settings.py`**: Added `WHISPER_MODEL` setting driven by `WHISPER_MODEL_SIZE` env var (default: `"base"`). Removed unused `WHISPER_SIZE = "base"` setting.
- **`cms/tests.py`**: Added `WhisperModelConfigTestCase` with 5 tests covering default behavior, valid model paths, invalid model fallback, path traversal rejection, and settings validation.

No changes to `files/tasks.py`, `cms/dev_settings.py`, or `cms/local_settings.py` — they all continue to work as-is.

## Related Issue
Fixes #481

## Motivation and Context
The Whisper model was hardcoded to `ggml-base.bin` in `cms/settings_utils.py`. Switching between model sizes required editing source files directly. There was also an unused `WHISPER_SIZE` setting in `settings.py` that was never wired up, adding confusion.

Deployments with different hardware profiles need a clean way to select the appropriate model — a server with 4GB+ RAM should use `large-v3` for better accuracy, while a constrained environment should use `tiny` or `base`.

## How Has This Been Tested?
- Ran `WhisperModelConfigTestCase` (5 tests) — all pass:
  - `test_whisper_model_setting_is_valid` — verifies `WHISPER_MODEL` is a valid model name
  - `test_get_whisper_cpp_paths_default` — no args defaults to `base`
  - `test_get_whisper_cpp_paths_with_valid_model` — each valid model constructs the correct path (with `subTest` for clear failure reporting)
  - `test_get_whisper_cpp_paths_with_invalid_model` — invalid names fall back to `base`
  - `test_get_whisper_cpp_paths_rejects_path_traversal` — adversarial input like `../../etc/passwd` is rejected
- Verified fallback logging: invalid model logs `WARNING`, missing base model logs `ERROR`
- Verified `dev_settings.py` direct override pattern continues to work unchanged

## Screenshots (if appropriate):
N/A — backend-only change.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):
- [x] I have not imported `flux` in a new component
- [x] If adding a new feature, I used Modern Track patterns
- [x] New features do not create new SCSS files (use Tailwind instead)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Whisper model selection is now driven by the WHISPER_MODEL_SIZE environment variable (defaults to "base"), supporting multiple model sizes; invalid or missing selections and unavailable model files fall back to "base" with warnings logged.

* **Tests**
  * Added tests validating model selection: default behavior, each valid model, fallbacks for missing/invalid requests, and rejection of path-traversal-like inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->