### PR TITLE
fix: resolve Django migration conflict in files app

### DIFF
--- a/files/migrations/0019_category_topic_slug.py
+++ b/files/migrations/0019_category_topic_slug.py
@@ -1,12 +1,11 @@
-"""Add nullable slug fields to Category and Topic — backfilled in 0018."""
+"""Add nullable slug fields to Category and Topic — backfilled in 0020."""
 
 from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
-        ("files", "0016_add_encoding_drain_composite_index"),
+        ("files", "0018_add_hls_encryption_fields"),
     ]
 
     operations = [

--- a/files/migrations/0020_populate_slugs.py
+++ b/files/migrations/0020_populate_slugs.py
@@ -12,7 +12,7 @@ def populate_slugs(apps, schema_editor):
             n = 1
             while model.objects.filter(slug=slug).exclude(pk=obj.pk).exists():
                 suffix = f"-{n}"
-                slug = f"{base[:100 - len(suffix)]}{suffix}"
+                slug = f"{base[: 100 - len(suffix)]}{suffix}"
                 n += 1
             obj.slug = slug
             obj.save(update_fields=["slug"])
@@ -22,9 +22,8 @@ def populate_slugs(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
-        ("files", "0017_category_topic_slug"),
+        ("files", "0019_category_topic_slug"),
     ]
 
     operations = [


### PR DESCRIPTION
## Description
Renumber the slug migrations (`0017_category_topic_slug` / `0018_populate_slugs`) to `0019` / `0020` and update their dependency chain so they come after the already-merged `0018_add_hls_encryption_fields`, resolving the Django migration graph conflict.

## Related Issue
N/A

## Motivation and Context
Two feature branches both created migrations branching from the same parent in the `files` app, causing a leaf-node conflict that prevents `manage.py migrate` from running. This linearizes the graph.

## How Has This Been Tested?
- `manage.py showmigrations files` confirms a single linear chain with no conflicts

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):
- [x] I have not imported `flux` in a new component
- [ ] If adding a new feature, I used Modern Track patterns
- [ ] New features do not create new SCSS files (use Tailwind instead)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database migrations and their dependencies to maintain proper sequencing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->