### PR TITLE
feat: add opt-in AES-128 HLS encryption for filmmaker-controlled access (#472)

### DIFF
--- a/files/forms.py
+++ b/files/forms.py
@@ -70,6 +70,7 @@ class MediaForm(forms.ModelForm):
             "state",
             "password",
             "allow_download",
+            "is_encrypted",
         ]
 
         widgets = {
@@ -107,6 +108,7 @@ class MediaForm(forms.ModelForm):
 
         self.fields["state"].label = "Status"
         self.fields["allow_download"].label = "Allow Download"
+        self.fields["is_encrypted"].label = "Enable HLS Encryption"
         self.fields["reported_times"].label = "Reported Times"
         self.fields["enable_comments"].label = "Enable Comments"
         self.fields["new_tags"].label = "Tags"
@@ -144,10 +146,14 @@ class MediaForm(forms.ModelForm):
             self.fields.pop("is_reviewed")
             self.fields.pop("add_date")
 
+        if self.instance.media_type != "video":
+            self.fields.pop("is_encrypted", None)
+
         if not is_mediacms_editor(user):
             if not user.advancedUser:
                 self.fields.pop("media_file")
                 self.fields.pop("password")
+                self.fields.pop("is_encrypted", None)
                 self.fields["state"]
                 self.fields["state"] = forms.ChoiceField(
                     choices=MEDIA_STATES,

--- a/files/migrations/0017_add_hls_encryption_fields.py
+++ b/files/migrations/0017_add_hls_encryption_fields.py
@@ -1,0 +1,32 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("files", "0016_add_encoding_drain_composite_index"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="media",
+            name="is_encrypted",
+            field=models.BooleanField(default=False, help_text="Enable AES-128 encryption for HLS streaming"),
+        ),
+        migrations.AddField(
+            model_name="media",
+            name="encryption_key",
+            field=models.CharField(blank=True, help_text="Hex-encoded AES-128 encryption key", max_length=64),
+        ),
+        migrations.AddField(
+            model_name="media",
+            name="offline_access",
+            field=models.CharField(
+                blank=True,
+                choices=[("stream_only", "Stream Only"), ("offline", "Offline")],
+                default="stream_only",
+                help_text="Controls whether offline playback is allowed",
+                max_length=20,
+            ),
+        ),
+    ]

--- a/files/migrations/0017_add_hls_encryption_fields.py
+++ b/files/migrations/0017_add_hls_encryption_fields.py
@@ -1,3 +1,4 @@
+import django.core.validators
 from django.db import migrations, models
 
 
@@ -16,7 +17,17 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="media",
             name="encryption_key",
-            field=models.CharField(blank=True, help_text="Hex-encoded AES-128 encryption key", max_length=64),
+            field=models.CharField(
+                blank=True,
+                help_text="Hex-encoded AES-128 encryption key",
+                max_length=32,
+                validators=[
+                    django.core.validators.RegexValidator(
+                        message="Must be blank or exactly 32 hex characters",
+                        regex="^(?:[0-9A-Fa-f]{32})?$",
+                    )
+                ],
+            ),
         ),
         migrations.AddField(
             model_name="media",

--- a/files/migrations/0018_add_hls_encryption_fields.py
+++ b/files/migrations/0018_add_hls_encryption_fields.py
@@ -29,15 +29,4 @@ class Migration(migrations.Migration):
                 ],
             ),
         ),
-        migrations.AddField(
-            model_name="media",
-            name="offline_access",
-            field=models.CharField(
-                blank=True,
-                choices=[("stream_only", "Stream Only"), ("offline", "Offline")],
-                default="stream_only",
-                help_text="Controls whether offline playback is allowed",
-                max_length=20,
-            ),
-        ),
     ]

--- a/files/migrations/0018_add_hls_encryption_fields.py
+++ b/files/migrations/0018_add_hls_encryption_fields.py
@@ -5,7 +5,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("files", "0016_add_encoding_drain_composite_index"),
+        ("files", "0017_add_my_uploads_indexes"),
     ]
 
     operations = [

--- a/files/models.py
+++ b/files/models.py
@@ -298,6 +298,7 @@ class Media(models.Model):
         choices=[("stream_only", "Stream Only"), ("offline", "Offline")],
         default="stream_only",
         blank=True,
+        help_text="Controls whether offline playback is allowed",
     )
     # keep track if media file has changed
     company = models.CharField("Production Company", max_length=300, blank=True, null=True)

--- a/files/models.py
+++ b/files/models.py
@@ -285,6 +285,14 @@ class Media(models.Model):
         help_text="In case existing URLs of media exist, for use in migrations",
     )
     hls_file = models.CharField(max_length=1000, blank=True)
+    is_encrypted = models.BooleanField(default=False, help_text="Enable AES-128 encryption for HLS streaming")
+    encryption_key = models.CharField(max_length=64, blank=True, help_text="Hex-encoded AES-128 encryption key")
+    offline_access = models.CharField(
+        max_length=20,
+        choices=[("stream_only", "Stream Only"), ("offline", "Offline")],
+        default="stream_only",
+        blank=True,
+    )
     # keep track if media file has changed
     company = models.CharField("Production Company", max_length=300, blank=True, null=True)
     website = models.CharField("Website", max_length=300, blank=True, null=True)
@@ -297,6 +305,7 @@ class Media(models.Model):
     __original_uploaded_poster = None
     __original_state = None
     __original_password = None
+    __original_is_encrypted = None
 
     class Meta:
         ordering = ["-add_date"]
@@ -331,6 +340,7 @@ class Media(models.Model):
         self.__original_uploaded_poster = self.uploaded_poster
         self.__original_state = self.state
         self.__original_password = self.password
+        self.__original_is_encrypted = self.is_encrypted
 
     def save(self, *args, **kwargs):
         if not self.title:
@@ -383,6 +393,13 @@ class Media(models.Model):
             self._invalidate_permission_cache()
             self.__original_state = self.state
             self.__original_password = self.password
+        # Re-generate HLS if encryption was toggled (guard against None on first save)
+        if self.pk and self.__original_is_encrypted is not None and self.is_encrypted != self.__original_is_encrypted:
+            self.__original_is_encrypted = self.is_encrypted
+            if self.encodings.filter(profile__extension="mp4", status="success", chunk=False, profile__codec="h264").exists():
+                from . import tasks
+
+                tasks.create_hls.delay(self.friendly_token)
         # has to save first for uploaded_poster path to exist
         if self.uploaded_poster and self.uploaded_poster != self.__original_uploaded_poster:
             with open(self.uploaded_poster.path, "rb") as f:
@@ -390,6 +407,15 @@ class Media(models.Model):
                 myfile = File(f)
                 thumbnail_name = helpers.get_file_name(self.uploaded_poster.path)
                 self.uploaded_thumbnail.save(content=myfile, name=thumbnail_name)
+
+    def ensure_encryption_key(self):
+        """Generate an AES-128 key if one doesn't exist. Returns hex string."""
+        if not self.encryption_key:
+            import secrets
+
+            self.encryption_key = secrets.token_hex(16)
+            self.save(update_fields=["encryption_key"])
+        return self.encryption_key
 
     def transcribe_function(self):
         can_transcribe = False

--- a/files/models.py
+++ b/files/models.py
@@ -13,6 +13,7 @@ from django.conf import settings
 from django.contrib.postgres.indexes import GinIndex
 from django.contrib.postgres.search import SearchVectorField
 from django.core.files import File
+from django.core.validators import RegexValidator
 from django.db import connection, models
 from django.db.models import Q
 from django.db.models.signals import (
@@ -286,7 +287,12 @@ class Media(models.Model):
     )
     hls_file = models.CharField(max_length=1000, blank=True)
     is_encrypted = models.BooleanField(default=False, help_text="Enable AES-128 encryption for HLS streaming")
-    encryption_key = models.CharField(max_length=64, blank=True, help_text="Hex-encoded AES-128 encryption key")
+    encryption_key = models.CharField(
+        max_length=32,
+        blank=True,
+        validators=[RegexValidator(regex=r"^(?:[0-9A-Fa-f]{32})?$", message="Must be blank or exactly 32 hex characters")],
+        help_text="Hex-encoded AES-128 encryption key",
+    )
     offline_access = models.CharField(
         max_length=20,
         choices=[("stream_only", "Stream Only"), ("offline", "Offline")],
@@ -409,12 +415,28 @@ class Media(models.Model):
                 self.uploaded_thumbnail.save(content=myfile, name=thumbnail_name)
 
     def ensure_encryption_key(self):
-        """Generate an AES-128 key if one doesn't exist. Returns hex string."""
-        if not self.encryption_key:
-            import secrets
+        """Generate an AES-128 key if one doesn't exist. Returns hex string.
+
+        Uses select_for_update to prevent concurrent workers from generating
+        different keys for the same media.
+        """
+        if self.encryption_key:
+            return self.encryption_key
+
+        import secrets
+
+        from django.db import transaction
+
+        with transaction.atomic():
+            locked = self.__class__.objects.select_for_update().get(pk=self.pk)
+            if locked.encryption_key:
+                self.encryption_key = locked.encryption_key
+                return self.encryption_key
 
             self.encryption_key = secrets.token_hex(16)
-            self.save(update_fields=["encryption_key"])
+            locked.encryption_key = self.encryption_key
+            locked.save(update_fields=["encryption_key"])
+
         return self.encryption_key
 
     def transcribe_function(self):

--- a/files/models.py
+++ b/files/models.py
@@ -293,13 +293,6 @@ class Media(models.Model):
         validators=[RegexValidator(regex=r"^(?:[0-9A-Fa-f]{32})?$", message="Must be blank or exactly 32 hex characters")],
         help_text="Hex-encoded AES-128 encryption key",
     )
-    offline_access = models.CharField(
-        max_length=20,
-        choices=[("stream_only", "Stream Only"), ("offline", "Offline")],
-        default="stream_only",
-        blank=True,
-        help_text="Controls whether offline playback is allowed",
-    )
     # keep track if media file has changed
     company = models.CharField("Production Company", max_length=300, blank=True, null=True)
     website = models.CharField("Website", max_length=300, blank=True, null=True)

--- a/files/secure_media_views.py
+++ b/files/secure_media_views.py
@@ -28,6 +28,121 @@ from .models import Encoding, Media, Subtitle
 
 logger = logging.getLogger(__name__)
 
+
+# --- Standalone permission functions (used by SecureMediaView and MediaKeyView) ---
+
+
+def user_has_elevated_access(user, media: Media) -> bool:
+    """Check if user is owner, editor, or manager with caching. Assumes user is authenticated."""
+    if not user.is_authenticated:
+        return False
+
+    cache_key = get_elevated_access_cache_key(user.id, media.uid)
+
+    cached_result = get_cached_permission(cache_key)
+    if cached_result is not None:
+        return cached_result
+
+    result = user == media.user or is_mediacms_editor(user) or is_mediacms_manager(user) or is_curator(user)
+
+    set_cached_permission(cache_key, result)
+    return result
+
+
+def _calculate_access_permission(request, media: Media) -> bool:
+    """Calculate access permission without caching."""
+    user = request.user
+
+    if user.is_authenticated and user_has_elevated_access(user, media):
+        return True
+
+    if media.state == "restricted":
+        session_password_hash = request.session.get(f"media_password_{media.friendly_token}")
+        query_password = request.GET.get("password")
+
+        expected_password_hash = None
+        if media.password:
+            expected_password_hash = hashlib.pbkdf2_hmac(
+                "sha256",
+                media.password.encode("utf-8"),
+                media.friendly_token.encode("utf-8"),
+                iterations=600_000,
+            ).hex()
+
+        valid_session_password = (
+            bool(session_password_hash)
+            and bool(expected_password_hash)
+            and hmac.compare_digest(session_password_hash, expected_password_hash)
+        )
+
+        valid_query_password = False
+        if query_password and expected_password_hash:
+            query_hash = hashlib.pbkdf2_hmac(
+                "sha256",
+                query_password.encode("utf-8"),
+                media.friendly_token.encode("utf-8"),
+                iterations=600_000,
+            ).hex()
+            valid_query_password = hmac.compare_digest(query_hash, expected_password_hash)
+
+        if valid_session_password or valid_query_password:
+            return True
+
+        return False
+
+    if not user.is_authenticated:
+        return False
+
+    if media.state == "private":
+        return False
+
+    return False
+
+
+def check_media_access_permission(request, media: Media) -> bool:
+    """Check if the user has permission to access the media, with caching."""
+    user = request.user
+    user_id = user.id if user.is_authenticated else "anonymous"
+
+    if media.state in ("public", "unlisted"):
+        return True
+
+    additional_data = None
+    if media.state == "restricted":
+        session_password_hash = request.session.get(f"media_password_{media.friendly_token}")
+        query_password = request.GET.get("password")
+
+        if session_password_hash:
+            attempt_material = session_password_hash
+        elif query_password:
+            attempt_material = hashlib.pbkdf2_hmac(
+                "sha256",
+                query_password.encode("utf-8"),
+                media.friendly_token.encode("utf-8"),
+                iterations=600_000,
+            ).hex()
+        else:
+            attempt_material = "no_password"
+
+        password_hash = hashlib.blake2b(attempt_material.encode("utf-8"), digest_size=6).hexdigest()
+        additional_data = f"restricted:{password_hash}"
+
+    cache_key = get_permission_cache_key(user_id, media.uid, additional_data)
+
+    cached_result = get_cached_permission(cache_key)
+    if cached_result is not None:
+        return cached_result
+
+    result = _calculate_access_permission(request, media)
+
+    cache_timeout = PERMISSION_CACHE_TIMEOUT
+    if media.state == "restricted" and additional_data:
+        cache_timeout = RESTRICTED_MEDIA_CACHE_TIMEOUT
+
+    set_cached_permission(cache_key, result, cache_timeout)
+    return result
+
+
 # Configuration constants
 CACHE_CONTROL_MAX_AGE = 604800  # 1 week
 MEDIA_PATH_CACHE_TIMEOUT = 300  # 5 minutes for file path → Media ID mapping
@@ -965,138 +1080,12 @@ class SecureMediaView(View):
         return not is_video_like
 
     def _user_has_elevated_access(self, user, media: Media) -> bool:
-        """Check if user is owner, editor, or manager with caching. Assumes user is authenticated."""
-        if not user.is_authenticated:
-            return False
-
-        # Generate cache key for elevated access check
-        cache_key = get_elevated_access_cache_key(user.id, media.uid)
-
-        # Try to get from cache first
-        cached_result = get_cached_permission(cache_key)
-        if cached_result is not None:
-            logger.debug(f"Using cached elevated access result for user {user.id}, media {media.uid}")
-            return cached_result
-
-        # Calculate the result
-        result = user == media.user or is_mediacms_editor(user) or is_mediacms_manager(user) or is_curator(user)
-
-        # Cache the result
-        set_cached_permission(cache_key, result)
-
-        return result
+        """Delegate to module-level function."""
+        return user_has_elevated_access(user, media)
 
     def _check_access_permission(self, request, media: Media) -> bool:
-        """Check if the user has permission to access the media with caching."""
-        user = request.user
-        user_id = user.id if user.is_authenticated else "anonymous"
-
-        # For public and unlisted media, no need to cache (always accessible)
-        if media.state in ("public", "unlisted"):
-            return True
-
-        # For restricted media, include password info in cache key
-        additional_data = None
-        if media.state == "restricted":
-            session_password_hash = request.session.get(f"media_password_{media.friendly_token}")
-            query_password = request.GET.get("password")
-
-            # Determine what password material to use for cache key
-            if session_password_hash:
-                # Session already contains hash of the correct password
-                attempt_material = session_password_hash
-            elif query_password:
-                # Hash the query password to compare with expected hash
-                attempt_material = hashlib.pbkdf2_hmac(
-                    "sha256",
-                    query_password.encode("utf-8"),
-                    media.friendly_token.encode("utf-8"),
-                    iterations=600_000,
-                ).hex()
-            else:
-                attempt_material = "no_password"
-
-            # Create a shorter hash for cache key (avoid key length issues)
-            password_hash = hashlib.blake2b(attempt_material.encode("utf-8"), digest_size=6).hexdigest()
-            additional_data = f"restricted:{password_hash}"
-        # Generate cache key
-        cache_key = get_permission_cache_key(user_id, media.uid, additional_data)
-
-        # Try to get from cache first
-        cached_result = get_cached_permission(cache_key)
-        if cached_result is not None:
-            logger.debug(f"Using cached permission result for user {user_id}, media {media.uid}")
-            return cached_result
-
-        # Calculate permission (original logic)
-        result = self._calculate_access_permission(request, media)
-
-        # Cache the result (but with shorter timeout for restricted media with passwords)
-        cache_timeout = PERMISSION_CACHE_TIMEOUT
-        if media.state == "restricted" and additional_data:
-            # Shorter cache for password-based access
-            cache_timeout = RESTRICTED_MEDIA_CACHE_TIMEOUT
-
-        set_cached_permission(cache_key, result, cache_timeout)
-
-        return result
-
-    def _calculate_access_permission(self, request, media: Media) -> bool:
-        """Calculate access permission without caching (original logic)."""
-        user = request.user
-
-        # Elevated users bypass further checks for non-public media
-        if user.is_authenticated and self._user_has_elevated_access(user, media):
-            logger.debug(f"Access granted for '{media.state}' media: user has elevated permissions")
-            return True
-
-        if media.state == "restricted":
-            session_password_hash = request.session.get(f"media_password_{media.friendly_token}")
-            query_password = request.GET.get("password")
-
-            # Generate expected hash of the stored password for comparison using PBKDF2
-            expected_password_hash = None
-            if media.password:
-                expected_password_hash = hashlib.pbkdf2_hmac(
-                    "sha256",
-                    media.password.encode("utf-8"),
-                    media.friendly_token.encode("utf-8"),
-                    iterations=600_000,
-                ).hex()
-
-            # Compare hashes: session stores a hash; hash the query param as well
-            valid_session_password = (
-                bool(session_password_hash)
-                and bool(expected_password_hash)
-                and hmac.compare_digest(session_password_hash, expected_password_hash)
-            )
-
-            valid_query_password = False
-            if query_password and expected_password_hash:
-                query_hash = hashlib.pbkdf2_hmac(
-                    "sha256",
-                    query_password.encode("utf-8"),
-                    media.friendly_token.encode("utf-8"),
-                    iterations=600_000,
-                ).hex()
-                valid_query_password = hmac.compare_digest(query_hash, expected_password_hash)
-
-            if valid_session_password or valid_query_password:
-                logger.debug("Restricted media access granted: valid password provided")
-                return True
-
-            logger.debug("Restricted media access denied: no valid password provided")
-            return False
-
-        if not user.is_authenticated:
-            logger.debug(f"Access denied for '{media.state}' media: user not authenticated")
-            return False
-
-        if media.state == "private":
-            logger.debug("Private media access denied: user lacks elevated permissions")
-            return False
-
-        return False
+        """Delegate to module-level function."""
+        return check_media_access_permission(request, media)
 
     def _serve_file(self, file_path: str, head_request: bool = False) -> HttpResponse:
         """Serve file using X-Accel-Redirect (production) or Django (development)."""

--- a/files/serializers.py
+++ b/files/serializers.py
@@ -201,6 +201,7 @@ class SingleMediaSerializer(serializers.ModelSerializer):
             "license_info",
             "tags_info",
             "hls_info",
+            "is_encrypted",
             "subtitles_info",
             "ratings_info",
             "allow_download",

--- a/files/tasks.py
+++ b/files/tasks.py
@@ -19,6 +19,7 @@ from django.conf import settings
 from django.core.cache import cache
 from django.core.files import File
 from django.db.models import F, Q
+from django.urls import reverse
 
 from actions.models import USER_MEDIA_ACTIONS, MediaAction
 from users.models import User
@@ -796,7 +797,9 @@ def create_hls(friendly_token):
         encryption_flags = []
         if media.is_encrypted:
             key_hex = media.ensure_encryption_key()
-            key_uri = f"{settings.SSL_FRONTEND_HOST}/api/v1/keys/{media.friendly_token}/"
+            # Root-relative URI so the key resolves against whatever origin
+            # served the playlist (works in dev, prod, and copied artifacts).
+            key_uri = reverse("api_get_media_key", kwargs={"friendly_token": media.friendly_token})
             encryption_flags = [
                 f"--encryption-key={key_hex}",
                 f"--encryption-key-uri={key_uri}",

--- a/files/tasks.py
+++ b/files/tasks.py
@@ -793,10 +793,20 @@ def create_hls(friendly_token):
             existing_output_dir = output_dir
             output_dir = os.path.join(settings.HLS_DIR, p + produce_friendly_token())
         files = [f.media_file.path for f in encodings if f.media_file]
+        encryption_flags = []
+        if media.is_encrypted:
+            key_hex = media.ensure_encryption_key()
+            key_uri = f"{settings.SSL_FRONTEND_HOST}/api/v1/keys/{media.friendly_token}/"
+            encryption_flags = [
+                f"--encryption-key={key_hex}",
+                f"--encryption-key-uri={key_uri}",
+                "--encryption-mode=AES-128",
+            ]
         cmd = [
             settings.MP4HLS_COMMAND,
             "--segment-duration=4",
             f"--output-dir={output_dir}",
+            *encryption_flags,
             *files,
         ]
         subprocess.run(cmd, capture_output=True)

--- a/files/tests/test_hls_encryption.py
+++ b/files/tests/test_hls_encryption.py
@@ -1,0 +1,253 @@
+"""
+Tests for AES-128 HLS encryption (issue #472).
+
+Covers:
+- MediaKeyView endpoint (404, 403, 200 paths)
+- Media.ensure_encryption_key() generation and idempotency
+- Encryption toggle re-dispatching create_hls
+- create_hls task encryption flag injection
+"""
+
+from unittest.mock import patch
+
+from django.test import Client, TestCase
+from django.urls import reverse
+
+from files.models import Media
+from users.models import User
+
+
+def create_test_media(user, title="Test Video", **kwargs):
+    """Create a Media object with media_init patched out."""
+    desired_state = kwargs.pop("state", None)
+    with patch.object(Media, "media_init", return_value=None):
+        media = Media.objects.create(title=title, user=user, **kwargs)
+    if desired_state and media.state != desired_state:
+        Media.objects.filter(pk=media.pk).update(state=desired_state)
+        media.refresh_from_db()
+    return media
+
+
+class EnsureEncryptionKeyTests(TestCase):
+    """Tests for Media.ensure_encryption_key()."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="owner", email="owner@example.com", password="pw")
+        self.media = create_test_media(self.user)
+
+    def test_generates_32_char_hex_key(self):
+        key = self.media.ensure_encryption_key()
+        self.assertEqual(len(key), 32)
+        # Hex characters only
+        int(key, 16)
+
+    def test_returns_existing_key_without_regenerating(self):
+        first_key = self.media.ensure_encryption_key()
+        second_key = self.media.ensure_encryption_key()
+        self.assertEqual(first_key, second_key)
+
+    def test_persists_key_to_database(self):
+        key = self.media.ensure_encryption_key()
+        self.media.refresh_from_db()
+        self.assertEqual(self.media.encryption_key, key)
+
+
+class MediaKeyViewTests(TestCase):
+    """Tests for the MediaKeyView endpoint."""
+
+    def setUp(self):
+        self.client = Client()
+        self.owner = User.objects.create_user(username="owner", email="owner@example.com", password="pw")
+        self.other_user = User.objects.create_user(username="other", email="other@example.com", password="pw")
+
+    def _key_url(self, friendly_token):
+        return reverse("api_get_media_key", kwargs={"friendly_token": friendly_token})
+
+    def test_returns_404_when_media_not_found(self):
+        response = self.client.get(self._key_url("nonexistent-token"))
+        self.assertEqual(response.status_code, 404)
+
+    def test_returns_404_when_media_not_encrypted(self):
+        media = create_test_media(self.owner, state="public")
+        response = self.client.get(self._key_url(media.friendly_token))
+        self.assertEqual(response.status_code, 404)
+
+    def test_returns_404_when_encryption_key_missing(self):
+        media = create_test_media(self.owner, state="public")
+        Media.objects.filter(pk=media.pk).update(is_encrypted=True, encryption_key="")
+        response = self.client.get(self._key_url(media.friendly_token))
+        self.assertEqual(response.status_code, 404)
+
+    def test_returns_404_when_encryption_key_malformed(self):
+        media = create_test_media(self.owner, state="public")
+        # Bypass the model validator with a direct UPDATE
+        Media.objects.filter(pk=media.pk).update(is_encrypted=True, encryption_key="not-hex-zzzzzzzzzzzzzzzzzzzzzzzzzzz")
+        response = self.client.get(self._key_url(media.friendly_token))
+        self.assertEqual(response.status_code, 404)
+
+    def test_returns_key_for_public_encrypted_media_anonymous(self):
+        media = create_test_media(self.owner, state="public")
+        Media.objects.filter(pk=media.pk).update(
+            is_encrypted=True,
+            encryption_key="0123456789abcdef0123456789abcdef",
+        )
+        response = self.client.get(self._key_url(media.friendly_token))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "application/octet-stream")
+        self.assertEqual(int(response["Content-Length"]), 16)
+        self.assertEqual(len(response.content), 16)
+        self.assertIn("no-store", response["Cache-Control"])
+
+    def test_returns_403_for_private_media_anonymous(self):
+        media = create_test_media(self.owner, state="private")
+        Media.objects.filter(pk=media.pk).update(
+            is_encrypted=True,
+            encryption_key="0123456789abcdef0123456789abcdef",
+        )
+        response = self.client.get(self._key_url(media.friendly_token))
+        self.assertEqual(response.status_code, 403)
+
+    def test_returns_key_for_private_media_owner(self):
+        media = create_test_media(self.owner, state="private")
+        Media.objects.filter(pk=media.pk).update(
+            is_encrypted=True,
+            encryption_key="0123456789abcdef0123456789abcdef",
+        )
+        self.client.force_login(self.owner)
+        response = self.client.get(self._key_url(media.friendly_token))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.content), 16)
+
+    def test_returns_403_for_private_media_other_user(self):
+        media = create_test_media(self.owner, state="private")
+        Media.objects.filter(pk=media.pk).update(
+            is_encrypted=True,
+            encryption_key="0123456789abcdef0123456789abcdef",
+        )
+        self.client.force_login(self.other_user)
+        response = self.client.get(self._key_url(media.friendly_token))
+        self.assertEqual(response.status_code, 403)
+
+    def test_decoded_key_matches_stored_hex(self):
+        media = create_test_media(self.owner, state="public")
+        Media.objects.filter(pk=media.pk).update(
+            is_encrypted=True,
+            encryption_key="0123456789abcdef0123456789abcdef",
+        )
+        response = self.client.get(self._key_url(media.friendly_token))
+        self.assertEqual(response.content, bytes.fromhex("0123456789abcdef0123456789abcdef"))
+
+
+class EncryptionToggleTests(TestCase):
+    """Tests for the encryption-toggle re-dispatch path in Media.save()."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="owner", email="owner@example.com", password="pw")
+
+    def test_toggling_encryption_dispatches_create_hls_when_h264_exists(self):
+        media = create_test_media(self.user)
+        # Simulate a media with successful h264 encoding
+        with patch.object(Media, "encodings") as mock_encodings:
+            mock_encodings.filter.return_value.exists.return_value = True
+            with patch("files.tasks.create_hls.delay") as mock_delay:
+                media.is_encrypted = True
+                media.save()
+                mock_delay.assert_called_once_with(media.friendly_token)
+
+    def test_toggling_encryption_does_not_dispatch_without_h264(self):
+        media = create_test_media(self.user)
+        with patch.object(Media, "encodings") as mock_encodings:
+            mock_encodings.filter.return_value.exists.return_value = False
+            with patch("files.tasks.create_hls.delay") as mock_delay:
+                media.is_encrypted = True
+                media.save()
+                mock_delay.assert_not_called()
+
+    def test_new_media_creation_does_not_dispatch_encryption_task(self):
+        # Creating a new Media should not trigger create_hls regardless of
+        # the encryption tracker default — the `is not None` guard handles this.
+        with patch("files.tasks.create_hls.delay") as mock_delay:
+            create_test_media(self.user)
+            mock_delay.assert_not_called()
+
+    def test_no_dispatch_when_encryption_unchanged(self):
+        media = create_test_media(self.user)
+        with patch("files.tasks.create_hls.delay") as mock_delay:
+            media.title = "Updated title"
+            media.save()
+            mock_delay.assert_not_called()
+
+
+class CreateHlsEncryptionFlagsTests(TestCase):
+    """Tests for create_hls task injecting Bento4 encryption flags."""
+
+    def setUp(self):
+        from files.models import EncodeProfile
+
+        self.user = User.objects.create_user(username="owner", email="owner@example.com", password="pw")
+        self.profile = EncodeProfile.objects.create(name="h264_test", extension="mp4", codec="h264", resolution=720)
+
+    def _make_media_with_encoding(self, is_encrypted=False, encryption_key=""):
+        from files.models import Encoding
+
+        media = create_test_media(self.user)
+        if is_encrypted or encryption_key:
+            Media.objects.filter(pk=media.pk).update(is_encrypted=is_encrypted, encryption_key=encryption_key)
+            media.refresh_from_db()
+
+        # Create an Encoding with media_file populated to a fake path so create_hls
+        # has something to pass to mp4hls.
+        encoding = Encoding(media=media, profile=self.profile, status="success", chunk=False)
+        encoding.media_file.name = "encoded/fake.mp4"
+        encoding.save()
+        return media
+
+    def _run_create_hls_capturing_cmd(self, friendly_token):
+        """Run create_hls with subprocess and filesystem mocked. Returns the cmd list."""
+        from django.conf import settings as django_settings
+
+        from files import tasks
+
+        with patch("files.tasks.subprocess.run") as mock_run, patch("files.tasks.os.path.exists") as mock_exists:
+            # mp4hls binary check returns True; HLS output dir returns False
+            # so we skip the cp -rT branch.
+            def exists_side_effect(path):
+                return path == getattr(django_settings, "MP4HLS_COMMAND", "")
+
+            mock_exists.side_effect = exists_side_effect
+            tasks.create_hls(friendly_token)
+
+            if not mock_run.call_args_list:
+                return None
+            return mock_run.call_args_list[0][0][0]
+
+    def test_omits_encryption_flags_when_not_encrypted(self):
+        media = self._make_media_with_encoding(is_encrypted=False)
+        cmd = self._run_create_hls_capturing_cmd(media.friendly_token)
+        self.assertIsNotNone(cmd)
+        self.assertNotIn("--encryption-mode=AES-128", cmd)
+        self.assertFalse(any(arg.startswith("--encryption-key=") for arg in cmd))
+
+    def test_includes_encryption_flags_when_encrypted(self):
+        media = self._make_media_with_encoding(
+            is_encrypted=True,
+            encryption_key="0123456789abcdef0123456789abcdef",
+        )
+        cmd = self._run_create_hls_capturing_cmd(media.friendly_token)
+        self.assertIsNotNone(cmd)
+        self.assertIn("--encryption-key=0123456789abcdef0123456789abcdef", cmd)
+        self.assertIn("--encryption-mode=AES-128", cmd)
+
+    def test_key_uri_is_root_relative(self):
+        media = self._make_media_with_encoding(
+            is_encrypted=True,
+            encryption_key="0123456789abcdef0123456789abcdef",
+        )
+        cmd = self._run_create_hls_capturing_cmd(media.friendly_token)
+        self.assertIsNotNone(cmd)
+        key_uri_flag = next(arg for arg in cmd if arg.startswith("--encryption-key-uri="))
+        key_uri = key_uri_flag.split("=", 1)[1]
+        # Must be root-relative, not an absolute URL
+        self.assertTrue(key_uri.startswith("/"), f"Expected root-relative URI, got: {key_uri}")
+        self.assertFalse(key_uri.startswith("http"), f"URI should not be absolute, got: {key_uri}")
+        self.assertIn(media.friendly_token, key_uri)

--- a/files/urls.py
+++ b/files/urls.py
@@ -91,6 +91,11 @@ urlpatterns = [
         name="api_get_playlist",
     ),
     re_path(r"^api/v1/user/action/(?P<action>[\w]*)$", views.UserActions.as_view()),
+    re_path(
+        r"^api/v1/keys/(?P<friendly_token>[\w]+(-[\w]+)*)/?$",
+        views.MediaKeyView.as_view(),
+        name="api_get_media_key",
+    ),
     path("fu/", include(("uploader.urls", "uploader"), namespace="uploader")),
     # TODO: https://site.com/channel/UCwobzUc3z-0PrFpoRxNszXQ channel
     # ADMIN VIEWS

--- a/files/views.py
+++ b/files/views.py
@@ -2134,8 +2134,11 @@ class MediaKeyView(APIView):
         except ValueError:
             raise Http404
 
+        if len(key_bytes) != 16:
+            raise Http404
+
         response = HttpResponse(key_bytes, content_type="application/octet-stream")
-        response["Content-Length"] = 16
+        response["Content-Length"] = len(key_bytes)
         response["Cache-Control"] = "no-store, no-cache, must-revalidate, max-age=0"
         response["Pragma"] = "no-cache"
         response["Access-Control-Allow-Credentials"] = "true"

--- a/files/views.py
+++ b/files/views.py
@@ -87,6 +87,7 @@ from .models import (
     Topic,
     TopMessage,
 )
+from .secure_media_views import check_media_access_permission
 from .query_cache import (
     MEDIA_DETAIL_TIMEOUT,
     MEDIA_LIST_TIMEOUT,
@@ -2111,3 +2112,31 @@ class IndexPageFeaturedList(APIView):
         indexfeatured = IndexPageFeatured.objects.filter(active=True).order_by("ordering")
         serializer = IndexPageFeaturedSerializer(indexfeatured, many=True, context={"request": request})
         return Response(serializer.data)
+
+
+class MediaKeyView(APIView):
+    """Serve AES-128 decryption key for encrypted HLS streams."""
+
+    def get(self, request, friendly_token):
+        try:
+            media = Media.objects.select_related("user").get(friendly_token=friendly_token)
+        except Media.DoesNotExist:
+            raise Http404
+
+        if not media.is_encrypted or not media.encryption_key:
+            raise Http404
+
+        if not check_media_access_permission(request, media):
+            return HttpResponse(status=403)
+
+        try:
+            key_bytes = bytes.fromhex(media.encryption_key)
+        except ValueError:
+            raise Http404
+
+        response = HttpResponse(key_bytes, content_type="application/octet-stream")
+        response["Content-Length"] = 16
+        response["Cache-Control"] = "no-store, no-cache, must-revalidate, max-age=0"
+        response["Pragma"] = "no-cache"
+        response["Access-Control-Allow-Credentials"] = "true"
+        return response

--- a/files/views.py
+++ b/files/views.py
@@ -2141,5 +2141,4 @@ class MediaKeyView(APIView):
         response["Content-Length"] = len(key_bytes)
         response["Cache-Control"] = "no-store, no-cache, must-revalidate, max-age=0"
         response["Pragma"] = "no-cache"
-        response["Access-Control-Allow-Credentials"] = "true"
         return response

--- a/frontend/packages/media-player/src/MediaPlayer.js
+++ b/frontend/packages/media-player/src/MediaPlayer.js
@@ -78,6 +78,7 @@ const defaults = {
 			enableLowInitialPlaylist: true, // Conservative default due to unreliable device detection
 			limitRenditionByPlayerDimensions: true,
 			useDevicePixelRatio: true,
+			withCredentials: true, // Send session cookies with HLS key requests (AES-128 encryption)
 		},
 	},
 };

--- a/frontend/src/static/js/components/-NEW-/VideoPlayer.js
+++ b/frontend/src/static/js/components/-NEW-/VideoPlayer.js
@@ -242,6 +242,8 @@ export function VideoPlayer(props) {
 				useNetworkInformationApi: deviceTier === 'high',
 				maxPlaylistRetries: 2,
 				playlistExclusionDuration: 60,
+				// Send session cookies with HLS key requests (AES-128 encryption)
+				withCredentials: true,
 			},
 		};
 

--- a/templates/cms/edit_media.html
+++ b/templates/cms/edit_media.html
@@ -163,6 +163,24 @@
 					</div>
 
 
+				{% elif field.name == "is_encrypted" %}
+					<div class="fieldWrapper">
+						<div class="transcribe_section_title" style="margin-top: 1.5em; font-size: 120%; font-weight: bold;">
+							HLS Encryption
+						</div>
+						<div id="div_id_is_encrypted" class="control-group">
+							<div class="controls">
+								<label for="id_is_encrypted" class="checkbox">
+									{{ field }}
+									<span class="normal_label" style="font-weight: normal !important;">{{ field.label }}</span>
+								</label>
+							</div>
+						</div>
+						<div class="transcribe_section_title" style="margin-top: 0.5em; font-size: 100%;">
+							When enabled, HLS streams are encrypted with AES-128. Only authorized viewers can decrypt and play the video. Enabling this on an already-encoded video will re-generate the HLS stream.
+						</div>
+					</div>
+
 				{% elif field.name == "uploaded_poster" %}
 					<div class="fieldWrapper">
 						{{ field.errors }}


### PR DESCRIPTION
## Description

Add opt-in AES-128 HLS encryption for filmmaker-controlled access protection. When a filmmaker enables encryption on a video, HLS segments are encrypted using Bento4 `mp4hls`'s native `--encryption-key` flag. Decryption keys are served through a permission-gated Django endpoint. Video.js VHS handles AES-128 decryption natively — no new frontend dependencies needed.

**Changes:**
- Add `is_encrypted` and `encryption_key` fields to Media model (+ migration)
- Pass `--encryption-key`, `--encryption-key-uri`, `--encryption-mode` flags to Bento4 `mp4hls` when encryption is enabled
- Extract permission logic from `SecureMediaView` into standalone functions (`check_media_access_permission`, `user_has_elevated_access`)
- Add `MediaKeyView` at `GET /api/v1/keys/<friendly_token>/` — returns raw 16-byte AES key after permission check
- Add `withCredentials: true` to Video.js VHS options for session cookie forwarding
- Add "Enable HLS Encryption" checkbox in edit form (advanced users and editors only, video media only)
- Expose `is_encrypted` in API serializer (`encryption_key` is excluded)
- Toggling encryption on existing video re-triggers HLS generation
- Key URI uses `reverse()` for root-relative paths (portable across environments)
- `ensure_encryption_key()` uses `select_for_update` to prevent concurrent key generation race

Default behavior unchanged — encryption is opt-in, `is_encrypted` defaults to `False`.

## Related Issue

Fixes #472

## Motivation and Context

`.m4s` HLS segments bypass Django's permission system — anyone with a direct segment URL can access content regardless of access controls. Encryption ensures segments are useless without the key, and the key is gated by Django's permission layer.

## QA Test Cases

### Setup
- Need a video with successful h264 encodings
- Login as an advanced user or editor

### 1. Encryption toggle in edit form
- [ ] Go to edit page for a video → "HLS Encryption" checkbox visible under whisper section
- [ ] Login as a regular (non-advanced) user → checkbox is NOT visible
- [ ] Open edit page for an audio file → checkbox is NOT visible

### 2. Enable encryption
- [ ] Check "Enable HLS Encryption" and save
- [ ] Wait for HLS regeneration (runs via Celery)
- [ ] Inspect the media stream `.m3u8` — should contain `#EXT-X-KEY:METHOD=AES-128,URI="/api/v1/keys/{token}"`

### 3. Key endpoint access control
- [ ] `GET /api/v1/keys/{token}/` for **public** encrypted video (not logged in) → **200**, 16 bytes
- [ ] `GET /api/v1/keys/{token}/` for **private** encrypted video (not logged in) → **403**
- [ ] `GET /api/v1/keys/{token}/` for **private** encrypted video (logged in as owner) → **200**
- [ ] `GET /api/v1/keys/{token}/` for **non-encrypted** video → **404**
- [ ] Response headers include `Cache-Control: no-store`

### 4. Browser playback
- [ ] Play an encrypted public video in the browser → video plays normally
- [ ] Open DevTools Network tab → confirm `/api/v1/keys/{token}` request returns 200
- [ ] Play a non-encrypted video → plays normally (no key request in Network tab)

### 5. Disable encryption
- [ ] Uncheck "Enable HLS Encryption" and save
- [ ] HLS regenerates without encryption
- [ ] `.m3u8` no longer contains `#EXT-X-KEY` tag
- [ ] Video plays without key fetch

### 6. Existing videos unaffected
- [ ] Videos that were never encrypted play normally with no changes

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):
- [x] I have not imported `flux` in a new component
- [x] If adding a new feature, I used Modern Track patterns
- [x] New features do not create new SCSS files (use Tailwind instead)