### PR TITLE
feat: add user-scoped Manage Uploads page with bulk operations (#402)

### DIFF
--- a/files/context_processors.py
+++ b/files/context_processors.py
@@ -3,7 +3,7 @@ import json
 from django.conf import settings
 
 from .lists import UNUSUAL_COUNTRIES
-from .methods import can_upload_media, is_curator, is_mediacms_editor, is_mediacms_manager
+from .methods import can_manage_uploads, can_upload_media, is_curator, is_mediacms_editor, is_mediacms_manager
 from .models import HomepagePopup, TopMessage
 
 # NOTE: context_processors.py can be considered as a dumping ground of sorts for
@@ -43,6 +43,7 @@ def stuff(request):
     ret["IS_MEDIACMS_EDITOR"] = is_mediacms_editor(request.user)
     ret["IS_MEDIACMS_MANAGER"] = is_mediacms_manager(request.user)
     ret["IS_CURATOR"] = is_curator(request.user)
+    ret["CAN_MANAGE_UPLOADS"] = can_manage_uploads(request.user)
     ret["ALLOW_RATINGS"] = settings.ALLOW_RATINGS
     ret["ALLOW_RATINGS_CONFIRMED_EMAIL_ONLY"] = settings.ALLOW_RATINGS_CONFIRMED_EMAIL_ONLY
     ret["VIDEO_PLAYER_FEATURED_VIDEO_ON_INDEX_PAGE"] = settings.VIDEO_PLAYER_FEATURED_VIDEO_ON_INDEX_PAGE

--- a/files/management_views.py
+++ b/files/management_views.py
@@ -138,9 +138,18 @@ class MyUploadsList(APIView):
 
     def delete(self, request, format=None):
         tokens = request.GET.get("tokens")
-        if tokens:
-            tokens = [t.strip() for t in tokens.split(",") if t.strip()]
-            Media.objects.filter(friendly_token__in=tokens, user=request.user).delete()
+        if not tokens:
+            return Response(
+                {"detail": "tokens query parameter is required"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        tokens = [t.strip() for t in tokens.split(",") if t.strip()]
+        if not tokens:
+            return Response(
+                {"detail": "tokens must contain at least one value"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        Media.objects.filter(friendly_token__in=tokens, user=request.user).delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 

--- a/files/management_views.py
+++ b/files/management_views.py
@@ -143,13 +143,19 @@ class MyUploadsList(APIView):
                 {"detail": "tokens query parameter is required"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
-        tokens = [t.strip() for t in tokens.split(",") if t.strip()]
+        tokens = list(set(t.strip() for t in tokens.split(",") if t.strip()))
         if not tokens:
             return Response(
                 {"detail": "tokens must contain at least one value"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
-        Media.objects.filter(friendly_token__in=tokens, user=request.user).delete()
+        qs = Media.objects.filter(friendly_token__in=tokens, user=request.user)
+        if qs.count() != len(tokens):
+            return Response(
+                {"detail": "one or more tokens not found or not owned by you"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        qs.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 

--- a/files/management_views.py
+++ b/files/management_views.py
@@ -11,7 +11,7 @@ from users.serializers import UserSerializer
 from .methods import is_mediacms_manager
 from .models import Comment, Media
 from .permissions import IsManageUploadsUser, IsMediacmsEditor
-from .serializers import CommentSerializer, MediaSerializer
+from .serializers import CommentSerializer, ManageUploadSerializer, MediaSerializer
 
 
 class MediaList(APIView):
@@ -133,7 +133,7 @@ class MyUploadsList(APIView):
         paginator = pagination_class()
         page = paginator.paginate_queryset(media, request)
 
-        serializer = MediaSerializer(page, many=True, context={"request": request})
+        serializer = ManageUploadSerializer(page, many=True, context={"request": request})
         return paginator.get_paginated_response(serializer.data)
 
     def delete(self, request, format=None):

--- a/files/management_views.py
+++ b/files/management_views.py
@@ -1,3 +1,4 @@
+from django.db import transaction
 from rest_framework import status
 from rest_framework.parsers import JSONParser
 from rest_framework.response import Response
@@ -9,7 +10,7 @@ from users.serializers import UserSerializer
 
 from .methods import is_mediacms_manager
 from .models import Comment, Media
-from .permissions import IsMediacmsEditor
+from .permissions import IsManageUploadsUser, IsMediacmsEditor
 from .serializers import CommentSerializer, MediaSerializer
 
 
@@ -93,6 +94,91 @@ class MediaList(APIView):
             tokens = tokens.split(",")
             Media.objects.filter(friendly_token__in=tokens).delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class MyUploadsList(APIView):
+    permission_classes = (IsManageUploadsUser,)
+    parser_classes = (JSONParser,)
+
+    def get(self, request, format=None):
+        params = self.request.query_params
+        ordering = params.get("ordering", "").strip()
+        sort_by = params.get("sort_by", "").strip()
+        state = params.get("state", "").strip()
+        encoding_status = params.get("encoding_status", "").strip()
+        search = params.get("search", "").strip()
+
+        sort_by_options = ["title", "add_date", "edit_date", "views", "likes"]
+        if sort_by not in sort_by_options:
+            sort_by = "add_date"
+        ordering = "" if ordering == "asc" else "-"
+
+        if state not in ["private", "public", "unlisted"]:
+            state = None
+
+        if encoding_status not in ["pending", "running", "fail", "success"]:
+            encoding_status = None
+
+        pagination_class = api_settings.DEFAULT_PAGINATION_CLASS
+        qs = Media.objects.filter(user=request.user)
+        if state:
+            qs = qs.filter(state=state)
+        if encoding_status:
+            qs = qs.filter(encoding_status=encoding_status)
+        if search:
+            qs = qs.filter(title__icontains=search)
+
+        media = qs.order_by(f"{ordering}{sort_by}")
+
+        paginator = pagination_class()
+        page = paginator.paginate_queryset(media, request)
+
+        serializer = MediaSerializer(page, many=True, context={"request": request})
+        return paginator.get_paginated_response(serializer.data)
+
+    def delete(self, request, format=None):
+        tokens = request.GET.get("tokens")
+        if tokens:
+            tokens = [t.strip() for t in tokens.split(",") if t.strip()]
+            Media.objects.filter(friendly_token__in=tokens, user=request.user).delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class MyUploadsBulkState(APIView):
+    permission_classes = (IsManageUploadsUser,)
+    parser_classes = (JSONParser,)
+
+    def post(self, request, format=None):
+        tokens = request.data.get("tokens", [])
+        new_state = request.data.get("state", "").strip()
+
+        if not tokens or not isinstance(tokens, list):
+            return Response(
+                {"detail": "tokens must be a non-empty list"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # Deduplicate tokens to avoid count mismatch on repeated values
+        tokens = list(set(tokens))
+
+        if new_state not in ["private", "public", "unlisted"]:
+            return Response(
+                {"detail": "state must be private, public, or unlisted"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        with transaction.atomic():
+            qs = Media.objects.select_for_update().filter(
+                friendly_token__in=tokens, user=request.user
+            )
+            if qs.count() != len(tokens):
+                return Response(
+                    {"detail": "one or more tokens not found or not owned by you"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            updated = qs.update(state=new_state)
+        return Response({"updated": updated}, status=status.HTTP_200_OK)
 
 
 class CommentList(APIView):

--- a/files/management_views.py
+++ b/files/management_views.py
@@ -120,7 +120,7 @@ class MyUploadsList(APIView):
             encoding_status = None
 
         pagination_class = api_settings.DEFAULT_PAGINATION_CLASS
-        qs = Media.objects.filter(user=request.user)
+        qs = Media.objects.select_related("user").filter(user=request.user)
         if state:
             qs = qs.filter(state=state)
         if encoding_status:
@@ -149,13 +149,16 @@ class MyUploadsList(APIView):
                 {"detail": "tokens must contain at least one value"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
-        qs = Media.objects.filter(friendly_token__in=tokens, user=request.user)
-        if qs.count() != len(tokens):
-            return Response(
-                {"detail": "one or more tokens not found or not owned by you"},
-                status=status.HTTP_400_BAD_REQUEST,
+        with transaction.atomic():
+            qs = Media.objects.select_for_update().filter(
+                friendly_token__in=tokens, user=request.user
             )
-        qs.delete()
+            if qs.count() != len(tokens):
+                return Response(
+                    {"detail": "one or more tokens not found or not owned by you"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            qs.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 

--- a/files/methods.py
+++ b/files/methods.py
@@ -570,6 +570,15 @@ def is_mediacms_manager(user):
     return manager
 
 
+def can_manage_uploads(user):
+    """Check if user can access Manage Uploads page.
+    Trusted Users (advancedUser), Editors, Managers, and Superusers."""
+    try:
+        return bool(user.is_superuser or user.is_manager or user.is_editor or user.advancedUser)
+    except Exception:
+        return False
+
+
 def is_curator(user):
     curator = False
     try:

--- a/files/methods.py
+++ b/files/methods.py
@@ -575,7 +575,7 @@ def can_manage_uploads(user):
     Trusted Users (advancedUser), Editors, Managers, and Superusers."""
     try:
         return bool(user.is_superuser or user.is_manager or user.is_editor or user.advancedUser)
-    except Exception:
+    except AttributeError:
         return False
 
 

--- a/files/migrations/0017_add_my_uploads_indexes.py
+++ b/files/migrations/0017_add_my_uploads_indexes.py
@@ -1,0 +1,25 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("files", "0016_add_encoding_drain_composite_index"),
+    ]
+
+    operations = [
+        migrations.AddIndex(
+            model_name="media",
+            index=models.Index(
+                fields=["user", "state", "add_date"],
+                name="media_user_state_date_idx",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="media",
+            index=models.Index(
+                fields=["user", "encoding_status"],
+                name="media_user_encoding_idx",
+            ),
+        ),
+    ]

--- a/files/permissions.py
+++ b/files/permissions.py
@@ -1,8 +1,13 @@
 from rest_framework import permissions
 
-from .methods import is_mediacms_editor
+from .methods import can_manage_uploads, is_mediacms_editor
 
 
 class IsMediacmsEditor(permissions.BasePermission):
     def has_permission(self, request, view):
         return bool(is_mediacms_editor(request.user))
+
+
+class IsManageUploadsUser(permissions.BasePermission):
+    def has_permission(self, request, view):
+        return bool(request.user.is_authenticated and can_manage_uploads(request.user))

--- a/files/serializers.py
+++ b/files/serializers.py
@@ -97,6 +97,27 @@ class MediaSerializer(serializers.ModelSerializer):
         )
 
 
+class ManageUploadSerializer(serializers.ModelSerializer):
+    url = serializers.SerializerMethodField()
+
+    def get_url(self, obj):
+        return self.context["request"].build_absolute_uri(obj.get_absolute_url())
+
+    class Meta:
+        model = Media
+        fields = (
+            "friendly_token",
+            "title",
+            "url",
+            "add_date",
+            "media_type",
+            "encoding_status",
+            "state",
+            "views",
+            "likes",
+        )
+
+
 class SingleMediaSerializer(serializers.ModelSerializer):
     user = serializers.ReadOnlyField(source="user.username")
     url = serializers.SerializerMethodField()

--- a/files/tests/test_my_uploads.py
+++ b/files/tests/test_my_uploads.py
@@ -247,11 +247,11 @@ class MyUploadsBulkDeleteTests(TestCase):
         self.assertFalse(Media.objects.filter(friendly_token=token).exists())
 
     def test_cannot_delete_other_users_media(self):
-        """User cannot delete another user's media."""
+        """User cannot delete another user's media — returns 400."""
         self.client.login(username="usera", password="testpass123")
         token_b = self.media_b.friendly_token
         response = self.client.delete(f"/api/v1/my_uploads?tokens={token_b}")
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, 400)
         # User B's media should still exist
         self.assertTrue(Media.objects.filter(friendly_token=token_b).exists())
 

--- a/files/tests/test_my_uploads.py
+++ b/files/tests/test_my_uploads.py
@@ -1,0 +1,380 @@
+import json
+from unittest.mock import patch
+
+from django.test import Client, TestCase
+
+from files.methods import can_manage_uploads
+from files.models import Media
+from users.models import User
+
+
+def create_test_media(user, title, **kwargs):
+    """Create a Media object with media_init patched out to avoid file processing.
+
+    Note: Media.save() overrides state on creation via get_default_state(),
+    so we set state after creation if provided.
+    """
+    desired_state = kwargs.pop("state", None)
+    with patch.object(Media, "media_init", return_value=None):
+        media = Media.objects.create(title=title, user=user, **kwargs)
+    if desired_state and media.state != desired_state:
+        Media.objects.filter(pk=media.pk).update(state=desired_state)
+        media.refresh_from_db()
+    return media
+
+
+class MyUploadsPermissionTests(TestCase):
+    """Test permission checks for Manage Uploads feature."""
+
+    def setUp(self):
+        self.client = Client()
+
+        self.regular_user = User.objects.create_user(
+            username="regularuser",
+            email="regular@example.com",
+            password="testpass123",
+        )
+
+        self.trusted_user = User.objects.create_user(
+            username="trusteduser",
+            email="trusted@example.com",
+            password="testpass123",
+        )
+        self.trusted_user.advancedUser = True
+        self.trusted_user.save()
+
+        self.editor_user = User.objects.create_user(
+            username="editoruser",
+            email="editor@example.com",
+            password="testpass123",
+        )
+        self.editor_user.is_editor = True
+        self.editor_user.save()
+
+        self.manager_user = User.objects.create_user(
+            username="manageruser",
+            email="manager@example.com",
+            password="testpass123",
+        )
+        self.manager_user.is_manager = True
+        self.manager_user.save()
+
+        self.superuser = User.objects.create_superuser(
+            username="superuser",
+            email="super@example.com",
+            password="testpass123",
+        )
+
+    def test_can_manage_uploads_helper(self):
+        """Test can_manage_uploads returns correct values for each role."""
+        self.assertFalse(can_manage_uploads(self.regular_user))
+        self.assertTrue(can_manage_uploads(self.trusted_user))
+        self.assertTrue(can_manage_uploads(self.editor_user))
+        self.assertTrue(can_manage_uploads(self.manager_user))
+        self.assertTrue(can_manage_uploads(self.superuser))
+
+    def test_page_anonymous_redirect(self):
+        """Anonymous user is redirected from manage uploads page."""
+        response = self.client.get("/manage/uploads")
+        self.assertEqual(response.status_code, 302)
+
+    def test_page_regular_user_redirect(self):
+        """Regular user is redirected from manage uploads page."""
+        self.client.login(username="regularuser", password="testpass123")
+        response = self.client.get("/manage/uploads")
+        self.assertEqual(response.status_code, 302)
+
+    def test_page_trusted_user_allowed(self):
+        """Trusted user can access manage uploads page."""
+        self.client.login(username="trusteduser", password="testpass123")
+        response = self.client.get("/manage/uploads")
+        self.assertEqual(response.status_code, 200)
+
+    def test_api_anonymous_forbidden(self):
+        """Anonymous user gets 403 on API."""
+        response = self.client.get("/api/v1/my_uploads")
+        self.assertEqual(response.status_code, 403)
+
+    def test_api_regular_user_forbidden(self):
+        """Regular user gets 403 on API."""
+        self.client.login(username="regularuser", password="testpass123")
+        response = self.client.get("/api/v1/my_uploads")
+        self.assertEqual(response.status_code, 403)
+
+    def test_api_trusted_user_allowed(self):
+        """Trusted user can access API."""
+        self.client.login(username="trusteduser", password="testpass123")
+        response = self.client.get("/api/v1/my_uploads")
+        self.assertEqual(response.status_code, 200)
+
+    def test_api_editor_allowed(self):
+        """Editor can access API."""
+        self.client.login(username="editoruser", password="testpass123")
+        response = self.client.get("/api/v1/my_uploads")
+        self.assertEqual(response.status_code, 200)
+
+    def test_api_superuser_allowed(self):
+        """Superuser can access API."""
+        self.client.login(username="superuser", password="testpass123")
+        response = self.client.get("/api/v1/my_uploads")
+        self.assertEqual(response.status_code, 200)
+
+
+class MyUploadsOwnershipTests(TestCase):
+    """Test that users can only see/modify their own uploads."""
+
+    def setUp(self):
+        self.client = Client()
+
+        self.user_a = User.objects.create_user(
+            username="usera",
+            email="usera@example.com",
+            password="testpass123",
+        )
+        self.user_a.advancedUser = True
+        self.user_a.save()
+
+        self.user_b = User.objects.create_user(
+            username="userb",
+            email="userb@example.com",
+            password="testpass123",
+        )
+        self.user_b.advancedUser = True
+        self.user_b.save()
+
+        # Create media for user_a
+        self.media_a1 = create_test_media(
+            user=self.user_a,
+            title="User A Video 1",
+            media_type="video",
+            state="public",
+        )
+        self.media_a2 = create_test_media(
+            user=self.user_a,
+            title="User A Video 2",
+            media_type="video",
+            state="private",
+        )
+
+        # Create media for user_b
+        self.media_b1 = create_test_media(
+            user=self.user_b,
+            title="User B Video 1",
+            media_type="video",
+            state="public",
+        )
+
+    def test_user_only_sees_own_uploads(self):
+        """User A only sees their own uploads."""
+        self.client.login(username="usera", password="testpass123")
+        response = self.client.get("/api/v1/my_uploads")
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        results = data.get("results", [])
+        self.assertEqual(len(results), 2)
+        tokens = [r["friendly_token"] for r in results]
+        self.assertIn(self.media_a1.friendly_token, tokens)
+        self.assertIn(self.media_a2.friendly_token, tokens)
+        self.assertNotIn(self.media_b1.friendly_token, tokens)
+
+    def test_user_b_only_sees_own_uploads(self):
+        """User B only sees their own uploads."""
+        self.client.login(username="userb", password="testpass123")
+        response = self.client.get("/api/v1/my_uploads")
+        data = response.json()
+        results = data.get("results", [])
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["friendly_token"], self.media_b1.friendly_token)
+
+    def test_filter_by_state(self):
+        """Filtering by state returns correct subset."""
+        self.client.login(username="usera", password="testpass123")
+        response = self.client.get("/api/v1/my_uploads?state=private")
+        data = response.json()
+        results = data.get("results", [])
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["friendly_token"], self.media_a2.friendly_token)
+
+    def test_search_by_title(self):
+        """Searching by title returns matching items."""
+        self.client.login(username="usera", password="testpass123")
+        response = self.client.get("/api/v1/my_uploads?search=Video 1")
+        data = response.json()
+        results = data.get("results", [])
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["friendly_token"], self.media_a1.friendly_token)
+
+
+class MyUploadsBulkDeleteTests(TestCase):
+    """Test bulk delete with ownership verification."""
+
+    def setUp(self):
+        self.client = Client()
+
+        self.user_a = User.objects.create_user(
+            username="usera",
+            email="usera@example.com",
+            password="testpass123",
+        )
+        self.user_a.advancedUser = True
+        self.user_a.save()
+
+        self.user_b = User.objects.create_user(
+            username="userb",
+            email="userb@example.com",
+            password="testpass123",
+        )
+        self.user_b.advancedUser = True
+        self.user_b.save()
+
+        self.media_a = create_test_media(
+            user=self.user_a,
+            title="User A Video",
+            media_type="video",
+        )
+        self.media_b = create_test_media(
+            user=self.user_b,
+            title="User B Video",
+            media_type="video",
+        )
+
+    def test_delete_own_media(self):
+        """User can delete their own media."""
+        self.client.login(username="usera", password="testpass123")
+        token = self.media_a.friendly_token
+        response = self.client.delete(f"/api/v1/my_uploads?tokens={token}")
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(Media.objects.filter(friendly_token=token).exists())
+
+    def test_cannot_delete_other_users_media(self):
+        """User cannot delete another user's media."""
+        self.client.login(username="usera", password="testpass123")
+        token_b = self.media_b.friendly_token
+        response = self.client.delete(f"/api/v1/my_uploads?tokens={token_b}")
+        self.assertEqual(response.status_code, 204)
+        # User B's media should still exist
+        self.assertTrue(Media.objects.filter(friendly_token=token_b).exists())
+
+
+class MyUploadsBulkStateTests(TestCase):
+    """Test bulk state change with ownership verification."""
+
+    def setUp(self):
+        self.client = Client()
+
+        self.user_a = User.objects.create_user(
+            username="usera",
+            email="usera@example.com",
+            password="testpass123",
+        )
+        self.user_a.advancedUser = True
+        self.user_a.save()
+
+        self.user_b = User.objects.create_user(
+            username="userb",
+            email="userb@example.com",
+            password="testpass123",
+        )
+        self.user_b.advancedUser = True
+        self.user_b.save()
+
+        self.media_a1 = create_test_media(
+            user=self.user_a,
+            title="User A Video 1",
+            media_type="video",
+            state="public",
+        )
+        self.media_a2 = create_test_media(
+            user=self.user_a,
+            title="User A Video 2",
+            media_type="video",
+            state="public",
+        )
+        self.media_b = create_test_media(
+            user=self.user_b,
+            title="User B Video",
+            media_type="video",
+            state="public",
+        )
+
+    def test_bulk_state_change_own_media(self):
+        """User can change state of their own media."""
+        self.client.login(username="usera", password="testpass123")
+        response = self.client.post(
+            "/api/v1/my_uploads/bulk_state",
+            data=json.dumps({
+                "tokens": [self.media_a1.friendly_token, self.media_a2.friendly_token],
+                "state": "private",
+            }),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["updated"], 2)
+
+        self.media_a1.refresh_from_db()
+        self.media_a2.refresh_from_db()
+        self.assertEqual(self.media_a1.state, "private")
+        self.assertEqual(self.media_a2.state, "private")
+
+    def test_cannot_change_state_of_other_users_media(self):
+        """User cannot change state of another user's media — count mismatch returns 400."""
+        self.client.login(username="usera", password="testpass123")
+        response = self.client.post(
+            "/api/v1/my_uploads/bulk_state",
+            data=json.dumps({
+                "tokens": [self.media_b.friendly_token],
+                "state": "private",
+            }),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 400)
+
+        # User B's media should still be public
+        self.media_b.refresh_from_db()
+        self.assertEqual(self.media_b.state, "public")
+
+    def test_mixed_tokens_rejected(self):
+        """Request with mix of own and other user's tokens is rejected."""
+        self.client.login(username="usera", password="testpass123")
+        response = self.client.post(
+            "/api/v1/my_uploads/bulk_state",
+            data=json.dumps({
+                "tokens": [self.media_a1.friendly_token, self.media_b.friendly_token],
+                "state": "private",
+            }),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 400)
+
+        # Neither media should have changed
+        self.media_a1.refresh_from_db()
+        self.media_b.refresh_from_db()
+        self.assertEqual(self.media_a1.state, "public")
+        self.assertEqual(self.media_b.state, "public")
+
+    def test_invalid_state_rejected(self):
+        """Invalid state value is rejected."""
+        self.client.login(username="usera", password="testpass123")
+        response = self.client.post(
+            "/api/v1/my_uploads/bulk_state",
+            data=json.dumps({
+                "tokens": [self.media_a1.friendly_token],
+                "state": "restricted",
+            }),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_empty_tokens_rejected(self):
+        """Empty tokens list is rejected."""
+        self.client.login(username="usera", password="testpass123")
+        response = self.client.post(
+            "/api/v1/my_uploads/bulk_state",
+            data=json.dumps({
+                "tokens": [],
+                "state": "private",
+            }),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 400)

--- a/files/urls.py
+++ b/files/urls.py
@@ -100,6 +100,10 @@ urlpatterns = [
     path("manage/users", views.manage_users, name="manage_users"),
     path("manage/media", views.manage_media, name="manage_media"),
     path("manage/comments", views.manage_comments, name="manage_comments"),
+    # USER MANAGE UPLOADS
+    path("api/v1/my_uploads", management_views.MyUploadsList.as_view()),
+    path("api/v1/my_uploads/bulk_state", management_views.MyUploadsBulkState.as_view()),
+    path("manage/uploads", views.manage_uploads, name="manage_uploads"),
     path("manage/users/export", views.export_users, name="export_users"),
     path("api/v1/encode_profiles/", views.EncodeProfileList.as_view()),
     path("api/v1/tasks", views.TasksList.as_view()),

--- a/files/views.py
+++ b/files/views.py
@@ -52,6 +52,7 @@ from .helpers import (
     rm_file,
 )
 from .methods import (
+    can_manage_uploads,
     can_upload_media,
     get_current_featured_media,
     get_user_or_session,
@@ -212,6 +213,20 @@ def manage_comments(request):
 
     context = {}
     return render(request, "cms/manage_comments.html", context)
+
+
+def manage_uploads(request):
+    if request.user.is_anonymous:
+        return HttpResponseRedirect("/")
+
+    if user_requires_mfa(request.user) and not is_mfa_enabled(request.user):
+        return HttpResponseRedirect("/accounts/2fa/totp/activate")
+
+    if not can_manage_uploads(request.user):
+        return HttpResponseRedirect("/")
+
+    context = {}
+    return render(request, "cms/manage_uploads.html", context)
 
 
 def export_users(request):

--- a/frontend/src/entries/manage-uploads.js
+++ b/frontend/src/entries/manage-uploads.js
@@ -1,0 +1,4 @@
+import { renderPage } from '../static/js/_helpers.js';
+import { ManageUploadsPage } from '../static/js/pages/ManageUploadsPage';
+
+renderPage('page-manage-uploads', ManageUploadsPage);

--- a/frontend/src/static/js/components/-NEW-/ManageItem/ManageUploadItem.js
+++ b/frontend/src/static/js/components/-NEW-/ManageItem/ManageUploadItem.js
@@ -1,0 +1,173 @@
+import React, { useRef, useState, useEffect, useCallback } from 'react';
+import PropTypes from 'prop-types';
+
+import { usePopup } from '../hooks/usePopup';
+import { PopupMain } from '../Popup';
+import { formatManagementTableDate } from '../../../functions/formatManagementTableDate.js';
+import PageStore from '../../../pages/_PageStore.js';
+
+function ManageItemTitle(props) {
+	if (void 0 !== props.title && void 0 !== props.url) {
+		return (<a href={props.url} title={props.title}>{props.title}</a>);
+	}
+	if (void 0 !== props.title) {
+		return (props.title);
+	}
+	if (void 0 !== props.url) {
+		return (props.url);
+	}
+	return (<i className="non-available">N/A</i>);
+}
+
+function ManageItemDate(props) {
+	if (void 0 !== props.date) {
+		return (formatManagementTableDate(new Date(Date.parse(props.date))));
+	}
+	return (<i className="non-available">N/A</i>);
+}
+
+function ManageUploadItemActions(props) {
+	const [popupContentRef, PopupContent, PopupTrigger] = usePopup();
+	const [isOpenPopup, setIsOpenPopup] = useState(false);
+
+	function onPopupShow() {
+		setIsOpenPopup(true);
+	}
+
+	function onPopupHide() {
+		setIsOpenPopup(false);
+	}
+
+	function onCancel() {
+		popupContentRef.current.tryToHide();
+	}
+
+	function onProceed() {
+		popupContentRef.current.tryToHide();
+		if ('function' === typeof props.onProceed) {
+			props.onProceed();
+		}
+	}
+
+	const positionState = { updating: false, pending: 0 };
+
+	const onWindowResize = useCallback(function () {
+		if (positionState.updating) {
+			positionState.pending = positionState.pending + 1;
+		} else {
+			positionState.updating = true;
+
+			const popupElem = props.containerRef.current.querySelector('.popup');
+
+			if (popupElem) {
+				const containerClientRect = props.containerRef.current.getBoundingClientRect();
+				popupElem.style.position = 'fixed';
+				popupElem.style.left = containerClientRect.x + 'px';
+
+				if (document.body.offsetHeight < 32 + popupElem.offsetHeight + window.scrollY + containerClientRect.top) {
+					popupElem.style.top = (containerClientRect.y - popupElem.offsetHeight) + 'px';
+				} else {
+					popupElem.style.top = (containerClientRect.y + containerClientRect.height) + 'px';
+				}
+			}
+
+			setTimeout(() => {
+				positionState.updating = false;
+				if (positionState.pending) {
+					positionState.pending = 0;
+					onWindowResize();
+				}
+			}, 8);
+		}
+	}, []);
+
+	useEffect(() => {
+		if (isOpenPopup) {
+			PageStore.on('window_scroll', onWindowResize);
+			PageStore.on('window_resize', onWindowResize);
+			onWindowResize();
+		} else {
+			PageStore.removeListener('window_scroll', onWindowResize);
+			PageStore.removeListener('window_resize', onWindowResize);
+		}
+	}, [isOpenPopup]);
+
+	return (
+		<div ref={props.containerRef} className="actions">
+			<PopupTrigger contentRef={popupContentRef}>
+				<button title={'Delete' + (void 0 !== props.title ? ' "' + props.title + '"' : '')}>Delete</button>
+			</PopupTrigger>
+			<PopupContent contentRef={popupContentRef} showCallback={onPopupShow} hideCallback={onPopupHide}>
+				<PopupMain>
+					<div className="popup-message">
+						<span className="popup-message-title">Media removal</span>
+						<span className="popup-message-main">{"You're willing to remove media" + (void 0 !== props.title ? ' "' + props.title + '"' : '')}?</span>
+					</div>
+					<hr />
+					<span className="popup-message-bottom">
+						<button className="button-link cancel-profile-removal" onClick={onCancel}>CANCEL</button>
+						<button className="button-link proceed-profile-removal" onClick={onProceed}>PROCEED</button>
+					</span>
+				</PopupMain>
+			</PopupContent>
+		</div>
+	);
+}
+
+export function ManageUploadItem(props) {
+	const actionsContainerRef = useRef(null);
+	const [selected, setSelected] = useState(false);
+
+	function onRowCheck() {
+		setSelected(!selected);
+	}
+
+	function onClickProceed() {
+		if ('function' === typeof props.onProceedRemoval) {
+			props.onProceedRemoval(props.token);
+		}
+	}
+
+	useEffect(() => {
+		if ('function' === typeof props.onCheckRow) {
+			props.onCheckRow(props.token, selected);
+		}
+	}, [selected]);
+
+	useEffect(() => {
+		setSelected(props.selectedRow);
+	}, [props.selectedRow]);
+
+	return (
+		<div className="item manage-item manage-upload-item">
+			<div className="mi-checkbox">
+				<input type="checkbox" checked={selected} onChange={onRowCheck} />
+			</div>
+			<div className="mi-title">
+				<ManageItemTitle title={props.title} url={props.url} />
+				{props.hideDeleteAction ? null : <ManageUploadItemActions containerRef={actionsContainerRef} title={props.title} onProceed={onClickProceed} />}
+			</div>
+			<div className="mi-added"><ManageItemDate date={props.add_date} /></div>
+			<div className="mi-type">{void 0 === props.media_type ? <i className="non-available">N/A</i> : props.media_type}</div>
+			<div className="mi-encoding">{void 0 === props.encoding_status ? <i className="non-available">N/A</i> : props.encoding_status}</div>
+			<div className="mi-state">{void 0 === props.state ? <i className="non-available">N/A</i> : props.state}</div>
+			<div className="mi-views">{void 0 === props.views ? <i className="non-available">N/A</i> : props.views}</div>
+			<div className="mi-likes">{void 0 === props.likes ? <i className="non-available">N/A</i> : props.likes}</div>
+		</div>
+	);
+}
+
+ManageUploadItem.propTypes = {
+	token: PropTypes.string,
+	title: PropTypes.string,
+	url: PropTypes.string,
+	add_date: PropTypes.string,
+	media_type: PropTypes.string,
+	encoding_status: PropTypes.string,
+	state: PropTypes.string,
+	views: PropTypes.number,
+	likes: PropTypes.number,
+	onCheckRow: PropTypes.func,
+	selectedRow: PropTypes.bool.isRequired,
+	hideDeleteAction: PropTypes.bool.isRequired,
+};

--- a/frontend/src/static/js/components/-NEW-/ManageItem/ManageUploadItem.js
+++ b/frontend/src/static/js/components/-NEW-/ManageItem/ManageUploadItem.js
@@ -7,20 +7,20 @@ import { formatManagementTableDate } from '../../../functions/formatManagementTa
 import PageStore from '../../../pages/_PageStore.js';
 
 function ManageItemTitle(props) {
-	if (void 0 !== props.title && void 0 !== props.url) {
+	if (props.title && props.url) {
 		return (<a href={props.url} title={props.title}>{props.title}</a>);
 	}
-	if (void 0 !== props.title) {
+	if (props.title) {
 		return (props.title);
 	}
-	if (void 0 !== props.url) {
+	if (props.url) {
 		return (props.url);
 	}
 	return (<i className="non-available">N/A</i>);
 }
 
 function ManageItemDate(props) {
-	if (void 0 !== props.date) {
+	if (props.date) {
 		return (formatManagementTableDate(new Date(Date.parse(props.date))));
 	}
 	return (<i className="non-available">N/A</i>);
@@ -105,13 +105,13 @@ function ManageUploadItemActions(props) {
 	return (
 		<div ref={props.containerRef} className="actions">
 			<PopupTrigger contentRef={popupContentRef}>
-				<button title={'Delete' + (void 0 !== props.title ? ' "' + props.title + '"' : '')}>Delete</button>
+				<button title={'Delete' + (props.title ? ' "' + props.title + '"' : '')}>Delete</button>
 			</PopupTrigger>
 			<PopupContent contentRef={popupContentRef} showCallback={onPopupShow} hideCallback={onPopupHide}>
 				<PopupMain>
 					<div className="popup-message">
 						<span className="popup-message-title">Media removal</span>
-						<span className="popup-message-main">{"You're willing to remove media" + (void 0 !== props.title ? ' "' + props.title + '"' : '')}?</span>
+						<span className="popup-message-main">{"You're willing to remove media" + (props.title ? ' "' + props.title + '"' : '')}?</span>
 					</div>
 					<hr />
 					<span className="popup-message-bottom">
@@ -158,11 +158,11 @@ export function ManageUploadItem(props) {
 				{props.hideDeleteAction ? null : <ManageUploadItemActions containerRef={actionsContainerRef} title={props.title} onProceed={onClickProceed} />}
 			</div>
 			<div className="mi-added"><ManageItemDate date={props.add_date} /></div>
-			<div className="mi-type">{void 0 === props.media_type ? <i className="non-available">N/A</i> : props.media_type}</div>
-			<div className="mi-encoding">{void 0 === props.encoding_status ? <i className="non-available">N/A</i> : props.encoding_status}</div>
-			<div className="mi-state">{void 0 === props.state ? <i className="non-available">N/A</i> : props.state}</div>
-			<div className="mi-views">{void 0 === props.views ? <i className="non-available">N/A</i> : props.views}</div>
-			<div className="mi-likes">{void 0 === props.likes ? <i className="non-available">N/A</i> : props.likes}</div>
+			<div className="mi-type">{props.media_type !== undefined ? props.media_type : <i className="non-available">N/A</i>}</div>
+			<div className="mi-encoding">{props.encoding_status !== undefined ? props.encoding_status : <i className="non-available">N/A</i>}</div>
+			<div className="mi-state">{props.state !== undefined ? props.state : <i className="non-available">N/A</i>}</div>
+			<div className="mi-views">{props.views !== undefined ? props.views : <i className="non-available">N/A</i>}</div>
+			<div className="mi-likes">{props.likes !== undefined ? props.likes : <i className="non-available">N/A</i>}</div>
 		</div>
 	);
 }

--- a/frontend/src/static/js/components/-NEW-/ManageItem/ManageUploadItem.js
+++ b/frontend/src/static/js/components/-NEW-/ManageItem/ManageUploadItem.js
@@ -57,6 +57,11 @@ function ManageUploadItemActions(props) {
 		} else {
 			positionState.updating = true;
 
+			if (!props.containerRef.current) {
+				positionState.updating = false;
+				return;
+			}
+
 			const popupElem = props.containerRef.current.querySelector('.popup');
 
 			if (popupElem) {
@@ -90,6 +95,11 @@ function ManageUploadItemActions(props) {
 			PageStore.removeListener('window_scroll', onWindowResize);
 			PageStore.removeListener('window_resize', onWindowResize);
 		}
+
+		return () => {
+			PageStore.removeListener('window_scroll', onWindowResize);
+			PageStore.removeListener('window_resize', onWindowResize);
+		};
 	}, [isOpenPopup]);
 
 	return (

--- a/frontend/src/static/js/components/-NEW-/ManageItem/ManageUploadItemHeader.js
+++ b/frontend/src/static/js/components/-NEW-/ManageItem/ManageUploadItemHeader.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { MaterialIcon } from '../MaterialIcon.js';
+import { useManagementTableHeader } from './hooks/useManagementTableHeader';
+
+export function ManageUploadItemHeader(props) {
+	const [sort, order, isSelected, sortByColumn, checkAll] = useManagementTableHeader({ ...props, type: 'my-uploads' });
+
+	return (
+		<div className="item manage-item manage-item-header manage-upload-item">
+			<div className="mi-checkbox">
+				<input type="checkbox" checked={isSelected} onChange={checkAll} />
+			</div>
+			<div id="title" onClick={sortByColumn} className={'mi-title mi-col-sort' + ('title' === sort ? ('asc' === order ? ' asc' : ' desc') : '')}>
+				Title
+				<div className="mi-col-sort-icons"><span><MaterialIcon type="arrow_drop_up" /></span><span><MaterialIcon type="arrow_drop_down" /></span></div>
+			</div>
+			<div id="add_date" onClick={sortByColumn} className={'mi-added mi-col-sort' + ('add_date' === sort ? ('asc' === order ? ' asc' : ' desc') : '')}>
+				Date added
+				<div className="mi-col-sort-icons"><span><MaterialIcon type="arrow_drop_up" /></span><span><MaterialIcon type="arrow_drop_down" /></span></div>
+			</div>
+			<div className="mi-type">Media type</div>
+			<div className="mi-encoding">Encoding</div>
+			<div className="mi-state">State</div>
+			<div id="views" onClick={sortByColumn} className={'mi-views mi-col-sort' + ('views' === sort ? ('asc' === order ? ' asc' : ' desc') : '')}>
+				Views
+				<div className="mi-col-sort-icons"><span><MaterialIcon type="arrow_drop_up" /></span><span><MaterialIcon type="arrow_drop_down" /></span></div>
+			</div>
+			<div id="likes" onClick={sortByColumn} className={'mi-likes mi-col-sort' + ('likes' === sort ? ('asc' === order ? ' asc' : ' desc') : '')}>
+				Likes
+				<div className="mi-col-sort-icons"><span><MaterialIcon type="arrow_drop_up" /></span><span><MaterialIcon type="arrow_drop_down" /></span></div>
+			</div>
+		</div>
+	);
+}
+
+ManageUploadItemHeader.propTypes = {
+	sort: PropTypes.string.isRequired,
+	order: PropTypes.string.isRequired,
+	selected: PropTypes.bool.isRequired,
+	onClickColumnSort: PropTypes.func,
+	onCheckAllRows: PropTypes.func,
+};

--- a/frontend/src/static/js/components/-NEW-/ManageItemList/ManageItemList.js
+++ b/frontend/src/static/js/components/-NEW-/ManageItemList/ManageItemList.js
@@ -462,7 +462,7 @@ export function ManageItemList(props){
 
                 let entry;
 
-                if( 'media' === tableType ){
+                if( 'media' === tableType || 'my-uploads' === tableType ){
 
                     for(entry of items){
                         newSelected.push( entry.friendly_token );
@@ -589,8 +589,10 @@ export function ManageItemList(props){
 	}
 
 	useEffect(()=>{
-		// console.log('ITEMS:', items);
-	}, [items]);
+		if( 'function' === typeof props.onSelectionChange ){
+			props.onSelectionChange(selectedItems);
+		}
+	}, [selectedItems]);
 
 	useEffect(()=>{
 		if( parsedRequestUrl ){

--- a/frontend/src/static/js/components/-NEW-/ManageItemList/includes/functions.js
+++ b/frontend/src/static/js/components/-NEW-/ManageItemList/includes/functions.js
@@ -4,10 +4,12 @@ import ReactDOM from 'react-dom';
 import { ManageMediaItem } from '../../ManageItem/ManageMediaItem';
 import { ManageUsersItem } from '../../ManageItem/ManageUsersItem';
 import { ManageCommentsItem } from '../../ManageItem/ManageCommentsItem';
+import { ManageUploadItem } from '../../ManageItem/ManageUploadItem';
 
 import { ManageMediaItemHeader } from '../../ManageItem/ManageMediaItemHeader';
 import { ManageUsersItemHeader } from '../../ManageItem/ManageUsersItemHeader';
 import { ManageCommentsItemHeader } from '../../ManageItem/ManageCommentsItemHeader';
+import { ManageUploadItemHeader } from '../../ManageItem/ManageUploadItemHeader';
 
 function useManageItem(props){
 
@@ -85,6 +87,26 @@ function ListManageUserItem(props){
 	return( <ManageUsersItem {...args} /> );
 }
 
+function ListManageUploadItem(props){
+
+	const [ itemData, itemProps ] = useManageItem(props);
+
+	const args = {
+		...itemProps,
+		title: itemData.title,
+		url: itemData.url.replace( " ", "%20" ),
+		add_date: itemData.add_date,
+		media_type: itemData.media_type,
+		encoding_status: itemData.encoding_status,
+		state: itemData.state,
+		views: itemData.views,
+		likes: itemData.likes,
+		token: itemData.friendly_token,
+	};
+
+	return( <ManageUploadItem {...args} /> );
+}
+
 function ListManageCommentItem(props){
 
 	const [ itemData, itemProps ] = useManageItem(props);
@@ -125,6 +147,10 @@ function ListManageItem(props){
 		return <ListManageCommentItem {...args} selectedRow={ -1 < props.selectedItems.indexOf(props.item.uid) } />
 	}
 
+	if( 'my-uploads' === props.type ){
+		return <ListManageUploadItem {...args} selectedRow={ -1 < props.selectedItems.indexOf(props.item.friendly_token) } />
+	}
+
 	return null;
 }
 
@@ -151,6 +177,10 @@ function ListManageItemHeader(props){
 
 	if( 'comments' === props.type ){
 		return <ManageCommentsItemHeader {...args} />
+	}
+
+	if( 'my-uploads' === props.type ){
+		return <ManageUploadItemHeader {...args} />
 	}
 
 	return null;

--- a/frontend/src/static/js/mediacms/api.js
+++ b/frontend/src/static/js/mediacms/api.js
@@ -50,6 +50,7 @@ export function init(base_url, endpoints) {
 			media: endpoints.manage_media,
 			users: endpoints.manage_users,
 			comments: endpoints.manage_comments,
+			myUploads: endpoints.my_uploads,
 		},
 		search: {
 			query: endpoints.search + "?q=",

--- a/frontend/src/static/js/mediacms/config.js
+++ b/frontend/src/static/js/mediacms/config.js
@@ -89,6 +89,7 @@ export function config(glbl) {
 			media: !glbl.user.is.anonymous ? glbl.url.manageMedia : "",
 			users: !glbl.user.is.anonymous ? glbl.url.manageUsers : "",
 			comments: !glbl.user.is.anonymous ? glbl.url.manageComments : "",
+			uploads: !glbl.user.is.anonymous ? glbl.url.manageUploads : "",
 		},
 	});
 

--- a/frontend/src/static/js/mediacms/member.js
+++ b/frontend/src/static/js/mediacms/member.js
@@ -26,6 +26,7 @@ export function init( user, features ){
 			manageMedia: false,
 			manageUsers: false,
 			manageComments: false,
+			manageUploads: false,
 			reportMedia: false,
 			downloadMedia: false,
 			saveMedia: false,
@@ -70,6 +71,7 @@ export function init( user, features ){
 			MEMBER.can.manageMedia = true === user.can.manageMedia;
 			MEMBER.can.manageUsers = true === user.can.manageUsers;
 			MEMBER.can.manageComments = true === user.can.manageComments;
+			MEMBER.can.manageUploads = true === user.can.manageUploads;
 
 			MEMBER.can.contactUser = true === user.can.contactUser;
 

--- a/frontend/src/static/js/pages/ManageUploadsPage/ManageUploadsPage.scss
+++ b/frontend/src/static/js/pages/ManageUploadsPage/ManageUploadsPage.scss
@@ -94,45 +94,24 @@
 
 	.bulk-action-btn {
 		padding: 6px 12px;
-		border: 1px solid #ddd;
+		border: 1px solid var(--input-border-color);
 		border-radius: 4px;
-		background: #fff;
+		background: var(--input-bg-color);
+		color: var(--body-text-color);
 		cursor: pointer;
 		font-size: 13px;
 		transition: background-color 0.15s;
 
 		&:hover {
-			background: #f0f0f0;
+			background: var(--nav-menu-item-hover-bg-color);
 		}
 
 		&.bulk-action-delete {
-			color: #d32f2f;
-			border-color: #d32f2f;
+			color: var(--danger-color);
+			border-color: var(--danger-color);
 
 			&:hover {
-				background: #fce4ec;
-			}
-		}
-	}
-
-	.dark_theme & {
-
-		.bulk-action-btn {
-			background: #333;
-			border-color: #555;
-			color: #ddd;
-
-			&:hover {
-				background: #444;
-			}
-
-			&.bulk-action-delete {
-				color: #ef5350;
-				border-color: #ef5350;
-
-				&:hover {
-					background: #4a1a1a;
-				}
+				opacity: 0.85;
 			}
 		}
 	}
@@ -142,27 +121,16 @@
 
 	.mi-search-input {
 		padding: 6px 12px;
-		border: 1px solid #ddd;
+		border: 1px solid var(--input-border-color);
 		border-radius: 4px;
+		background: var(--input-bg-color);
+		color: var(--input-color);
 		font-size: 14px;
 		width: 200px;
 		outline: none;
 
 		&:focus {
 			border-color: var(--default-theme-color);
-		}
-	}
-
-	.dark_theme & {
-
-		.mi-search-input {
-			background: #333;
-			border-color: #555;
-			color: #ddd;
-
-			&:focus {
-				border-color: var(--default-theme-color);
-			}
 		}
 	}
 }

--- a/frontend/src/static/js/pages/ManageUploadsPage/ManageUploadsPage.scss
+++ b/frontend/src/static/js/pages/ManageUploadsPage/ManageUploadsPage.scss
@@ -1,0 +1,168 @@
+@import '../../../css/includes/_variables.scss';
+@import '../../../css/includes/_variables_dimensions.scss';
+@import '../../../css/config/index.scss';
+
+#page-manage-uploads {
+
+	.media-list-wrapper {
+		padding: 0 16px;
+
+		@media (min-width: 710px) {
+			padding: 0 24px;
+		}
+
+		max-width: calc(48px + calc(var(--default-item-width) * var(--default-max-row-items)));
+	}
+
+	.manage-items-list {
+		overflow: auto;
+	}
+
+	.items-list-outer {
+		position: relative;
+		display: block;
+	}
+
+	.items-list-wrap {
+		position: relative;
+		display: inline-block;
+		width: 100%;
+		min-height: 0;
+	}
+
+	.manage-upload-item {
+
+		> * {
+			width: (100/8) * 1%;
+			text-align: center;
+		}
+
+		.mi-title {
+			padding-left: 16px;
+			padding-right: 16px;
+			text-align: inherit;
+			font-weight: 500;
+		}
+
+		.mi-type,
+		.mi-encoding,
+		.mi-state {
+			text-transform: capitalize;
+		}
+
+		.mi-checkbox {
+			min-width: 48px;
+			width: 48px;
+		}
+
+		.mi-title {
+			min-width: 240px;
+			width: 100%;
+		}
+
+		.mi-added {
+			min-width: 120px;
+		}
+
+		.mi-encoding {
+			min-width: 120px;
+		}
+
+		.mi-state,
+		.mi-type {
+			min-width: 88px;
+		}
+
+		.mi-views,
+		.mi-likes {
+			min-width: 72px;
+		}
+	}
+}
+
+.manage-uploads-bulk-actions {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 8px 0;
+	flex-wrap: wrap;
+
+	.bulk-selected-count {
+		font-weight: 500;
+		margin-right: 8px;
+	}
+
+	.bulk-action-btn {
+		padding: 6px 12px;
+		border: 1px solid #ddd;
+		border-radius: 4px;
+		background: #fff;
+		cursor: pointer;
+		font-size: 13px;
+		transition: background-color 0.15s;
+
+		&:hover {
+			background: #f0f0f0;
+		}
+
+		&.bulk-action-delete {
+			color: #d32f2f;
+			border-color: #d32f2f;
+
+			&:hover {
+				background: #fce4ec;
+			}
+		}
+	}
+
+	.dark_theme & {
+
+		.bulk-action-btn {
+			background: #333;
+			border-color: #555;
+			color: #ddd;
+
+			&:hover {
+				background: #444;
+			}
+
+			&.bulk-action-delete {
+				color: #ef5350;
+				border-color: #ef5350;
+
+				&:hover {
+					background: #4a1a1a;
+				}
+			}
+		}
+	}
+}
+
+.mi-filter-search {
+
+	.mi-search-input {
+		padding: 6px 12px;
+		border: 1px solid #ddd;
+		border-radius: 4px;
+		font-size: 14px;
+		width: 200px;
+		outline: none;
+
+		&:focus {
+			border-color: var(--default-theme-color);
+		}
+	}
+
+	.dark_theme & {
+
+		.mi-search-input {
+			background: #333;
+			border-color: #555;
+			color: #ddd;
+
+			&:focus {
+				border-color: var(--default-theme-color);
+			}
+		}
+	}
+}

--- a/frontend/src/static/js/pages/ManageUploadsPage/components/BulkActions.jsx
+++ b/frontend/src/static/js/pages/ManageUploadsPage/components/BulkActions.jsx
@@ -1,33 +1,27 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
-export function UploadsBulkActions(props) {
-	const [selectedItemsSize, setSelectedItemsSize] = useState(props.selectedItemsSize);
+export function UploadsBulkActions({ selectedItemsSize, onBulkStateChange }) {
+	if (!selectedItemsSize) {
+		return null;
+	}
 
 	function onClickMakePrivate() {
-		if ('function' === typeof props.onBulkStateChange) {
-			props.onBulkStateChange('private');
+		if ('function' === typeof onBulkStateChange) {
+			onBulkStateChange('private');
 		}
 	}
 
 	function onClickMakePublic() {
-		if ('function' === typeof props.onBulkStateChange) {
-			props.onBulkStateChange('public');
+		if ('function' === typeof onBulkStateChange) {
+			onBulkStateChange('public');
 		}
 	}
 
 	function onClickMakeUnlisted() {
-		if ('function' === typeof props.onBulkStateChange) {
-			props.onBulkStateChange('unlisted');
+		if ('function' === typeof onBulkStateChange) {
+			onBulkStateChange('unlisted');
 		}
-	}
-
-	useEffect(() => {
-		setSelectedItemsSize(props.selectedItemsSize);
-	}, [props.selectedItemsSize]);
-
-	if (!selectedItemsSize) {
-		return null;
 	}
 
 	return (

--- a/frontend/src/static/js/pages/ManageUploadsPage/components/BulkActions.jsx
+++ b/frontend/src/static/js/pages/ManageUploadsPage/components/BulkActions.jsx
@@ -1,0 +1,46 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+
+export function UploadsBulkActions(props) {
+	const [selectedItemsSize, setSelectedItemsSize] = useState(props.selectedItemsSize);
+
+	function onClickMakePrivate() {
+		if ('function' === typeof props.onBulkStateChange) {
+			props.onBulkStateChange('private');
+		}
+	}
+
+	function onClickMakePublic() {
+		if ('function' === typeof props.onBulkStateChange) {
+			props.onBulkStateChange('public');
+		}
+	}
+
+	function onClickMakeUnlisted() {
+		if ('function' === typeof props.onBulkStateChange) {
+			props.onBulkStateChange('unlisted');
+		}
+	}
+
+	useEffect(() => {
+		setSelectedItemsSize(props.selectedItemsSize);
+	}, [props.selectedItemsSize]);
+
+	if (!selectedItemsSize) {
+		return null;
+	}
+
+	return (
+		<div className="manage-uploads-bulk-actions">
+			<span className="bulk-selected-count">{selectedItemsSize} selected</span>
+			<button className="bulk-action-btn bulk-action-private" onClick={onClickMakePrivate}>Make Private</button>
+			<button className="bulk-action-btn bulk-action-public" onClick={onClickMakePublic}>Make Public</button>
+			<button className="bulk-action-btn bulk-action-unlisted" onClick={onClickMakeUnlisted}>Make Unlisted</button>
+		</div>
+	);
+}
+
+UploadsBulkActions.propTypes = {
+	selectedItemsSize: PropTypes.number.isRequired,
+	onBulkStateChange: PropTypes.func,
+};

--- a/frontend/src/static/js/pages/ManageUploadsPage/components/UploadFilters.jsx
+++ b/frontend/src/static/js/pages/ManageUploadsPage/components/UploadFilters.jsx
@@ -22,10 +22,9 @@ const filters = {
 	],
 };
 
-export function UploadFilters(props) {
-	props = { hidden: false, ...props };
+export function UploadFilters({ hidden = false, onFiltersUpdate }) {
 
-	const [isHidden, setIsHidden] = useState(props.hidden);
+	const [isHidden, setIsHidden] = useState(hidden);
 
 	const [state, setState] = useState('all');
 	const [encodingStatus, setEncodingStatus] = useState('all');
@@ -51,12 +50,12 @@ export function UploadFilters(props) {
 		switch (ev.currentTarget.getAttribute('filter')) {
 			case 'state':
 				args.state = ev.currentTarget.getAttribute('value');
-				props.onFiltersUpdate(args);
+				onFiltersUpdate(args);
 				setState(args.state);
 				break;
 			case 'encoding_status':
 				args.encoding_status = ev.currentTarget.getAttribute('value');
-				props.onFiltersUpdate(args);
+				onFiltersUpdate(args);
 				setEncodingStatus(args.encoding_status);
 				break;
 		}
@@ -77,14 +76,14 @@ export function UploadFilters(props) {
 				encoding_status: encodingStatus,
 				search: encodeURIComponent(val),
 			};
-			props.onFiltersUpdate(args);
+			onFiltersUpdate(args);
 		}, 300);
 	}
 
 	useEffect(() => {
-		setIsHidden(props.hidden);
+		setIsHidden(hidden);
 		onWindowResize();
-	}, [props.hidden]);
+	}, [hidden]);
 
 	useEffect(() => {
 		PageStore.on('window_resize', onWindowResize);

--- a/frontend/src/static/js/pages/ManageUploadsPage/components/UploadFilters.jsx
+++ b/frontend/src/static/js/pages/ManageUploadsPage/components/UploadFilters.jsx
@@ -1,0 +1,138 @@
+import React, { useState, useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
+
+import { FilterOptions } from '../../../components/-NEW-/FilterOptions';
+import PageStore from '../../_PageStore.js';
+
+import '../../../components/styles/ManageItemList-filters.scss';
+
+const filters = {
+	state: [
+		{ id: 'all', title: 'All' },
+		{ id: 'public', title: 'Public' },
+		{ id: 'private', title: 'Private' },
+		{ id: 'unlisted', title: 'Unlisted' },
+	],
+	encoding_status: [
+		{ id: 'all', title: 'All' },
+		{ id: 'success', title: 'Success' },
+		{ id: 'running', title: 'Running' },
+		{ id: 'pending', title: 'Pending' },
+		{ id: 'fail', title: 'Fail' },
+	],
+};
+
+export function UploadFilters(props) {
+	props = { hidden: false, ...props };
+
+	const [isHidden, setIsHidden] = useState(props.hidden);
+
+	const [state, setState] = useState('all');
+	const [encodingStatus, setEncodingStatus] = useState('all');
+	const [searchValue, setSearchValue] = useState('');
+
+	const containerRef = useRef(null);
+	const innerContainerRef = useRef(null);
+	const searchTimeoutRef = useRef(null);
+
+	function onWindowResize() {
+		if (!isHidden) {
+			containerRef.current.style.height = (24 + innerContainerRef.current.offsetHeight) + 'px';
+		}
+	}
+
+	function onFilterSelect(ev) {
+		const args = {
+			state: state,
+			encoding_status: encodingStatus,
+			search: encodeURIComponent(searchValue),
+		};
+
+		switch (ev.currentTarget.getAttribute('filter')) {
+			case 'state':
+				args.state = ev.currentTarget.getAttribute('value');
+				props.onFiltersUpdate(args);
+				setState(args.state);
+				break;
+			case 'encoding_status':
+				args.encoding_status = ev.currentTarget.getAttribute('value');
+				props.onFiltersUpdate(args);
+				setEncodingStatus(args.encoding_status);
+				break;
+		}
+	}
+
+	function onSearchChange(ev) {
+		const val = ev.target.value;
+		setSearchValue(val);
+
+		if (searchTimeoutRef.current) {
+			clearTimeout(searchTimeoutRef.current);
+		}
+
+		searchTimeoutRef.current = setTimeout(function () {
+			searchTimeoutRef.current = null;
+			const args = {
+				state: state,
+				encoding_status: encodingStatus,
+				search: encodeURIComponent(val),
+			};
+			props.onFiltersUpdate(args);
+		}, 300);
+	}
+
+	useEffect(() => {
+		setIsHidden(props.hidden);
+		onWindowResize();
+	}, [props.hidden]);
+
+	useEffect(() => {
+		PageStore.on('window_resize', onWindowResize);
+		return () => {
+			PageStore.removeListener('window_resize', onWindowResize);
+			if (searchTimeoutRef.current) {
+				clearTimeout(searchTimeoutRef.current);
+			}
+		};
+	}, []);
+
+	return (
+		<div ref={containerRef} className={"mi-filters-row" + (isHidden ? ' hidden' : '')}>
+			<div ref={innerContainerRef} className="mi-filters-row-inner">
+
+				<div className="mi-filter mi-filter-search">
+					<div className="mi-filter-title">SEARCH</div>
+					<div className="mi-filter-options">
+						<input
+							type="text"
+							placeholder="Search by title..."
+							value={searchValue}
+							onChange={onSearchChange}
+							className="mi-search-input"
+						/>
+					</div>
+				</div>
+
+				<div className="mi-filter">
+					<div className="mi-filter-title">STATE</div>
+					<div className="mi-filter-options">
+						<FilterOptions id={'state'} options={filters.state} selected={state} onSelect={onFilterSelect} />
+					</div>
+				</div>
+
+				<div className="mi-filter">
+					<div className="mi-filter-title">ENCODING STATUS</div>
+					<div className="mi-filter-options">
+						<FilterOptions id={'encoding_status'} options={filters.encoding_status} selected={encodingStatus} onSelect={onFilterSelect} />
+					</div>
+				</div>
+
+			</div>
+		</div>
+	);
+}
+
+UploadFilters.propTypes = {
+	hidden: PropTypes.bool,
+	onFiltersUpdate: PropTypes.func.isRequired,
+};

--- a/frontend/src/static/js/pages/ManageUploadsPage/index.jsx
+++ b/frontend/src/static/js/pages/ManageUploadsPage/index.jsx
@@ -1,0 +1,194 @@
+import React from 'react';
+
+import ApiUrlContext from '../../contexts/ApiUrlContext';
+
+import { Page } from '../_Page';
+import * as PageActions from '../_PageActions';
+
+import { MediaListWrapper } from '../components/MediaListWrapper';
+
+import { FiltersToggleButton } from '../../components/-NEW-/FiltersToggleButton';
+import { ManageItemList } from '../../components/-NEW-/ManageItemList/ManageItemList';
+
+import { UploadFilters } from './components/UploadFilters';
+import { UploadsBulkActions } from './components/BulkActions';
+
+import getCSRFToken from '../../functions/getCSRFToken';
+import postRequest from '../../functions/postRequest';
+
+import './ManageUploadsPage.scss';
+
+function genReqUrl(url, filters, sort, page) {
+	return url + '?' + filters + ('' === filters ? '' : '&') + sort + ('' === sort ? '' : '&') + 'page=' + page;
+}
+
+export class ManageUploadsPage extends Page {
+
+	constructor(props) {
+		super(props, 'manage-uploads');
+
+		this.state = {
+			resultsCount: null,
+			currentPage: 1,
+			requestUrl: ApiUrlContext._currentValue.manage.myUploads,
+			pageTitle: props.title,
+			hiddenFilters: true,
+			filterArgs: '',
+			sortingArgs: '',
+			sortBy: 'add_date',
+			ordering: 'desc',
+			refresh: 0,
+			selectedTokens: [],
+		};
+
+		this.getCountFunc = this.getCountFunc.bind(this);
+		this.onTablePageChange = this.onTablePageChange.bind(this);
+		this.onToggleFiltersClick = this.onToggleFiltersClick.bind(this);
+		this.onFiltersUpdate = this.onFiltersUpdate.bind(this);
+		this.onColumnSortClick = this.onColumnSortClick.bind(this);
+		this.onItemsRemoval = this.onItemsRemoval.bind(this);
+		this.onItemsRemovalFail = this.onItemsRemovalFail.bind(this);
+		this.onSelectionChange = this.onSelectionChange.bind(this);
+		this.onBulkStateChange = this.onBulkStateChange.bind(this);
+	}
+
+	onTablePageChange(newPageUrl, updatedPage) {
+		this.setState({
+			currentPage: updatedPage,
+			requestUrl: genReqUrl(ApiUrlContext._currentValue.manage.myUploads, this.state.filterArgs, this.state.sortingArgs, updatedPage),
+		});
+	}
+
+	onToggleFiltersClick() {
+		this.setState({
+			hiddenFilters: !this.state.hiddenFilters,
+		});
+	}
+
+	getCountFunc(resultsCount) {
+		this.setState({
+			resultsCount: resultsCount,
+		});
+	}
+
+	onFiltersUpdate(updatedArgs) {
+		const newArgs = [];
+
+		for (let arg in updatedArgs) {
+			if (null !== updatedArgs[arg] && 'all' !== updatedArgs[arg] && '' !== updatedArgs[arg]) {
+				newArgs.push(arg + '=' + updatedArgs[arg]);
+			}
+		}
+
+		this.setState({
+			filterArgs: newArgs.join('&'),
+			currentPage: 1,
+			requestUrl: genReqUrl(ApiUrlContext._currentValue.manage.myUploads, newArgs.join('&'), this.state.sortingArgs, 1),
+		});
+	}
+
+	onColumnSortClick(sort, order) {
+		const newArgs = 'sort_by=' + sort + '&ordering=' + order;
+		this.setState({
+			sortBy: sort,
+			ordering: order,
+			sortingArgs: newArgs,
+			requestUrl: genReqUrl(ApiUrlContext._currentValue.manage.myUploads, this.state.filterArgs, newArgs, this.state.currentPage),
+		});
+	}
+
+	onItemsRemoval() {
+		this.setState({
+			resultsCount: null,
+			selectedTokens: [],
+			refresh: this.state.refresh + 1,
+			requestUrl: ApiUrlContext._currentValue.manage.myUploads,
+		}, function () {
+			PageActions.addNotification("The media deleted successfully.", 'mediaRemovalSucceed');
+		});
+	}
+
+	onItemsRemovalFail() {
+		PageActions.addNotification("The media removal failed. Please try again.", 'mediaRemovalFailed');
+	}
+
+	onSelectionChange(selectedItems) {
+		this.setState({
+			selectedTokens: selectedItems,
+		});
+	}
+
+	onBulkStateChange(newState) {
+		const tokens = this.state.selectedTokens;
+
+		if (!tokens.length) {
+			return;
+		}
+
+		const self = this;
+
+		postRequest(
+			ApiUrlContext._currentValue.manage.myUploads + '/bulk_state',
+			{
+				tokens: tokens,
+				state: newState,
+			},
+			{
+				headers: {
+					'X-CSRFToken': getCSRFToken(),
+					'Content-Type': 'application/json',
+				},
+			},
+			false,
+			function (response) {
+				if (response && response.data && response.data.updated) {
+					self.setState({
+						resultsCount: null,
+						selectedTokens: [],
+						refresh: self.state.refresh + 1,
+						requestUrl: ApiUrlContext._currentValue.manage.myUploads,
+					}, function () {
+						PageActions.addNotification(
+							response.data.updated + ' item' + (response.data.updated > 1 ? 's' : '') + ' changed to ' + newState + '.',
+							'bulkStateChangeSucceed'
+						);
+					});
+				}
+			},
+			function () {
+				PageActions.addNotification("State change failed. Please try again.", 'bulkStateChangeFailed');
+			}
+		);
+	}
+
+	pageContent() {
+		return (
+			<MediaListWrapper title={this.state.pageTitle + (null === this.state.resultsCount ? '' : ' (' + this.state.resultsCount + ')')} className="">
+				<UploadsBulkActions
+					selectedItemsSize={this.state.selectedTokens.length}
+					onBulkStateChange={this.onBulkStateChange}
+				/>
+				<FiltersToggleButton onClick={this.onToggleFiltersClick} />
+				<UploadFilters hidden={this.state.hiddenFilters} onFiltersUpdate={this.onFiltersUpdate} />
+				<ManageItemList
+					pageItems={50}
+					manageType={'my-uploads'}
+					key={this.state.requestUrl + '[' + this.state.refresh + ']'}
+					requestUrl={this.state.requestUrl}
+					itemsCountCallback={this.getCountFunc}
+					onPageChange={this.onTablePageChange}
+					sortBy={this.state.sortBy}
+					ordering={this.state.ordering}
+					onRowsDelete={this.onItemsRemoval}
+					onRowsDeleteFail={this.onItemsRemovalFail}
+					onClickColumnSort={this.onColumnSortClick}
+					onSelectionChange={this.onSelectionChange}
+				/>
+			</MediaListWrapper>
+		);
+	}
+}
+
+ManageUploadsPage.defaultProps = {
+	title: 'Manage uploads',
+};

--- a/frontend/src/static/js/pages/ProfilePage/includes/ProfilePagesHeader.js
+++ b/frontend/src/static/js/pages/ProfilePage/includes/ProfilePagesHeader.js
@@ -367,7 +367,7 @@ class NavMenuInlineTabs extends React.PureComponent {
 							link={LinksContext._currentValue.profile.home}
 						/>
 
-						{this.userIsAuthor && UserContext._currentValue.can.manageUploads && LinksContext._currentValue.manage && LinksContext._currentValue.manage.uploads ? (
+						{this.userIsAuthor && UserContext._currentValue.can.manageUploads && LinksContext._currentValue.manage?.uploads ? (
 							<InlineTab
 								id="manage-uploads"
 								isActive={false}

--- a/frontend/src/static/js/pages/ProfilePage/includes/ProfilePagesHeader.js
+++ b/frontend/src/static/js/pages/ProfilePage/includes/ProfilePagesHeader.js
@@ -367,6 +367,15 @@ class NavMenuInlineTabs extends React.PureComponent {
 							link={LinksContext._currentValue.profile.home}
 						/>
 
+						{this.userIsAuthor && UserContext._currentValue.can.manageUploads && LinksContext._currentValue.manage && LinksContext._currentValue.manage.uploads ? (
+							<InlineTab
+								id="manage-uploads"
+								isActive={false}
+								label="Manage Uploads"
+								link={LinksContext._currentValue.manage.uploads}
+							/>
+						) : null}
+
 						{UserContext._currentValue.can.saveMedia ? (
 							<InlineTab
 								id="playlists"

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -89,6 +89,7 @@ export default defineConfig({
 				'manage-media': 'src/entries/manage-media.js',
 				'manage-users': 'src/entries/manage-users.js',
 				'manage-comments': 'src/entries/manage-comments.js',
+				'manage-uploads': 'src/entries/manage-uploads.js',
 				'profile-home': 'src/entries/profile-home.js',
 				'profile-about': 'src/entries/profile-about.js',
 				'profile-playlists': 'src/entries/profile-playlists.js',

--- a/templates/cms/manage_uploads.html
+++ b/templates/cms/manage_uploads.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+{% load static %}
+{% load django_vite %}
+
+{% block headtitle %}Manage uploads - {{PORTAL_NAME}}{% endblock headtitle %}
+
+{% block headermeta %}
+
+<meta property="og:title" content="Manage uploads - {{PORTAL_NAME}}">
+<meta property="og:type" content="website">
+<meta property="og:description" content="">
+
+{% endblock headermeta %}
+
+{% block topimports %}{% vite_asset 'src/entries/manage-uploads.js' %}{% endblock topimports %}
+
+{% block content %}<div id="page-manage-uploads"></div>{% endblock %}

--- a/templates/config/core/api.html
+++ b/templates/config/core/api.html
@@ -16,4 +16,5 @@ MediaCMS.api = {
     {% if IS_MEDIACMS_ADMIN or IS_MEDIACMS_MANAGER or IS_MEDIACMS_EDITOR %}manage_media: '/manage_media',{% endif %}
     {% if IS_MEDIACMS_ADMIN or IS_MEDIACMS_MANAGER %}manage_users: '/manage_users',{% endif %}
     {% if IS_MEDIACMS_ADMIN or IS_MEDIACMS_MANAGER or IS_MEDIACMS_EDITOR %}manage_comments: '/manage_comments',{% endif %}
+    {% if CAN_MANAGE_UPLOADS %}my_uploads: '/my_uploads',{% endif %}
 };

--- a/templates/config/core/url.html
+++ b/templates/config/core/url.html
@@ -30,6 +30,7 @@ MediaCMS.url = {
     {% if IS_MEDIACMS_ADMIN or IS_MEDIACMS_MANAGER or IS_MEDIACMS_EDITOR %}manageMedia: "{{FRONTEND_HOST}}/manage/media",{% endif %}
     {% if IS_MEDIACMS_ADMIN or IS_MEDIACMS_MANAGER %}manageUsers: "{{FRONTEND_HOST}}/manage/users",{% endif %}
     {% if IS_MEDIACMS_ADMIN or IS_MEDIACMS_MANAGER or IS_MEDIACMS_EDITOR %}manageComments: "{{FRONTEND_HOST}}/manage/comments",{% endif %}
+    {% if CAN_MANAGE_UPLOADS %}manageUploads: "{{FRONTEND_HOST}}/manage/uploads",{% endif %}
     {% else %}
     signin: "{{FRONTEND_HOST}}/accounts/login/",
     register: "{{FRONTEND_HOST}}/accounts/signup/",

--- a/templates/config/core/user.html
+++ b/templates/config/core/user.html
@@ -21,6 +21,7 @@ MediaCMS.user = {
 		manageMedia: {% if IS_MEDIACMS_ADMIN or IS_MEDIACMS_MANAGER or IS_MEDIACMS_EDITOR %}true{% else %}false{% endif %},
 		manageUsers: {% if IS_MEDIACMS_ADMIN or IS_MEDIACMS_MANAGER %}true{% else %}false{% endif %},
 		manageComments: {% if IS_MEDIACMS_ADMIN or IS_MEDIACMS_MANAGER or IS_MEDIACMS_EDITOR %}true{% else %}false{% endif %},
+		manageUploads: {% if CAN_MANAGE_UPLOADS %}true{% else %}false{% endif %},
 		contactUser: {% if SHOW_CONTACT_FORM or IS_MEDIACMS_ADMIN or IS_MEDIACMS_MANAGER or IS_MEDIACMS_EDITOR %}true{% else %}false{% endif %},
 	}{% if request.user.is_authenticated %},
 	pages: {


### PR DESCRIPTION
## Description

Add a user-scoped "Manage Uploads" page where Trusted Users, Editors, Managers, and Admins can bulk-manage their own video uploads with filtering, sorting, bulk state changes, and bulk delete.

**Backend:**
- `can_manage_uploads()` permission helper and `IsManageUploadsUser` permission class
- `MyUploadsList` API — GET with filters (state, encoding status, title search), sorting, pagination; DELETE with ownership-scoped bulk delete
- `MyUploadsBulkState` API — POST with atomic ownership verification (`select_for_update` + `transaction.atomic`) for bulk state changes (private/public/unlisted)
- Page view with anonymous redirect and MFA check
- Composite DB indexes on `(user, state, add_date)` and `(user, encoding_status)`

**Frontend:**
- `ManageUploadsPage` extending existing `ManageItemList` pattern via `manageType='my-uploads'`
- `ManageUploadItem` / `ManageUploadItemHeader` — simplified table row (no author/reviewed/featured columns, adds views/likes)
- `UploadFilters` — search input with debounce, state dropdown, encoding status dropdown
- `UploadsBulkActions` — Make Private / Make Public / Make Unlisted buttons (delete uses existing ManageItemList dropdown)
- "Manage Uploads" tab on profile page (own profile only, gated by `canManageUploads`)
- Full config plumbing: `api.html`, `url.html`, `user.html`, `api.js`, `config.js`, `member.js`

**Security:**
- All queries scoped to `user=request.user` at ORM level — no path to access other users' data
- Bulk state uses `transaction.atomic()` + `select_for_update()` to prevent TOCTOU races
- Count verification prevents IDOR on bulk operations (rejects if any token is not owned)
- Token deduplication, state validation (only private/public/unlisted), search value URL encoding

## Related Issue

Fixes #402

## Motivation and Context

Users currently manage uploads one-by-one through individual "Edit Media" pages. Power users (filmmakers, festival organizers, advocacy groups) with 50–200+ uploads need bulk operations for visibility changes, cleanup of failed/test content, and filtering by encoding status — all in one place.

## How Has This Been Tested?

**20 automated tests** (`files/tests/test_my_uploads.py`) cover permissions, ownership scoping, bulk operations, filters, and input validation. The manual QA plan below covers UI interactions that automated tests can't verify.

## QA Test Plan

**Setup:** Two accounts — User A (Trusted User or Admin, with 5+ uploads in mixed states) and User B (regular user).

### Core Flows

| # | Test | Steps | Expected |
|---|------|-------|----------|
| 1 | Access & visibility | Log in as User A → profile → click "Manage Uploads" tab | Page loads at `/manage/uploads`, shows only User A's uploads |
| 2 | Denied access | Log in as User B → visit `/manage/uploads` | Redirected to `/`. Tab not visible on profile |
| 3 | Filter + search | Toggle filters → select a state → type in search box | Results update correctly, filters combine |
| 4 | Sort columns | Click "Title", "Date added", "Views", "Likes" headers | Rows reorder; click again reverses direction |
| 5 | Bulk state change | Select 2+ items → click "Make Private" | Items change state, success notification |
| 6 | Bulk delete | Select items → "Bulk actions" dropdown → "Delete selected" → Apply → PROCEED | Confirmation popup → items removed |
| 7 | Delete cancel | Click "Delete" on a row → CANCEL | Item unchanged |
| 8 | Pagination | Have 51+ uploads → navigate pages | Pages load correctly |
| 9 | Other user's profile | Log in as User A → visit User B's profile | "Manage Uploads" tab not shown |
| 10 | Dark theme | Switch to dark theme → visit Manage Uploads | All elements render with correct theme colors |

## Screenshots
<img width="1800" height="1086" alt="image" src="https://github.com/user-attachments/assets/caf516f8-3dbf-45cf-b3cb-dd96ae08a40d" />

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):
- [x] I have not imported `flux` in a new component
- [x] If adding a new feature, I used Modern Track patterns
- [ ] New features do not create new SCSS files (use Tailwind instead)

> Note: SCSS was used for the manage uploads page styles to stay consistent with existing `ManageItemList.scss` patterns. The existing admin manage pages all use SCSS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manage Uploads page: list, sort, search, filters (state, encoding), per-item controls, selection, pagination and bulk actions (delete, change privacy); profile shows "Manage uploads" tab when available.
  * Client exposes manage-uploads UI, endpoint, and permission flag to the frontend.

* **Chores**
  * Added database indexes to speed personal upload listings.

* **Tests**
  * Added tests covering permissions, ownership, filtering, bulk delete and bulk-state updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


