### PR TITLE
feat: add playlist share with composite thumbnails (#406)

### DIFF
--- a/files/helpers.py
+++ b/files/helpers.py
@@ -1048,26 +1048,43 @@ def generate_composite_thumbnail(playlist):
     rows, cols = layout
     tiles_needed = rows * cols
 
-    playlist_media = list(
-        playlist.playlistmedia_set.select_related("media")[:tiles_needed]
-    )
-
-    if not playlist_media:
-        return None
-
     canvas_width = 1280
     canvas_height = 720
 
-    # Collect available thumbnail paths in playlist order
+    # Walk the full playlist in order and collect the first `tiles_needed`
+    # source images that actually exist on disk. Items whose media is missing
+    # an image are skipped so later items with valid images can fill their
+    # slots instead.
+    #
+    # Only include public media. The composite is served as the Open Graph
+    # image for the public playlist URL (see `PUBLIC_MEDIA_PATHS` in
+    # files/secure_media_views.py) and is fetched by unauthenticated social
+    # media crawlers, so it must not leak posters from private, unlisted, or
+    # restricted videos. This matches the anonymous-viewer filter used by
+    # PlaylistDetail.get() in files/views.py (`media__state="public"`).
+    #
+    # Prefer posters (width=1280/720) over thumbnails (width=344) so composite
+    # tiles render at full quality instead of being upscaled from the small
+    # thumbnail crop.
+    public_playlist_media = (
+        playlist.playlistmedia_set.filter(media__state="public")
+        .select_related("media")
+    )
     thumb_paths = []
-    for pm in playlist_media:
+    for pm in public_playlist_media.iterator():
         media = pm.media
-        # Prefer uploaded_thumbnail, fall back to thumbnail
-        field = media.uploaded_thumbnail or media.thumbnail
+        field = (
+            media.uploaded_poster
+            or media.poster
+            or media.uploaded_thumbnail
+            or media.thumbnail
+        )
         if field and field.name:
             full_path = os.path.join(settings.MEDIA_ROOT, field.name)
             if os.path.exists(full_path):
                 thumb_paths.append(full_path)
+                if len(thumb_paths) >= tiles_needed:
+                    break
 
     # If too many thumbnails are missing to fill the grid, bail out so the
     # caller can fall back to the single-video thumbnail. This avoids

--- a/files/helpers.py
+++ b/files/helpers.py
@@ -1041,20 +1041,12 @@ def generate_composite_thumbnail(playlist):
     if not playlist.friendly_token:
         return None
 
-    layout = _composite_grid_layout(playlist.media_count)
-    if layout is None:
-        return None
-
-    rows, cols = layout
-    tiles_needed = rows * cols
-
     canvas_width = 1280
     canvas_height = 720
 
-    # Walk the full playlist in order and collect the first `tiles_needed`
-    # source images that actually exist on disk. Items whose media is missing
-    # an image are skipped so later items with valid images can fill their
-    # slots instead.
+    # Walk the full playlist in order and collect all public media thumbnails
+    # that actually exist on disk. Items whose media is missing an image or
+    # is non-public are skipped.
     #
     # Only include public media. The composite is served as the Open Graph
     # image for the public playlist URL (see `PUBLIC_MEDIA_PATHS` in
@@ -1066,6 +1058,13 @@ def generate_composite_thumbnail(playlist):
     # Prefer posters (width=1280/720) over thumbnails (width=344) so composite
     # tiles render at full quality instead of being upscaled from the small
     # thumbnail crop.
+    #
+    # We collect up to 12 paths (the maximum grid needs 3×4 = 12 tiles),
+    # then pick the grid layout from the number of usable thumbnails we
+    # actually found — NOT from playlist.media_count, which includes
+    # non-public items and would over-estimate the grid for mixed-visibility
+    # playlists.
+    max_tiles = 12  # 3×4 is the largest grid
     public_playlist_media = (
         playlist.playlistmedia_set.filter(media__state="public")
         .select_related("media")
@@ -1083,14 +1082,16 @@ def generate_composite_thumbnail(playlist):
             full_path = os.path.join(settings.MEDIA_ROOT, field.name)
             if os.path.exists(full_path):
                 thumb_paths.append(full_path)
-                if len(thumb_paths) >= tiles_needed:
+                if len(thumb_paths) >= max_tiles:
                     break
 
-    # If too many thumbnails are missing to fill the grid, bail out so the
-    # caller can fall back to the single-video thumbnail. This avoids
-    # rendering a composite that's mostly empty cells.
-    if len(thumb_paths) < tiles_needed:
+    # Pick the grid layout from how many usable public thumbnails we found.
+    layout = _composite_grid_layout(len(thumb_paths))
+    if layout is None:
         return None
+
+    rows, cols = layout
+    tiles_needed = rows * cols
 
     canvas = Image.new("RGB", (canvas_width, canvas_height), (26, 26, 26))
     cell_w = canvas_width // cols

--- a/files/helpers.py
+++ b/files/helpers.py
@@ -1,6 +1,7 @@
 # Kudos to Werner Robitza, AVEQ GmbH
 import hashlib
 import json
+import logging
 import math
 import os
 import random
@@ -12,6 +13,8 @@ from fractions import Fraction
 
 import filetype
 from django.conf import settings
+
+logger = logging.getLogger(__name__)
 
 CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 
@@ -996,3 +999,135 @@ def can_view_all_user_media(requesting_user, profile_user):
 
     # Curators can see all content
     return bool(is_curator(requesting_user))
+
+
+def _composite_grid_layout(video_count):
+    """Pick a grid layout (rows, cols) for a given playlist size.
+
+    Returns None if the playlist has fewer than 4 videos — callers should
+    fall back to the single-video thumbnail in that case.
+    """
+    if video_count >= 12:
+        return (3, 4)  # 12 tiles
+    if video_count >= 8:
+        return (2, 4)  # 8 tiles
+    if video_count >= 6:
+        return (2, 3)  # 6 tiles
+    if video_count >= 4:
+        return (2, 2)  # 4 tiles
+    return None
+
+
+def generate_composite_thumbnail(playlist):
+    """Generate a composite thumbnail from playlist video thumbnails.
+
+    Creates a 1280x720 JPEG (16:9) grid image from the first N media
+    thumbnails in the playlist. Grid size depends on playlist length:
+        4-5 videos  -> 2x2 grid (4 tiles)
+        6-7 videos  -> 2x3 grid (6 tiles)
+        8-11 videos -> 2x4 grid (8 tiles)
+        12+ videos  -> 3x4 grid (12 tiles)
+        <4 videos   -> None (caller falls back to single-video thumbnail)
+
+    Saved to composite_thumbnails/{friendly_token}.jpg under MEDIA_ROOT
+    using an atomic temp-file + rename to prevent partial reads under
+    concurrent generation.
+
+    Returns the relative path from MEDIA_ROOT, or None on failure or
+    when the playlist has fewer than 4 videos.
+    """
+    from PIL import Image, UnidentifiedImageError
+
+    if not playlist.friendly_token:
+        return None
+
+    layout = _composite_grid_layout(playlist.media_count)
+    if layout is None:
+        return None
+
+    rows, cols = layout
+    tiles_needed = rows * cols
+
+    playlist_media = list(
+        playlist.playlistmedia_set.select_related("media")[:tiles_needed]
+    )
+
+    if not playlist_media:
+        return None
+
+    canvas_width = 1280
+    canvas_height = 720
+
+    # Collect available thumbnail paths in playlist order
+    thumb_paths = []
+    for pm in playlist_media:
+        media = pm.media
+        # Prefer uploaded_thumbnail, fall back to thumbnail
+        field = media.uploaded_thumbnail or media.thumbnail
+        if field and field.name:
+            full_path = os.path.join(settings.MEDIA_ROOT, field.name)
+            if os.path.exists(full_path):
+                thumb_paths.append(full_path)
+
+    # If too many thumbnails are missing to fill the grid, bail out so the
+    # caller can fall back to the single-video thumbnail. This avoids
+    # rendering a composite that's mostly empty cells.
+    if len(thumb_paths) < tiles_needed:
+        return None
+
+    canvas = Image.new("RGB", (canvas_width, canvas_height), (26, 26, 26))
+    cell_w = canvas_width // cols
+    cell_h = canvas_height // rows
+
+    try:
+        for idx, path in enumerate(thumb_paths[:tiles_needed]):
+            row = idx // cols
+            col = idx % cols
+            img = Image.open(path)
+            img = _crop_to_fill(img, cell_w, cell_h)
+            canvas.paste(img, (col * cell_w, row * cell_h))
+
+        output_dir = os.path.join(settings.MEDIA_ROOT, "composite_thumbnails")
+        os.makedirs(output_dir, exist_ok=True)
+        relative_path = f"composite_thumbnails/{playlist.friendly_token}.jpg"
+        full_path = os.path.join(settings.MEDIA_ROOT, relative_path)
+
+        # Atomic write: save to a temp file in the same directory,
+        # then os.replace() to swap into place. This prevents crawlers
+        # from reading a partially-written JPEG under concurrent generation.
+        fd, tmp_path = tempfile.mkstemp(suffix=".jpg", dir=output_dir)
+        try:
+            os.close(fd)
+            canvas.save(tmp_path, "JPEG", quality=85)
+            os.replace(tmp_path, full_path)
+        except Exception:
+            if os.path.exists(tmp_path):
+                try:
+                    os.remove(tmp_path)
+                except OSError:
+                    pass
+            raise
+
+        return relative_path
+    except (OSError, UnidentifiedImageError, ValueError) as e:
+        logger.warning(
+            "Composite thumbnail generation failed for playlist %s: %s",
+            playlist.friendly_token,
+            e,
+        )
+        return None
+
+
+def _crop_to_fill(img, target_w, target_h):
+    """Resize and center-crop an image to exactly fill target dimensions."""
+    from PIL import Image
+
+    src_w, src_h = img.size
+    scale = max(target_w / src_w, target_h / src_h)
+    new_w = int(src_w * scale)
+    new_h = int(src_h * scale)
+    img = img.resize((new_w, new_h), Image.LANCZOS)
+
+    left = (new_w - target_w) // 2
+    top = (new_h - target_h) // 2
+    return img.crop((left, top, left + target_w, top + target_h))

--- a/files/models.py
+++ b/files/models.py
@@ -1539,21 +1539,50 @@ class Playlist(models.Model):
 
     @cached_property
     def composite_thumbnail_url(self):
-        """Return URL for composite thumbnail, generating it on first access.
+        """Return the best-available share image URL for this playlist.
+
+        Prefers a real 1280x720 composite grid (when the playlist has >=4
+        public videos), falling back to the first media's thumbnail. This is
+        the "best effort" property consumed by the frontend share modal and
+        API serializers that just need *some* image to show.
+
+        Callers that need to distinguish a real composite from a fallback
+        (e.g., the playlist.html template, which only wants to emit
+        og:image:width/height=1280/720 when the real composite is in use)
+        should check `has_composite_thumbnail` first.
 
         Cached per-instance via @cached_property so that templates referencing
         this property multiple times (og:image, twitter:image) don't repeat
         the disk stat or regeneration work.
         """
+        if self.has_composite_thumbnail:
+            relative_path = f"composite_thumbnails/{self.friendly_token}.jpg"
+            return helpers.url_from_path(relative_path)
+        return self.thumbnail_url
+
+    @cached_property
+    def has_composite_thumbnail(self):
+        """Return True iff a real composite JPEG exists on disk for this
+        playlist, triggering generation on first access.
+
+        Separate from `composite_thumbnail_url` so the template can decide
+        whether to emit og:image:width/height=1280/720 — those dimensions
+        must only be declared when the actual 1280x720 composite is served,
+        not when we've fallen back to a single media thumbnail which is
+        much smaller.
+
+        Cached per-instance so the disk stat + generation runs at most once
+        per request, even though the template checks this property alongside
+        composite_thumbnail_url.
+        """
         if not self.friendly_token:
-            return self.thumbnail_url
+            return False
         relative_path = f"composite_thumbnails/{self.friendly_token}.jpg"
         full_path = os.path.join(settings.MEDIA_ROOT, relative_path)
-        if not os.path.exists(full_path):
-            result = helpers.generate_composite_thumbnail(self)
-            if result is None:
-                return self.thumbnail_url
-        return helpers.url_from_path(relative_path)
+        if os.path.exists(full_path):
+            return True
+        result = helpers.generate_composite_thumbnail(self)
+        return result is not None
 
     class Meta:
         ordering = ["-add_date"]  # This will show newest playlists first
@@ -2119,6 +2148,30 @@ def playlist_media_delete(sender, instance, **kwargs):
     """Invalidate playlist cache when media is removed from playlist."""
     invalidate_playlist_cache(instance.playlist.friendly_token)
     delete_composite_thumbnail(instance.playlist.friendly_token)
+
+
+@receiver(post_save, sender=Media)
+def invalidate_playlist_composites_on_state_change(sender, instance, created, **kwargs):
+    """Invalidate composite thumbnails of playlists that contain this media
+    when its visibility state changes.
+
+    The composite is filtered to `state="public"` media only (see
+    `generate_composite_thumbnail` in files/helpers.py), so when a media
+    transitions into or out of the public state, every playlist that contains
+    it needs its cached composite deleted so the next access regenerates with
+    the updated visibility.
+    """
+    if created:
+        return
+    original_state = getattr(instance, "_Media__original_state", None)
+    if original_state is None or original_state == instance.state:
+        return
+    if original_state != "public" and instance.state != "public":
+        return
+    friendly_tokens = Playlist.objects.filter(media=instance).values_list("friendly_token", flat=True)
+    for friendly_token in friendly_tokens:
+        delete_composite_thumbnail(friendly_token)
+        invalidate_playlist_cache(friendly_token)
 
 
 @receiver(pre_save, sender=Media)

--- a/files/models.py
+++ b/files/models.py
@@ -1537,19 +1537,38 @@ class Playlist(models.Model):
             return pm.media.thumbnail_url
         return None
 
+    @property
+    def public_thumbnail_url(self):
+        """Return the thumbnail URL of the first public media in the playlist.
+
+        Unlike ``thumbnail_url`` (which returns the first media regardless of
+        state), this property filters to ``state="public"`` so it is safe to
+        expose to anonymous viewers — e.g., as the OG image fallback when no
+        composite grid is available.
+        """
+        pm = self.playlistmedia_set.filter(media__state="public").first()
+        if pm:
+            return pm.media.thumbnail_url
+        return None
+
     @cached_property
     def composite_thumbnail_url(self):
         """Return the best-available share image URL for this playlist.
 
         Prefers a real 1280x720 composite grid (when the playlist has >=4
-        public videos), falling back to the first media's thumbnail. This is
-        the "best effort" property consumed by the frontend share modal and
-        API serializers that just need *some* image to show.
+        public videos), falling back to the first *public* media's thumbnail.
+        This is the "best effort" property consumed by the frontend share
+        modal and API serializers that just need *some* image to show.
 
         Callers that need to distinguish a real composite from a fallback
         (e.g., the playlist.html template, which only wants to emit
         og:image:width/height=1280/720 when the real composite is in use)
         should check `has_composite_thumbnail` first.
+
+        The composite URL includes a ``?v=<mtime>`` cache-buster so that
+        browsers and social media crawlers fetch the new version after a
+        playlist membership change triggers regeneration. This mirrors the
+        ``build_versioned_url()`` pattern used by ``Media.thumbnail_url``.
 
         Cached per-instance via @cached_property so that templates referencing
         this property multiple times (og:image, twitter:image) don't repeat
@@ -1557,8 +1576,14 @@ class Playlist(models.Model):
         """
         if self.has_composite_thumbnail:
             relative_path = f"composite_thumbnails/{self.friendly_token}.jpg"
-            return helpers.url_from_path(relative_path)
-        return self.thumbnail_url
+            base_url = helpers.url_from_path(relative_path)
+            full_path = os.path.join(settings.MEDIA_ROOT, relative_path)
+            try:
+                version = int(os.path.getmtime(full_path))
+            except OSError:
+                version = 0
+            return helpers.build_versioned_url(base_url, version)
+        return self.public_thumbnail_url
 
     @cached_property
     def has_composite_thumbnail(self):

--- a/files/models.py
+++ b/files/models.py
@@ -1537,6 +1537,24 @@ class Playlist(models.Model):
             return pm.media.thumbnail_url
         return None
 
+    @cached_property
+    def composite_thumbnail_url(self):
+        """Return URL for composite thumbnail, generating it on first access.
+
+        Cached per-instance via @cached_property so that templates referencing
+        this property multiple times (og:image, twitter:image) don't repeat
+        the disk stat or regeneration work.
+        """
+        if not self.friendly_token:
+            return self.thumbnail_url
+        relative_path = f"composite_thumbnails/{self.friendly_token}.jpg"
+        full_path = os.path.join(settings.MEDIA_ROOT, relative_path)
+        if not os.path.exists(full_path):
+            result = helpers.generate_composite_thumbnail(self)
+            if result is None:
+                return self.thumbnail_url
+        return helpers.url_from_path(relative_path)
+
     class Meta:
         ordering = ["-add_date"]  # This will show newest playlists first
 
@@ -2063,28 +2081,44 @@ def comment_delete(sender, instance, **kwargs):
                 # Cache invalidation will be handled by Media.save() method
 
 
+def delete_composite_thumbnail(friendly_token):
+    """Delete cached composite thumbnail so it regenerates on next access."""
+    path = os.path.join(settings.MEDIA_ROOT, "composite_thumbnails", f"{friendly_token}.jpg")
+    if os.path.exists(path):
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+
+
 @receiver(post_save, sender=Playlist)
 def playlist_save(sender, instance, created, **kwargs):
     """Invalidate playlist cache when playlist is saved."""
     invalidate_playlist_cache(instance.friendly_token)
+    # Note: composite thumbnail is intentionally NOT deleted here. Title and
+    # description edits don't change the visible thumbnails, so regenerating
+    # would just add latency to the next page load.
 
 
 @receiver(pre_delete, sender=Playlist)
 def playlist_pre_delete(sender, instance, **kwargs):
     """Invalidate playlist cache when playlist is deleted."""
     invalidate_playlist_cache(instance.friendly_token)
+    delete_composite_thumbnail(instance.friendly_token)
 
 
 @receiver(post_save, sender=PlaylistMedia)
 def playlist_media_save(sender, instance, created, **kwargs):
     """Invalidate playlist cache when media is added/removed from playlist."""
     invalidate_playlist_cache(instance.playlist.friendly_token)
+    delete_composite_thumbnail(instance.playlist.friendly_token)
 
 
 @receiver(pre_delete, sender=PlaylistMedia)
 def playlist_media_delete(sender, instance, **kwargs):
     """Invalidate playlist cache when media is removed from playlist."""
     invalidate_playlist_cache(instance.playlist.friendly_token)
+    delete_composite_thumbnail(instance.playlist.friendly_token)
 
 
 @receiver(pre_save, sender=Media)

--- a/files/secure_media_views.py
+++ b/files/secure_media_views.py
@@ -47,6 +47,8 @@ PUBLIC_MEDIA_PATHS = [
     # Category and topic thumbnails are truly public
     "original/categories/",
     "original/topics/",
+    # Composite thumbnails for playlist social sharing
+    "composite_thumbnails/",
 ]
 
 # Security headers for different content types

--- a/files/serializers.py
+++ b/files/serializers.py
@@ -313,6 +313,7 @@ class PlaylistDetailSerializer(serializers.ModelSerializer):
             "media_count",
             "url",
             "thumbnail_url",
+            "composite_thumbnail_url",
         )
 
 

--- a/frontend/src/static/js/components/-NEW-/PlaylistShareButton.js
+++ b/frontend/src/static/js/components/-NEW-/PlaylistShareButton.js
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+
+import { usePopup } from './hooks/usePopup';
+
+import { default as Popup, PopupMain } from './Popup';
+
+import { MaterialIcon } from './MaterialIcon';
+import { CircleIconButton } from './CircleIconButton';
+import { PlaylistShareOptions } from './PlaylistShareOptions';
+
+import { NavigationContentApp } from './NavigationContentApp';
+
+export function PlaylistShareButton(props){
+
+	const [ popupContentRef, PopupContent, PopupTrigger ] = usePopup();
+
+	function onPopupHide(){}
+
+	return (<div className="share">
+
+				<PopupTrigger contentRef={ popupContentRef }>
+					<button>
+						<CircleIconButton type="span"><MaterialIcon type="share" /></CircleIconButton>
+						<span>SHARE</span>
+					</button>
+				</PopupTrigger>
+
+				<PopupContent contentRef={ popupContentRef } hideCallback={ onPopupHide }>
+					<NavigationContentApp
+						initPage="shareOptions"
+						pageChangeSelector={ '.change-page' }
+						pageIdSelectorAttr={ 'data-page-id' }
+						pages={{
+							shareOptions: <div className="popup-fullscreen">
+											<PopupMain>
+												<span className="popup-fullscreen-overlay"></span>
+												<PlaylistShareOptions url={ props.url } title={ props.title } thumbnailUrl={ props.thumbnailUrl } />
+											</PopupMain>
+										</div>,
+						}}
+						focusFirstItemOnPageChange={ false }
+					/>
+				</PopupContent>
+
+			</div>);
+}

--- a/frontend/src/static/js/components/-NEW-/PlaylistShareOptions.js
+++ b/frontend/src/static/js/components/-NEW-/PlaylistShareOptions.js
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useEffect } from 'react';
+import React, { useRef, useState, useEffect, useContext, useMemo } from 'react';
 
 import LayoutStore from '../../stores/LayoutStore.js';
 
@@ -11,11 +11,7 @@ import { CircleIconButton } from './CircleIconButton';
 
 import ShareOptionsContext from '../../contexts/ShareOptionsContext';
 
-function shareOptionsList(url, title){
-
-	const socialMedia = ShareOptionsContext._currentValue;
-	const encodedUrl = encodeURIComponent(url);
-	const encodedTitle = encodeURIComponent(title);
+function shareOptionsList(socialMedia, encodedUrl, encodedTitle){
 
 	const ret = {};
 
@@ -99,9 +95,9 @@ function shareOptionsList(url, title){
 	return ret;
 }
 
-function ShareOptions(url, title){
+function ShareOptions(socialMedia, encodedUrl, encodedTitle){
 
-	const shareOptions = shareOptionsList(url, title);
+	const shareOptions = shareOptionsList(socialMedia, encodedUrl, encodedTitle);
 
 	const compList = [];
 
@@ -111,7 +107,7 @@ function ShareOptions(url, title){
 
 			if( k === 'whatsapp' ){
 				compList.push( <div key={ "share-" + k } className={ "sh-option share-" + k }>
-									<a href={ shareOptions[k].shareUrl } title="" target="_blank" data-action='share/whatsapp/share'>
+									<a href={ shareOptions[k].shareUrl } title="" target="_blank" rel="noopener noreferrer" data-action='share/whatsapp/share'>
 										<span></span>
 										<span>{ shareOptions[k].title }</span>
 									</a>
@@ -127,7 +123,7 @@ function ShareOptions(url, title){
 			}
 			else{
 				compList.push( <div key={ "share-" + k } className={ "sh-option share-" + k }>
-									<a href={ shareOptions[k].shareUrl } title="" target="_blank">
+									<a href={ shareOptions[k].shareUrl } title="" target="_blank" rel="noopener noreferrer">
 										<span></span>
 										<span>{ shareOptions[k].title }</span>
 									</a>
@@ -163,18 +159,72 @@ export function PlaylistShareOptions(props){
 	const [ sliderButtonsVisible, setSliderButtonsVisible ] = useState({ prev: false, next: false });
 
 	const [ dimensions, setDimensions ] = useState( updateDimensions() );
-	const [ shareOptions ] = useState( ShareOptions(props.url, props.title) );
+
+	// Read the share platform list from context instead of the private
+	// `_currentValue` internal. The app doesn't currently mount a Provider
+	// (the default-value path is the only path), but going through useContext
+	// keeps us off private React APIs and lets a future Provider work as
+	// expected without touching this component.
+	const socialMedia = useContext(ShareOptionsContext);
+
+	// Derive share options reactively from props + context so URL/title/
+	// platform-list changes propagate to the UI. useMemo also avoids rebuilding
+	// the option list on every unrelated re-render (slider state, resize).
+	const shareOptions = useMemo(() => {
+		const encodedUrl = encodeURIComponent(props.url || '');
+		const encodedTitle = encodeURIComponent(props.title || '');
+		return ShareOptions(socialMedia, encodedUrl, encodedTitle);
+	}, [props.url, props.title, socialMedia]);
 
 	function onWindowResize(){
 		setDimensions(updateDimensions());
 	}
 
 	function onClickCopyLink(){
-		const input = containerRef.current.querySelector('.copy-field input');
-		if( input ){
-			navigator.clipboard.writeText(input.value).then(function(){
-				PageActions.addNotification("Link copied to clipboard", 'clipboardLinkCopy');
+		const input = containerRef.current && containerRef.current.querySelector('.copy-field input');
+		if( ! input ){ return; }
+
+		function notifySuccess(){
+			PageActions.addNotification("Link copied to clipboard", 'clipboardLinkCopy');
+		}
+
+		function notifyFailure(err){
+			const detail = err && err.message ? ': ' + err.message : '';
+			PageActions.addNotification("Couldn't copy link, please copy manually" + detail, 'clipboardLinkCopy');
+		}
+
+		// Fallback path for insecure origins / older browsers where the async
+		// Clipboard API isn't available. Selects the input so the user can
+		// manually copy if execCommand also fails.
+		function copyViaExecCommand(){
+			try {
+				input.focus();
+				input.select();
+				input.setSelectionRange(0, input.value.length);
+				const ok = document.execCommand && document.execCommand('copy');
+				if( ok ){
+					notifySuccess();
+				} else {
+					notifyFailure(new Error('execCommand copy returned false'));
+				}
+			} catch(err) {
+				notifyFailure(err);
+			}
+		}
+
+		if( navigator.clipboard && typeof navigator.clipboard.writeText === 'function' ){
+			navigator.clipboard.writeText(input.value).then(notifySuccess).catch(function(err){
+				// Some browsers reject writeText even on secure origins (e.g.,
+				// document not focused, permissions policy). Try the legacy
+				// path before giving up and surfacing the error.
+				copyViaExecCommand();
+				if( err ){
+					// eslint-disable-next-line no-console
+					console.warn('clipboard.writeText failed, falling back to execCommand:', err);
+				}
 			});
+		} else {
+			copyViaExecCommand();
 		}
 	}
 

--- a/frontend/src/static/js/components/-NEW-/PlaylistShareOptions.js
+++ b/frontend/src/static/js/components/-NEW-/PlaylistShareOptions.js
@@ -1,0 +1,249 @@
+import React, { useRef, useState, useEffect } from 'react';
+
+import LayoutStore from '../../stores/LayoutStore.js';
+
+import PageStore from '../../pages/_PageStore.js';
+import * as PageActions from '../../pages/_PageActions.js';
+
+import ItemsInlineSlider from "./includes/itemLists/ItemsInlineSlider";
+
+import { CircleIconButton } from './CircleIconButton';
+
+import ShareOptionsContext from '../../contexts/ShareOptionsContext';
+
+function shareOptionsList(url, title){
+
+	const socialMedia = ShareOptionsContext._currentValue;
+	const encodedUrl = encodeURIComponent(url);
+	const encodedTitle = encodeURIComponent(title);
+
+	const ret = {};
+
+	let i = 0;
+
+	while( i < socialMedia.length){
+
+		switch( socialMedia[i] ){
+			case 'email':
+				ret[ socialMedia[i] ] = {
+					title: 'Email',
+					shareUrl: "mailto:?body=" + encodedUrl,
+				};
+				break;
+			case 'fb':
+				ret[ socialMedia[i] ] = {
+					title: 'Facebook',
+					shareUrl: 'https://www.facebook.com/sharer.php?u=' + encodedUrl,
+				};
+				break;
+			case 'tw':
+				ret[ socialMedia[i] ] = {
+					title: 'Twitter',
+					shareUrl: 'https://twitter.com/intent/tweet?url=' + encodedUrl,
+				};
+				break;
+			case 'reddit':
+				ret[ socialMedia[i] ] = {
+					title: 'reddit',
+					shareUrl: 'https://reddit.com/submit?url=' + encodedUrl + '&title=' + encodedTitle,
+				};
+				break;
+			case 'tumblr':
+				ret[ socialMedia[i] ] = {
+					title: 'Tumblr',
+					shareUrl: 'https://www.tumblr.com/widgets/share/tool?canonicalUrl=' + encodedUrl + '&title=' + encodedTitle,
+				};
+				break;
+			case 'pinterest':
+				ret[ socialMedia[i] ] = {
+					title: 'Pinterest',
+					shareUrl: 'http://pinterest.com/pin/create/link/?url=' + encodedUrl,
+				};
+				break;
+			case 'vk':
+				ret[ socialMedia[i] ] = {
+					title: 'ВКонтакте',
+					shareUrl: 'http://vk.com/share.php?url=' + encodedUrl + '&title=' + encodedTitle,
+				};
+				break;
+			case 'linkedin':
+				ret[ socialMedia[i] ] = {
+					title: 'LinkedIn',
+					shareUrl: 'https://www.linkedin.com/shareArticle?mini=true&url=' + encodedUrl,
+				};
+				break;
+			case 'mix':
+				ret[ socialMedia[i] ] = {
+					title: 'Mix',
+					shareUrl: 'https://mix.com/add?url=' + encodedUrl,
+				};
+				break;
+			case 'whatsapp':
+				ret[ socialMedia[i] ] = {
+					title: 'WhatsApp',
+					shareUrl: 'whatsapp://send?text=' + encodedUrl,
+				};
+				break;
+			case 'telegram':
+				ret[ socialMedia[i] ] = {
+					title: 'Telegram',
+					shareUrl: 'https://t.me/share/url?url=' + encodedUrl + '&text=' + encodedTitle,
+				};
+				break;
+			// Skip 'embed' — playlists are not embeddable
+		}
+
+		i += 1;
+	}
+
+	return ret;
+}
+
+function ShareOptions(url, title){
+
+	const shareOptions = shareOptionsList(url, title);
+
+	const compList = [];
+
+	for(let k in shareOptions){
+
+		if( shareOptions.hasOwnProperty( k ) ){
+
+			if( k === 'whatsapp' ){
+				compList.push( <div key={ "share-" + k } className={ "sh-option share-" + k }>
+									<a href={ shareOptions[k].shareUrl } title="" target="_blank" data-action='share/whatsapp/share'>
+										<span></span>
+										<span>{ shareOptions[k].title }</span>
+									</a>
+								</div> );
+			}
+			else if( k === 'email' ){
+				compList.push( <div key="share-email" className="sh-option share-email">
+									<a href={ shareOptions[k].shareUrl } title="">
+										<span><i className="material-icons">email</i></span>
+										<span>{ shareOptions[k].title }</span>
+									</a>
+								</div> );
+			}
+			else{
+				compList.push( <div key={ "share-" + k } className={ "sh-option share-" + k }>
+									<a href={ shareOptions[k].shareUrl } title="" target="_blank">
+										<span></span>
+										<span>{ shareOptions[k].title }</span>
+									</a>
+								</div> );
+			}
+		}
+	}
+
+	return compList;
+}
+
+function NextSlideButton({onClick}){
+	return ( <span className="next-slide"><CircleIconButton buttonShadow={true} onClick={ onClick }><i className="material-icons">keyboard_arrow_right</i></CircleIconButton></span> );
+}
+
+function PreviousSlideButton({onClick}){
+	return( <span className="previous-slide"><CircleIconButton buttonShadow={true} onClick={ onClick }><i className="material-icons">keyboard_arrow_left</i></CircleIconButton></span> );
+}
+
+function updateDimensions(){
+	return {
+		maxFormContentHeight: LayoutStore.get('container-height') - ( 56 + ( 4 * 24 ) + 44 ),
+		maxPopupWidth: 518 > LayoutStore.get('container-width') - ( 2 * 40 ) ? LayoutStore.get('container-width') - ( 2 * 40 ) : null,
+	};
+}
+
+export function PlaylistShareOptions(props){
+
+	const containerRef = useRef(null);
+	const shareOptionsInnerRef = useRef(null);
+
+	const [ inlineSlider, setInlineSlider ] = useState( null );
+	const [ sliderButtonsVisible, setSliderButtonsVisible ] = useState({ prev: false, next: false });
+
+	const [ dimensions, setDimensions ] = useState( updateDimensions() );
+	const [ shareOptions ] = useState( ShareOptions(props.url, props.title) );
+
+	function onWindowResize(){
+		setDimensions(updateDimensions());
+	}
+
+	function onClickCopyLink(){
+		const input = containerRef.current.querySelector('.copy-field input');
+		if( input ){
+			navigator.clipboard.writeText(input.value).then(function(){
+				PageActions.addNotification("Link copied to clipboard", 'clipboardLinkCopy');
+			});
+		}
+	}
+
+	function updateSlider(){
+		inlineSlider.scrollToCurrentSlide();
+		updateSliderButtonsView();
+	}
+
+	function updateSliderButtonsView(){
+		setSliderButtonsVisible({
+			prev: inlineSlider.hasPreviousSlide(),
+			next: inlineSlider.hasNextSlide(),
+		});
+	}
+
+	function nextSlide(e){
+		// Stop propagation so the click-outside listener in PopupContent doesn't
+		// close the modal. React can re-render the arrow button between our
+		// onClick and the document-level click handler, which would otherwise
+		// detach ev.target and make popup.contains(target) return false.
+		if( e ){ e.stopPropagation(); }
+		inlineSlider.nextSlide();
+		updateSlider();
+	}
+
+	function prevSlide(e){
+		if( e ){ e.stopPropagation(); }
+		inlineSlider.previousSlide();
+		updateSlider();
+	}
+
+	useEffect(()=>{
+		setInlineSlider( new ItemsInlineSlider( shareOptionsInnerRef.current, '.sh-option' ) );
+	}, [shareOptions]);
+
+	useEffect(()=>{
+		if( inlineSlider ){
+			inlineSlider.updateDataStateOnResize( shareOptions.length, true, true );
+			updateSlider();
+		}
+	}, [dimensions, inlineSlider]);
+
+	useEffect(()=>{
+
+		PageStore.on( 'window_resize', onWindowResize );
+
+		return () => {
+			PageStore.removeListener( 'window_resize', onWindowResize );
+			setInlineSlider(null);
+		};
+	}, []);
+
+	return (<div ref={containerRef} className="playlist-share-options" style={ null !== dimensions.maxPopupWidth ? { 'maxWidth' : dimensions.maxPopupWidth + 'px' } : null }>
+					<div className="scrollable-content" style={ null !== dimensions.maxFormContentHeight ? { 'maxHeight' : dimensions.maxFormContentHeight + 'px' } : null }>
+						<div className="share-popup-title">Share playlist</div>
+						{ props.thumbnailUrl ? <div className="share-preview">
+							<img src={ props.thumbnailUrl } alt={ props.title || 'Playlist preview' } />
+						</div> : null }
+						{ shareOptions.length ? <div className="share-options">
+							{ sliderButtonsVisible.prev ? <PreviousSlideButton onClick={ prevSlide } /> : null }
+							<div ref={ shareOptionsInnerRef } className="share-options-inner">{ shareOptions }</div>
+							{ sliderButtonsVisible.next ? <NextSlideButton onClick={ nextSlide } /> : null }
+						</div> : null }
+					</div>
+					<div className="copy-field">
+						<div>
+							<input type="text" readOnly value={props.url} />
+							<button onClick={ onClickCopyLink }>COPY</button>
+						</div>
+					</div>
+				</div>);
+}

--- a/frontend/src/static/js/pages/PlaylistPage/index.js
+++ b/frontend/src/static/js/pages/PlaylistPage/index.js
@@ -81,7 +81,8 @@ function PlaylistMeta(props){
 
 function PlaylistActions(props){
 
-	const showShare = UserContext._currentValue.can.shareMedia;
+	const user = useContext(UserContext);
+	const showShare = !!( user && user.can && user.can.shareMedia );
 	const showOptions = props.loggedinUserPlaylist;
 
 	if( ! showShare && ! showOptions ){

--- a/frontend/src/static/js/pages/PlaylistPage/index.js
+++ b/frontend/src/static/js/pages/PlaylistPage/index.js
@@ -28,6 +28,8 @@ import { PlaylistCreationForm } from '../../components/-NEW-/PlaylistCreationFor
 
 import { NavigationContentApp } from '../../components/-NEW-/NavigationContentApp';
 
+import { PlaylistShareButton } from '../../components/-NEW-/PlaylistShareButton';
+
 import "../styles/PlaylistPage.scss";
 
 function PlayAllLink(props){
@@ -79,15 +81,17 @@ function PlaylistMeta(props){
 
 function PlaylistActions(props){
 
-	/*function onSaveClick(){
-		PlaylistPageActions.toggleSave();
-	}*/
+	const showShare = UserContext._currentValue.can.shareMedia;
+	const showOptions = props.loggedinUserPlaylist;
 
-	return  ( props.loggedinUserPlaylist ? <div className="playlist-actions">
-				{ /*props.loggedinUserPlaylist ? null : <CircleIconButton className="add-to-playlist" onClick={ onSaveClick } title={ props.savedPlaylist ? "Remove" : "Save playlist" }><i className="material-icons">{ this.props.savedPlaylist ? 'playlist_add_check' : 'playlist_add' }</i></CircleIconButton>*/ }
-				{/*<CircleIconButton type="link" href="#" title="Shuffle play"><i className="material-icons">shuffle</i></CircleIconButton>*/}
-				{ props.loggedinUserPlaylist ? <PlaylistOptions /> : null }
-			</div> : null );
+	if( ! showShare && ! showOptions ){
+		return null;
+	}
+
+	return  ( <div className="playlist-actions">
+				{ showShare ? <PlaylistShareButton url={ props.playlistUrl } title={ props.title || '' } thumbnailUrl={ props.compositeThumbnailUrl } /> : null }
+				{ showOptions ? <PlaylistOptions /> : null }
+			</div> );
 }
 
 function PlaylistAuthor(props){
@@ -508,8 +512,6 @@ export class PlaylistPage extends Page {
 							<div>{ PlaylistPageStore.get('visibility') }</div>
 						</div>*/}
 
-					<PlaylistActions loggedinUserPlaylist={ this.state.loggedinUserPlaylist } savedPlaylist={ this.state.savedPlaylist }  />
-
 					{ this.state.description ? <div className="playlist-description">{ this.state.description }</div> : null }
 
 					<PlaylistAuthor
@@ -517,6 +519,8 @@ export class PlaylistPage extends Page {
 						link={ PlaylistPageStore.get('author-link') }
 						thumb={ PlaylistPageStore.get('author-thumb') }
 						loggedinUserPlaylist={ this.state.loggedinUserPlaylist } />
+
+					<PlaylistActions loggedinUserPlaylist={ this.state.loggedinUserPlaylist } savedPlaylist={ this.state.savedPlaylist } title={ this.state.title } playlistUrl={ PlaylistPageStore.get('playlist-url') } compositeThumbnailUrl={ PlaylistPageStore.get('composite-thumbnail-url') } />
 
 				</div>,
 

--- a/frontend/src/static/js/pages/PlaylistPage/store.js
+++ b/frontend/src/static/js/pages/PlaylistPage/store.js
@@ -158,11 +158,22 @@ class PlaylistPageStore extends EventEmitter{
                 }
                 return null;
             case 'composite-thumbnail-url':
-                if( PlaylistPageStoreData[this.id].data && PlaylistPageStoreData[this.id].data.composite_thumbnail_url ){
+                // Prefer the composite thumbnail, fall back to the first media's
+                // thumbnail when the backend couldn't build a composite (e.g.,
+                // empty playlist, fewer than 4 public videos, generation failure).
+                // Both values arrive from the API as relative paths like
+                // "/media/composite_thumbnails/..." or "/media/original/thumbnails/...",
+                // so the same siteBase + startsWith('http') normalization applies.
+                if( PlaylistPageStoreData[this.id].data ){
                     const siteBase = this.mediacms_config.site.url.replace(/\/$/, '');
-                    const path = PlaylistPageStoreData[this.id].data.composite_thumbnail_url;
-                    // API returns a relative path like /media/composite_thumbnails/...
-                    return path.startsWith('http') ? path : siteBase + path;
+                    const compositePath = PlaylistPageStoreData[this.id].data.composite_thumbnail_url;
+                    if( compositePath ){
+                        return compositePath.startsWith('http') ? compositePath : siteBase + compositePath;
+                    }
+                    const fallbackPath = PlaylistPageStoreData[this.id].data.thumbnail_url;
+                    if( fallbackPath ){
+                        return fallbackPath.startsWith('http') ? fallbackPath : siteBase + fallbackPath;
+                    }
                 }
                 return null;
         }

--- a/frontend/src/static/js/pages/PlaylistPage/store.js
+++ b/frontend/src/static/js/pages/PlaylistPage/store.js
@@ -151,6 +151,20 @@ class PlaylistPageStore extends EventEmitter{
                 }
                 this.data.publishDateLabel = this.data.publishDateLabel || 'Created on ' + publishedOnDate( new Date( PlaylistPageStoreData[this.id].data.add_date ), 3 );
                 return this.data.publishDateLabel;
+            case 'playlist-url':
+                if( PlaylistPageStoreData[this.id].playlistId ){
+                    const base = this.mediacms_config.site.url.replace(/\/$/, '');
+                    return base + '/playlist/' + PlaylistPageStoreData[this.id].playlistId;
+                }
+                return null;
+            case 'composite-thumbnail-url':
+                if( PlaylistPageStoreData[this.id].data && PlaylistPageStoreData[this.id].data.composite_thumbnail_url ){
+                    const siteBase = this.mediacms_config.site.url.replace(/\/$/, '');
+                    const path = PlaylistPageStoreData[this.id].data.composite_thumbnail_url;
+                    // API returns a relative path like /media/composite_thumbnails/...
+                    return path.startsWith('http') ? path : siteBase + path;
+                }
+                return null;
         }
         return null;
     }

--- a/frontend/src/static/js/pages/styles/PlaylistPage.scss
+++ b/frontend/src/static/js/pages/styles/PlaylistPage.scss
@@ -575,7 +575,17 @@
 						position:relative;
 						display:block;
 						white-space:nowrap;
-						overflow:hidden;
+
+						// Allow horizontal touch scrolling on mobile so users can
+						// reach off-screen share targets. ItemsInlineSlider already
+						// drives wrapperDom.scrollLeft programmatically for the
+						// arrow buttons and reads it back to stay in sync with
+						// touch swipes, so the two input modes cooperate correctly
+						// once the container is actually scrollable.
+						// overflow-y:hidden prevents a stray vertical scrollbar
+						// when child baselines descend below the line-box.
+						overflow-x:auto;
+						overflow-y:hidden;
 						-webkit-overflow-scrolling:touch;
 						scroll-behavior:smooth;
 					}

--- a/frontend/src/static/js/pages/styles/PlaylistPage.scss
+++ b/frontend/src/static/js/pages/styles/PlaylistPage.scss
@@ -475,6 +475,7 @@
 
 		position:relative;
 		margin-top:12px;
+
 		// Flex row: SHARE aligned left, three-dot menu pushed to the right
 		// to visually land below the EDIT button (which is right-aligned
 		// on the author row above).
@@ -585,6 +586,7 @@
 						top:50%;
 						transform:translateY(-50%);
 						z-index:+2;
+
 						// Icons are ~60px + label ~18px = ~86px tall;
 						// nudge up slightly so the arrow sits on the icon row,
 						// not on the label below.
@@ -607,10 +609,24 @@
 							margin:1px 0;
 							display:block;
 							text-decoration:none;
-							outline:0;
 							border:0;
 							background:none;
 							color: var(--body-text-color);
+							border-radius:6px;
+
+							// Suppress the default focus ring for mouse clicks (where
+							// :focus fires without :focus-visible) but restore a visible
+							// ring for keyboard navigation via :focus-visible below.
+							// WCAG 2.4.7 (Focus Visible) requires keyboard users to see
+							// which share option currently has focus.
+							&:focus{
+								outline:0;
+							}
+
+							&:focus-visible{
+								outline:2px solid var(--body-text-color);
+								outline-offset:2px;
+							}
 
 							> *:first-child{
 								display:block;
@@ -718,7 +734,7 @@
 						width:100%;
 						height:42px;
 						padding:1px 0 1px 16px;
-						font-family:Arial;
+						font-family: Arial, "Helvetica Neue", Helvetica, sans-serif;
 						font-size:14px;
 						line-height:normal;
 						border:0;

--- a/frontend/src/static/js/pages/styles/PlaylistPage.scss
+++ b/frontend/src/static/js/pages/styles/PlaylistPage.scss
@@ -474,6 +474,13 @@
 	.playlist-actions{
 
 		position:relative;
+		margin-top:12px;
+		// Flex row: SHARE aligned left, three-dot menu pushed to the right
+		// to visually land below the EDIT button (which is right-aligned
+		// on the author row above).
+		display:flex;
+		align-items:center;
+		justify-content:space-between;
 
 		a.circle-icon-button,
 		button.circle-icon-button{
@@ -483,6 +490,257 @@
 
 			&:first-child{
 				margin-left:-8px;
+			}
+		}
+
+		> .playlist-options-wrap{
+			margin-left:auto;
+		}
+
+		.share{
+			display:inline-block;
+			position:relative;
+
+			// The Popup wrapper defaults to width:300px; display:block which would
+			// stretch .share's inline-block box and push sibling items (the three-dot
+			// menu) 300px to the right when the popup mounts. Since the real content
+			// (.popup-fullscreen) is position:fixed, we can safely take the intermediate
+			// .popup element out of flow so .share stays sized to its button alone.
+			> .popup{
+				position:absolute;
+				top:0;
+				left:0;
+				width:0;
+				height:0;
+			}
+
+			> button{
+				font-size:13px;
+				font-weight:500;
+				border:0;
+				background:none;
+				cursor:pointer;
+				padding:0;
+
+				> *{
+					display:inline-block;
+				}
+			}
+
+			.popup-fullscreen .popup-main > .playlist-share-options{
+				position:relative;
+				z-index:+1;
+				display:inline-block;
+				background-color: var(--popup-bg-color);
+				color: var(--body-text-color);
+				text-align:initial;
+				border-radius:2px;
+				box-shadow: 0 16px 24px 2px rgba(0,0,0, 0.14), 0 6px 30px 5px rgba(0,0,0, 0.12), 0 8px 10px -5px rgba(0,0,0, 0.4);
+				max-width:560px;
+				width:calc(100vw - 80px);
+
+				.scrollable-content{
+					display:block;
+					padding:20px 24px 8px;
+					overflow:auto;
+				}
+
+				.share-popup-title{
+					font-size:16px;
+					font-weight:500;
+					margin-bottom:16px;
+					line-height:1.25;
+					color: var(--body-text-color);
+				}
+
+				.share-preview{
+					margin-bottom:20px;
+
+					img{
+						display:block;
+						width:100%;
+						max-width:512px;
+						height:auto;
+						border-radius:4px;
+						box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+					}
+				}
+
+				.share-options{
+					position:relative;
+					margin-bottom:16px;
+
+					.share-options-inner{
+						position:relative;
+						display:block;
+						white-space:nowrap;
+						overflow:hidden;
+						-webkit-overflow-scrolling:touch;
+						scroll-behavior:smooth;
+					}
+
+					.previous-slide,
+					.next-slide{
+						position:absolute;
+						top:50%;
+						transform:translateY(-50%);
+						z-index:+2;
+						// Icons are ~60px + label ~18px = ~86px tall;
+						// nudge up slightly so the arrow sits on the icon row,
+						// not on the label below.
+						margin-top:-9px;
+					}
+
+					.previous-slide{ left:-4px; }
+					.next-slide{ right:-4px; }
+
+					.sh-option{
+						vertical-align:top;
+						position:relative;
+						display:inline-block;
+						padding-right:8px;
+						text-align:center;
+
+						a,
+						button{
+							padding:5px 5px 2px;
+							margin:1px 0;
+							display:block;
+							text-decoration:none;
+							outline:0;
+							border:0;
+							background:none;
+							color: var(--body-text-color);
+
+							> *:first-child{
+								display:block;
+								width:60px;
+								height:60px;
+								line-height:60px;
+								margin:0 auto 8px;
+								border-radius:50%;
+								background-position:center;
+								background-repeat:no-repeat;
+							}
+
+							> *:last-child{
+								font-size:13px;
+								line-height:18px;
+								overflow:hidden;
+								color: var(--body-text-color);
+							}
+
+							.material-icons{
+								padding:0;
+								margin:0 0 0 1px;
+								line-height:1;
+								font-size:30px;
+								overflow:hidden;
+								color:#fff;
+							}
+						}
+					}
+
+					.share-fb a > *:first-child,
+					.share-fb button > *:first-child{
+						background-color:rgb(59,89,152);
+						background-image:url("../../../images/social-media-icons/fb-logo.png");
+					}
+					.share-tw a > *:first-child,
+					.share-tw button > *:first-child{
+						background-color:rgb(29,161,242);
+						background-image:url("../../../images/social-media-icons/twitter-logo.png");
+					}
+					.share-reddit a > *:first-child,
+					.share-reddit button > *:first-child{
+						background-color:rgb(255,69,0);
+						background-image:url("../../../images/social-media-icons/reddit-logo.png");
+					}
+					.share-tumblr a > *:first-child,
+					.share-tumblr button > *:first-child{
+						background-color:rgb(53,70,92);
+						background-image:url("../../../images/social-media-icons/tumblr-logo.png");
+					}
+					.share-pinterest a > *:first-child,
+					.share-pinterest button > *:first-child{
+						background-color:rgb(189,8,28);
+						background-image:url("../../../images/social-media-icons/pinterest-logo.png");
+					}
+					.share-vk a > *:first-child,
+					.share-vk button > *:first-child{
+						background-color:rgb(70,128,194);
+						background-image:url("../../../images/social-media-icons/vk-logo.png");
+					}
+					.share-linkedin a > *:first-child,
+					.share-linkedin button > *:first-child{
+						background-color:rgb(0,119,181);
+						background-image:url("../../../images/social-media-icons/linkedin-logo.png");
+					}
+					.share-mix a > *:first-child,
+					.share-mix button > *:first-child{
+						background-color:rgb(255,130,38);
+						background-image:url("../../../images/social-media-icons/mix-logo.png");
+					}
+					.share-email a > *:first-child,
+					.share-email button > *:first-child{
+						background-color:rgb(136,136,136);
+					}
+					.share-whatsapp a > *:first-child,
+					.share-whatsapp button > *:first-child{
+						background-color:rgb(37,211,102);
+						background-image:url("../../../images/social-media-icons/whatsapp-logo.png");
+					}
+					.share-telegram a > *:first-child,
+					.share-telegram button > *:first-child{
+						background-color:rgb(0,136,204);
+						background-position:11px;
+						background-image:url("../../../images/social-media-icons/telegram-logo.png");
+					}
+				}
+
+				.copy-field{
+					$button-width: 5.5rem;
+
+					position:relative;
+					width:100%;
+					padding:0 24px 20px;
+					color: var(--body-text-color);
+
+					> div{
+						position:relative;
+						display:block;
+						padding-right:$button-width;
+						border:1px solid var(--popup-hr-bg-color);
+						border-radius:2px;
+					}
+
+					input[type="text"]{
+						width:100%;
+						height:42px;
+						padding:1px 0 1px 16px;
+						font-family:Arial;
+						font-size:14px;
+						line-height:normal;
+						border:0;
+						background:none;
+						color: var(--body-text-color);
+					}
+
+					button{
+						position:absolute;
+						top:0;
+						right:0;
+						width:$button-width;
+						height:42px;
+						line-height:20px;
+						border:0;
+						background:none;
+						font-size:14px;
+						font-weight:500;
+						cursor:pointer;
+						color: var(--theme-color, #ec1c24);
+					}
+				}
 			}
 		}
 

--- a/templates/cms/playlist.html
+++ b/templates/cms/playlist.html
@@ -16,28 +16,30 @@
 <meta property="og:description" content="{{ playlist.description|striptags|truncatewords:30 }}">
 <meta property="og:type" content="website">
 
-{% if playlist.composite_thumbnail_url %}
+{% if playlist.has_composite_thumbnail %}
 <meta property="og:image" content="{{FRONTEND_HOST}}{{ playlist.composite_thumbnail_url }}">
 <meta property="og:image:width" content="1280">
 <meta property="og:image:height" content="720">
+<meta name="twitter:image" content="{{FRONTEND_HOST}}{{ playlist.composite_thumbnail_url }}">
+{% elif playlist.thumbnail_url %}
+<meta property="og:image" content="{{FRONTEND_HOST}}{{ playlist.thumbnail_url }}">
+<meta name="twitter:image" content="{{FRONTEND_HOST}}{{ playlist.thumbnail_url }}">
 {% else %}
 <meta property="og:image" content="{{FRONTEND_HOST}}/media/userlogos/cinemata_share_banner-01.png">
+<meta name="twitter:image" content="{{FRONTEND_HOST}}/media/userlogos/cinemata_share_banner-01.png">
 {% endif %}
 
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="{{ playlist.title }}">
 <meta name="twitter:description" content="{{ playlist.description|striptags|truncatewords:30 }}">
-{% if playlist.composite_thumbnail_url %}
-<meta name="twitter:image" content="{{FRONTEND_HOST}}{{ playlist.composite_thumbnail_url }}">
-{% endif %}
 
 <script type="application/ld+json">
 {
     "@context": "https://schema.org",
     "@type": "ItemList",
-    "name": "{{ playlist.title }}",
-    "url": "{{FRONTEND_HOST}}{{ playlist.get_absolute_url }}",
-    "description": "{{ playlist.description|striptags|truncatewords:30 }}",
+    "name": "{{ playlist.title|escapejs }}",
+    "url": "{{ FRONTEND_HOST|escapejs }}{{ playlist.get_absolute_url|escapejs }}",
+    "description": "{{ playlist.description|striptags|truncatewords:30|escapejs }}",
     "numberOfItems": {{ playlist.media_count }}
 }
 </script>
@@ -47,6 +49,8 @@
 <meta property="og:type" content="website">
 <meta property="og:image" content="{{FRONTEND_HOST}}/media/userlogos/cinemata_share_banner-01.png">
 <meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Playlist - {{PORTAL_NAME}}">
+<meta name="twitter:image" content="{{FRONTEND_HOST}}/media/userlogos/cinemata_share_banner-01.png">
 {% endif %}
 
 {% endblock headermeta %}

--- a/templates/cms/playlist.html
+++ b/templates/cms/playlist.html
@@ -21,9 +21,9 @@
 <meta property="og:image:width" content="1280">
 <meta property="og:image:height" content="720">
 <meta name="twitter:image" content="{{FRONTEND_HOST}}{{ playlist.composite_thumbnail_url }}">
-{% elif playlist.thumbnail_url %}
-<meta property="og:image" content="{{FRONTEND_HOST}}{{ playlist.thumbnail_url }}">
-<meta name="twitter:image" content="{{FRONTEND_HOST}}{{ playlist.thumbnail_url }}">
+{% elif playlist.public_thumbnail_url %}
+<meta property="og:image" content="{{FRONTEND_HOST}}{{ playlist.public_thumbnail_url }}">
+<meta name="twitter:image" content="{{FRONTEND_HOST}}{{ playlist.public_thumbnail_url }}">
 {% else %}
 <meta property="og:image" content="{{FRONTEND_HOST}}/media/userlogos/cinemata_share_banner-01.png">
 <meta name="twitter:image" content="{{FRONTEND_HOST}}/media/userlogos/cinemata_share_banner-01.png">

--- a/templates/cms/playlist.html
+++ b/templates/cms/playlist.html
@@ -2,11 +2,57 @@
 {% load static %}
 {% load django_vite %}
 
-{% block headtitle %}Playlist - {{PORTAL_NAME}}{% endblock headtitle %}
+{% block headtitle %}{% if playlist %}{{ playlist.title }} - {% endif %}{{PORTAL_NAME}}{% endblock headtitle %}
+
+{% block headermeta %}
+
+{% if playlist %}
+<link rel="canonical" href="{{FRONTEND_HOST}}{{ playlist.get_absolute_url }}">
+
+<meta name="description" content="{{ playlist.description|striptags|truncatewords:30 }}">
+
+<meta property="og:title" content="{{ playlist.title }}">
+<meta property="og:url" content="{{FRONTEND_HOST}}{{ playlist.get_absolute_url }}">
+<meta property="og:description" content="{{ playlist.description|striptags|truncatewords:30 }}">
+<meta property="og:type" content="website">
+
+{% if playlist.composite_thumbnail_url %}
+<meta property="og:image" content="{{FRONTEND_HOST}}{{ playlist.composite_thumbnail_url }}">
+<meta property="og:image:width" content="1280">
+<meta property="og:image:height" content="720">
+{% else %}
+<meta property="og:image" content="{{FRONTEND_HOST}}/media/userlogos/cinemata_share_banner-01.png">
+{% endif %}
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="{{ playlist.title }}">
+<meta name="twitter:description" content="{{ playlist.description|striptags|truncatewords:30 }}">
+{% if playlist.composite_thumbnail_url %}
+<meta name="twitter:image" content="{{FRONTEND_HOST}}{{ playlist.composite_thumbnail_url }}">
+{% endif %}
+
+<script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    "name": "{{ playlist.title }}",
+    "url": "{{FRONTEND_HOST}}{{ playlist.get_absolute_url }}",
+    "description": "{{ playlist.description|striptags|truncatewords:30 }}",
+    "numberOfItems": {{ playlist.media_count }}
+}
+</script>
+
+{% else %}
+<meta property="og:title" content="Playlist - {{PORTAL_NAME}}">
+<meta property="og:type" content="website">
+<meta property="og:image" content="{{FRONTEND_HOST}}/media/userlogos/cinemata_share_banner-01.png">
+<meta name="twitter:card" content="summary_large_image">
+{% endif %}
+
+{% endblock headermeta %}
 
 {% block topimports %}{% vite_asset 'src/entries/playlist.js' %}{%endblock topimports %}
 
 {% block content %}
 {% if user %}<div id="page-playlist"></div>{% endif %}
 {% endblock %}
-

--- a/templates/config/index.html
+++ b/templates/config/index.html
@@ -3,6 +3,7 @@
 	var MediaCMS = {
 		{% if media %}mediaId: "{{media}}", {% endif %}
 		{% if user %}profileId: "{{user.username}}", {% endif %}
+		{% if playlist %}playlistId: "{{playlist.friendly_token}}", {% endif %}
 	};
 
 	{% include "config/core/api.html" %}


### PR DESCRIPTION
## Description

Adds playlist sharing with dynamically generated composite thumbnails. When users share a playlist link on social media, crawlers now fetch a grid image of the first N video thumbnails (2×2 / 2×3 / 2×4 / 3×4 depending on playlist length) instead of a blank preview. A share button with a modal is added to the playlist page, providing a thumbnail preview, social platform buttons, and a copy-link field.

**Backend**
- `files/helpers.py` — New `generate_composite_thumbnail(playlist)` using Pillow. Produces a 1280×720 JPEG grid:
  - 4–5 videos → 2×2
  - 6–7 videos → 2×3
  - 8–11 videos → 2×4
  - 12+ videos → 3×4
  - <4 videos → returns `None`, caller falls back to the first media's `thumbnail_url`
  - Atomic temp-file + `os.replace()` write prevents partial reads under concurrent crawler requests
  - Specific exception handling with `logger.warning` instead of broad `except`
- `files/models.py` — `Playlist.composite_thumbnail_url` is a `@cached_property` that lazily generates the composite on first access and caches the file on disk. Signal handlers (`playlist_pre_delete`, `playlist_media_save`, `playlist_media_delete`) delete the cached file when playlist media changes so the next access regenerates it.
- `files/secure_media_views.py` — `composite_thumbnails/` added to `PUBLIC_MEDIA_PATHS` so unauthenticated social media crawlers can fetch the OG image.
- `files/serializers.py` — `composite_thumbnail_url` exposed on `PlaylistDetailSerializer` for the frontend share modal.

**Template**
- `templates/cms/playlist.html` — New `headermeta` block with Open Graph, Twitter Card, and JSON-LD `ItemList` tags. Includes `og:image:width/height=1280/720` and fallback to the default share banner when no composite is available or the playlist is 404.
- `templates/config/index.html` — passes `playlistId` to `window.MediaCMS`.

**Frontend**
- `frontend/.../components/-NEW-/PlaylistShareButton.js` (new) — popup trigger following the `MediaShareButton` pattern.
- `frontend/.../components/-NEW-/PlaylistShareOptions.js` (new) — share modal adapted from `MediaShareOptions`. Props-based URL/title/thumbnail (decoupled from stores), URL-encoded share links, `navigator.clipboard.writeText` copy, and a horizontal slider with prev/next arrows. `stopPropagation()` on arrow handlers prevents React re-renders from triggering the outside-click modal dismissal.
- `frontend/.../pages/PlaylistPage/index.js` — `PlaylistActions` now renders for all viewers (not just the owner), gated by `UserContext.can.shareMedia`. Uses flexbox to keep SHARE left-aligned and the owner's three-dot menu right-aligned on the same row.
- `frontend/.../pages/PlaylistPage/store.js` — new `playlist-url` and `composite-thumbnail-url` getters with trailing-slash normalization.
- `frontend/.../pages/styles/PlaylistPage.scss` — scoped styles for `.playlist-actions` flex layout, `.share` wrapper (with a popup-out-of-flow hack to prevent the 300px default popup width from stretching the inline-block layout), `.playlist-share-options` modal card, preview image, social icons with colored circle backgrounds, prev/next slider arrows, and copy field.

**No database migration** — the composite thumbnail path is derived from `Playlist.friendly_token`.

## Related Issue

Fixes #406

## Motivation and Context

Shared playlist links currently show no preview image on social media because `templates/cms/playlist.html` had zero Open Graph meta tags. This hurts click-through rates for partner organizations like Gawad Alternatibo and Freedom Film Festival who actively promote their curated collections on Facebook, Twitter, and WhatsApp. This PR addresses #406 as part of Milestone 2's enhanced community engagement features.

## How Has This Been Tested?

**Tested locally against all 13 acceptance criteria from the ticket:**

| # | Criterion | Status | Notes |
|---|---|---|---|
| 1 | Composite thumbnails for 4, 6, 8, 12+ videos | ✅ | Verified 2×2, 2×3, 2×4, 3×4 generate 1280×720 JPEGs |
| 2 | <4 videos fall back to single video thumbnail | ✅ | 3-video playlist returns first media's `thumbnail_url` |
| 3 | Share button in correct location | ✅ | Rendered under author row on playlist details panel |
| 4 | Share modal displays all social media options | ✅ | 9 platforms from site config (VK/Mix not enabled in `features.html` site-wide) |
| 5 | Composite thumbnail shown in share preview | ✅ | Preview `<img>` at top of modal |
| 6 | Copy link functionality works | ✅ | Clipboard API + COPY button |
| 7 | All share links work correctly | ✅ | URL-encoded href attributes verified for all 9 platforms |
| 8 | Cached, not regenerated | ✅ | `@cached_property` + on-disk cache. 1st access 0.03ms, 2nd access 0ms, regen after delete 34ms |
| 9 | OG meta tags correctly set | ✅ | Verified via curl: `og:title/url/description/type/image` + `og:image:width/height=1280/720`, Twitter card, JSON-LD `ItemList` |
| 10 | Shared links display thumbnail on FB/Twitter | ✅ | Composite image publicly accessible (HTTP 200 no auth, 1280×720 JPEG). Real crawler verification requires a public URL. |
| 11 | Handles missing/broken thumbnails gracefully | ✅ | Returns `None` when can't fill grid, caller falls back to `thumbnail_url`. No crashes. |
| 12 | Performance: generation within 3 seconds | ✅ | 14–35 ms generation time (100× under budget) |
| 13 | Mobile responsive | ✅ | Verified at 375×812: modal centers, preview scales, social icons slide, copy field wraps |

**Test setup:**
- Local dev with Docker Postgres + Redis, Django dev server, Vite dev server
- Created test playlists of sizes 3, 4, 6, 8, 12 videos
- Tested logged in as `jeretest` (playlist owner) and logged out (anonymous viewer)
- Verified composite generation, cache invalidation on `PlaylistMedia.delete()`, and atomic-write error handling with forced `os.replace` exception

**Sanity checks:**
- `python manage.py check` passes
- All modified Python files compile
- Playwright automation confirmed share modal open/close, slider scrolling, URL encoding, and layout stability before/after opening the modal

## Screenshots (if appropriate):
<img width="656" height="665" alt="image" src="https://github.com/user-attachments/assets/e8910232-2ab8-4abe-9fa5-7df5cf94797e" />
<img width="673" height="653" alt="image" src="https://github.com/user-attachments/assets/4e371d76-41e4-4208-93b2-d7e35e85e53b" />
<img width="461" height="964" alt="image" src="https://github.com/user-attachments/assets/61552fea-46ab-4039-84fb-9f3afd79f64d" />


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):
- [x] I have not imported `flux` in a new component
- [ ] If adding a new feature, I used Modern Track patterns
- [ ] New features do not create new SCSS files (use Tailwind instead)

> **Note on Modern Track:** This PR extends the existing legacy `PlaylistPage` React components rather than using Modern Track / Tailwind patterns, because the playlist page itself is still on the legacy stack and reuses the existing `MediaShareButton` pattern. Migrating the playlist page to Modern Track is a separate concern outside this ticket's scope.

## QA Test Cases

**Setup:** On staging, log in as a regular (non-admin) test user and create a few playlists:

- `qa-small` — 2 public videos
- `qa-grid` — 6 public videos
- `qa-mixed` — 4 public + 2 private videos

### 1. Share button appears for everyone

- [ ] Log out and open any playlist → **SHARE** button is visible below the author row.
- [ ] Log in as the playlist owner and reopen the same playlist → **SHARE** is on the left, three-dot menu on the right, on the same row.

### 2. Share modal works

- [ ] Click **SHARE** → modal opens with a preview image, social icons, and a URL copy field.
- [ ] Click outside the modal → modal closes.
- [ ] Click **COPY** → notification "Link copied to clipboard" appears; paste it somewhere to confirm the URL is correct.
- [ ] Click Facebook, Twitter, WhatsApp icons → each opens the right share page in a new tab with the playlist URL and title pre-filled.

### 3. Composite thumbnail in preview

- [ ] Open **SHARE** on `qa-grid` (6 videos) → preview shows a **2×3 grid** of video thumbnails.
- [ ] Open **SHARE** on `qa-small` (2 videos) → preview shows a **single video thumbnail** (fallback).

### 4. Private videos don't leak into the composite

- [ ] Open `qa-mixed` in an **incognito window** (logged out).
- [ ] Open the share modal → the preview image only contains the **4 public** videos, never the 2 private ones.

### 5. Social media preview works

- [ ] Open https://developers.facebook.com/tools/debug/ and paste the staging URL of `qa-grid`. Click **Scrape Again**.
- [ ] **Expected:** Facebook shows the 2×3 composite image, the playlist title, and description. No "missing og:image" warnings.
- [ ] Bonus: repeat on https://cards-dev.twitter.com/validator — Twitter should show the same composite as a large image card.

### 6. Mobile

- [ ] Open any playlist on a mobile device (or 375px viewport in dev tools).
- [ ] Tap **SHARE** → modal fits within the screen, preview scales down, COPY button is tappable.
- [ ] Swipe left on the row of social icons → off-screen icons become reachable via swipe.

### 7. Sanity regression checks

- [ ] Existing playlists still render correctly.
- [ ] Owner can still edit / add / remove videos without errors.
- [ ] The media page (not playlist page) share button still works as before.
- [ ] No new errors in the browser console on any playlist page.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Playlists now generate and surface composite thumbnails (multi-media preview images) across UI and API.
  * Added playlist sharing UI: SHARE button, fullscreen share panel with per-platform targets and copy-link action.
  * Pages now include improved SEO/social previews: dynamic titles, canonical URLs, OG/Twitter tags, and JSON-LD.

* **Style / UX**
  * Tweaked playlist actions layout and popup styling for improved alignment and fullscreen share presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
