### PR TITLE
feat(ui-variant): add legacy/revamp UI variant gate with shared design tokens

### DIFF
--- a/cms/context_processors.py
+++ b/cms/context_processors.py
@@ -2,6 +2,8 @@ import os
 
 from django.conf import settings
 
+from cms.ui_variant import _SAFE_VARIANTS
+
 
 def ui_settings(request):
     """Add UI settings to template context"""
@@ -24,4 +26,9 @@ def ui_settings(request):
         "MAINTENANCE_MODE_ELAPSED_TIME": maintenance_elapsed_time,  # Total seconds since start
         "DEFAULT_FROM_EMAIL": getattr(settings, "DEFAULT_FROM_EMAIL", "support@example.com"),
         "VITE_DEV_MODE": os.getenv("VITE_DEV_MODE", "").lower() in ("1", "true", "yes"),
+        # Precedence: set by resolve_template on this request > settings.UI_VARIANT_DEFAULT > 'legacy'
+        # Clamped to _SAFE_VARIANTS so any operator misconfiguration cannot reach the JS bootstrap.
+        "UI_VARIANT": (
+            lambda v: v if v in _SAFE_VARIANTS else "legacy"
+        )(getattr(request, "ui_variant", getattr(settings, "UI_VARIANT_DEFAULT", "legacy"))),
     }

--- a/cms/settings.py
+++ b/cms/settings.py
@@ -576,6 +576,13 @@ VIDEO_PLAYER_FEATURED_VIDEO_ON_INDEX_PAGE = False
 # Video UI/UX settings
 USE_ROUNDED_CORNERS = True  # Default: rounded corners enabled
 
+# UI variant gate — incremental revamp rollout
+# UI_VARIANT_DEFAULT: fallback variant for non-migrated pages (must stay "legacy")
+# UI_VARIANT_REVAMP_PAGES: list of page keys served with the revamp template for all users
+# Override in local_settings.py for per-environment control
+UI_VARIANT_DEFAULT = "legacy"
+UI_VARIANT_REVAMP_PAGES = []  # e.g. ["home"] to enable the revamp home page
+
 # allow option to override the default admin url
 DJANGO_ADMIN_URL = "admin/"
 

--- a/cms/ui_variant.py
+++ b/cms/ui_variant.py
@@ -1,0 +1,27 @@
+from django.conf import settings
+
+_SAFE_VARIANTS = frozenset({"legacy", "revamp"})
+
+
+def resolve_template(request, page_key, legacy_template, revamp_template):
+    """Return the template to render for a page, and set request.ui_variant.
+
+    Resolution order:
+    1. page_key in UI_VARIANT_REVAMP_PAGES → revamp (all users)
+    2. is_staff + ?ui=revamp query param → revamp (staff preview only)
+    3. Otherwise → legacy
+    """
+    revamp_pages = getattr(settings, "UI_VARIANT_REVAMP_PAGES", None) or []
+
+    if page_key in revamp_pages:
+        variant = "revamp"
+    else:
+        user = getattr(request, "user", None)
+        is_staff = getattr(user, "is_staff", False)
+        if is_staff and request.GET.get("ui") == "revamp":
+            variant = "revamp"
+        else:
+            variant = "legacy"
+
+    request.ui_variant = variant
+    return revamp_template if variant == "revamp" else legacy_template

--- a/docs/brainstorms/2026-04-19-ui-variant-gate-requirements.md
+++ b/docs/brainstorms/2026-04-19-ui-variant-gate-requirements.md
@@ -1,0 +1,99 @@
+---
+date: 2026-04-19
+topic: ui-variant-gate
+---
+
+# UI Variant Gate with Shared Design Tokens
+
+## Problem Frame
+
+CinemataCMS is undergoing a major frontend redesign (Kumquat design system). Django renders templates directly and mounts Vite entry points per page. Three gaps block an incremental rollout:
+
+1. No server-side mechanism to serve a different template on the same URL based on configuration.
+2. Legacy SCSS pages and revamp Tailwind pages will have different CSS token palettes — without a runtime gate, either the old tokens bleed into revamp pages or the new tokens break legacy pages.
+3. Developers need a safe way to preview revamp pages before they are released to all users.
+
+## Requirements
+
+**Backend Variant Infrastructure**
+
+- R1. A `resolve_template(request, page_key, legacy_template, revamp_template)` helper returns `revamp_template` when `page_key` is in `settings.UI_VARIANT_REVAMP_PAGES` (accessed via `getattr(settings, 'UI_VARIANT_REVAMP_PAGES', [])` so a missing entry degrades to legacy, not an error), `legacy_template` otherwise. Users with `request.user.is_staff` can override to revamp via `?ui=revamp` query param (per-request, not persisted). The helper sets `request.ui_variant` as a side effect so downstream code can read the resolved value.
+- R2. `UI_VARIANT` is exposed to every template by extending the existing `cms/context_processors.ui_settings` function (not a new registered processor), defaulting to `"legacy"` if no view called `resolve_template()` (i.e., non-migrated pages). This keeps context processor registration to a single entry.
+- R3. Settings in `cms/settings.py` control the gate: `UI_VARIANT_DEFAULT = "legacy"`, `UI_VARIANT_REVAMP_PAGES = []`. Operators may override in `local_settings.py` for per-environment control.
+- R4. `?ui=revamp` staff preview is per-request only — no cookie, no session persistence. Non-staff users who send this param see the legacy template.
+
+**Frontend Bootstrap**
+
+- R5. The `templates/config/index.html` bootstrap adds `ui: { variant: "{{ UI_VARIANT }}" }` as a property inside the `MediaCMS` object literal (not as a separate post-assignment), so React code can read `window.MediaCMS.ui.variant` at initialization.
+
+**CSS Token Gate**
+
+- R6. `base.html` (or equivalent shared layout) sets `data-ui-variant="{{ UI_VARIANT }}"` on `<body>`. This is the runtime gate that makes CSS token scoping possible without build-time branching.
+- R7. **[Phase 3 — blocked on Figma token extraction]** Kumquat (revamp) design tokens use a distinct CSS var namespace (e.g., `--kq-brand-primary`) and are defined under the `body[data-ui-variant="revamp"]` selector. Legacy tokens (`body.light_theme` / `body.dark_theme`) are not modified. The Kumquat namespace avoids any collision with existing legacy vars.
+- R8. **[Phase 3 — blocked on Figma token extraction]** The `@theme inline` block in `frontend/src/static/css/tailwind.css` is extended with new entries mapping Kumquat CSS vars to Tailwind utility classes (e.g., `--color-kq-brand-primary: var(--kq-brand-primary)`). Revamp components use these new utility classes; legacy components use existing ones. Both sets of Tailwind mappings coexist in the same build.
+
+**Revamp Page Convention**
+
+- R9. Each revamp page container must carry `data-modern-track` to activate the `all: revert-layer` CSS isolation that prevents legacy SCSS from bleeding into Tailwind-rendered components.
+- R10. All revamp page code lives in `frontend/src/features/<page-name>/`, consistent with the modern track convention documented in `CONTRIBUTING.md`. No third frontend directory is created.
+- R11. Each revamp page has: a Django template (`templates/cms/<page>_revamp.html`), a Vite entry (`frontend/src/entries/<page>-revamp.js`), and an entry registered in `frontend/vite.config.js`.
+
+**Home Page Pilot (Phase 2)**
+
+- R12. The `index` view in `files/views.py` calls `resolve_template()` with key `"home"`, legacy template `"cms/index.html"`, revamp template `"cms/index_revamp.html"`.
+- R13. `frontend/src/features/home/` is created following the modern track convention documented in `CONTRIBUTING.md`. Internal directory structure is a planning decision.
+- R14. The home page is enabled for all users by adding `"home"` to `UI_VARIANT_REVAMP_PAGES`. Before that, only staff can preview via `/?ui=revamp`.
+
+**Testing**
+
+- R15. Tests (location to be confirmed against project's test discovery path during planning) cover: legacy default, allowlisted page (anon + logged-in), staff preview param, non-staff preview ignored, invalid variant param ignored, context processor exposes `UI_VARIANT`, bootstrap HTML contains `MediaCMS.ui.variant`, rendered response body carries `data-ui-variant` attribute for allowlisted pages, and the home revamp template contains `data-modern-track` on its root container.
+
+## Success Criteria
+
+- A page added to `UI_VARIANT_REVAMP_PAGES` serves the revamp template to all users with no code changes beyond the settings entry.
+- Legacy pages continue rendering unchanged when not in the allowlist.
+- Staff can preview any revamp page via `?ui=revamp` with no session side effects.
+- Revamp components use Kumquat tokens via Tailwind classes; legacy components use legacy SCSS vars — no visual cross-contamination between the two on the same browser session.
+- Removing a page from `UI_VARIANT_REVAMP_PAGES` immediately rolls back to legacy with no deploy required.
+
+## Scope Boundaries
+
+- No per-user opt-in, cookies, or session-based variant persistence.
+- No `django-waffle` or percentage rollout — the gate is binary per page.
+- `revamp` is a UI variant, not a new frontend track. `CONTRIBUTING.md` dual-track architecture (legacy / modern) is unchanged.
+- No middleware for variant resolution — page-specific via view helper.
+- Phase 3 (Kumquat token migration) and Phase 4 (expanding to more pages) are in scope as follow-on work but not gating the Phase 1+2 delivery.
+
+## Key Decisions
+
+- **`body[data-ui-variant]` as CSS gate**: Kumquat tokens are scoped under this selector so both palettes can coexist in trunk without conflicting. Separate palette files or build-time branching were rejected as they break trunk-based development.
+- **`resolve_template()` helper, not middleware**: Variant is page-specific (depends on the allowlist), so resolution belongs in the view, not on every request.
+- **Allowlist is the only gate**: When a page is in `UI_VARIANT_REVAMP_PAGES`, 100% of users see revamp. No opt-in UX.
+- **`data-modern-track` required on revamp containers**: The existing CSS isolation mechanism (`all: revert-layer` on `[data-modern-track]`) must be applied to revamp page root elements or legacy SCSS bleeds in.
+- **`renderPage` reuse confirmed**: `frontend/src/static/js/_helpers.js:6` exports `renderPage(idSelector, PageComponent)` — revamp entries use this directly.
+- **Staff preview uses `is_staff`**: Django's native `is_staff` flag gates `?ui=revamp` access. A data migration may be needed if `is_staff` is not currently populated for the intended preview audience.
+- **Kumquat token namespace is additive**: Kumquat vars use a distinct prefix (e.g., `--kq-*`) and extend `@theme inline` with new entries. Legacy vars and Tailwind mappings are unchanged. Revamp components use new utility class names; legacy components use existing ones.
+
+## Dependencies / Assumptions
+
+- Kumquat design tokens will be extracted from Figma and provided as CSS custom property names before Phase 3 begins (Figma file was inaccessible during brainstorm).
+- `base.html` can be modified to add `data-ui-variant` to `<body>` without breaking existing pages (the attribute is inert on legacy pages since no CSS targets `body[data-ui-variant="legacy"]`).
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+_(none — all product decisions resolved)_
+
+### Deferred to Planning
+
+- [Affects R6][Technical] Confirm `root.html` (line 66 has bare `<body>`) can be edited to `<body data-ui-variant="{{ UI_VARIANT }}">` without breaking non-migrated pages. `UI_VARIANT` defaults to `"legacy"` via `ui_settings`, so all pages receive the attribute.
+- [Affects R9][Technical] `data-modern-track` is currently applied in the React component (`ModernDemoPage.js`), not the Django template. Confirm whether revamp page components apply it in JS (consistent with existing pattern) or the revamp template applies it in HTML.
+- [Affects R7, R8][Needs research] Kumquat CSS var names — to be extracted from Figma once accessible. No placeholder token names should be committed before Figma is accessible. Planner must verify Figma access before starting Phase 3.
+- [Affects R13][Technical] Verify whether `HomePage` fetches data client-side via TanStack Query, or replicates context from the legacy `index` view. The rollback guarantee (reverting allowlist entry = immediate rollback) only holds if the legacy template and its view context are unchanged during the revamp rollout.
+- [Affects R14][Operational] Define monitoring signals (error rate, JS exception rate) to watch after `"home"` is added to `UI_VARIANT_REVAMP_PAGES`. The binary gate has no partial-rollback lever — monitoring is the safety net.
+- [Affects R15][Technical] Confirm test file location against the project's test discovery path. `tests/test_ui_variant.py` at repo root may need to move to an app-level `tests/` directory.
+
+## Next Steps
+
+-> `/ce:plan` for structured implementation planning

--- a/docs/plans/2026-04-19-001-feat-ui-variant-gate-plan.md
+++ b/docs/plans/2026-04-19-001-feat-ui-variant-gate-plan.md
@@ -1,0 +1,533 @@
+---
+title: "feat: Add legacy/revamp UI variant gate with shared design tokens"
+type: feat
+status: completed
+date: 2026-04-19
+origin: docs/brainstorms/2026-04-19-ui-variant-gate-requirements.md
+---
+
+# feat: Add legacy/revamp UI variant gate with shared design tokens
+
+## Overview
+
+Introduce a server-side UI variant gate that allows CinemataCMS to incrementally roll out a redesigned frontend (Kumquat design system) page-by-page without a big-bang release. Django views call a helper to resolve which template to render; a context processor propagates the resolved variant to all templates; a body attribute and React bootstrap variable expose the variant to CSS and JavaScript respectively. Staff can preview unfinished revamp pages via `?ui=revamp`. This plan covers Phase 1 (backend infrastructure) and Phase 2 (home page pilot). Phase 3 (Kumquat CSS tokens) is deferred until Figma access is restored.
+
+## Problem Frame
+
+Django renders page templates directly and mounts a specific Vite entry point per page. There is no mechanism to serve a different template on the same URL based on configuration, no runtime gate that keeps legacy and revamp CSS tokens isolated in a single build, and no safe staff-only preview path for unfinished revamp pages. (See origin: `docs/brainstorms/2026-04-19-ui-variant-gate-requirements.md`)
+
+## Requirements Trace
+
+- R1. `resolve_template()` helper — returns the correct template, sets `request.ui_variant`, degrades gracefully via `getattr`.
+- R2. `UI_VARIANT` exposed in every template context via `cms/context_processors.ui_settings` extension.
+- R3. `UI_VARIANT_DEFAULT` and `UI_VARIANT_REVAMP_PAGES` settings — overridable in `local_settings.py`.
+- R4. `?ui=revamp` preview gated to `is_staff` — per-request, no persistence.
+- R5. `window.MediaCMS.ui.variant` set inside the bootstrap object literal.
+- R6. `<body data-ui-variant="{{ UI_VARIANT }}">` in `root.html`.
+- R9. `data-modern-track` on revamp React component root elements (applied in JS, consistent with existing `ModernDemoPage` pattern).
+- R10. Revamp code in `frontend/src/features/home/` following modern-track convention.
+- R11. Revamp page has template, Vite entry, and registered rollup input.
+- R12. `index()` view calls `resolve_template()` for the home page.
+- R13. `frontend/src/features/home/` scaffolded following modern-track convention.
+- R14. Enabling the home page is a settings-only change (`UI_VARIANT_REVAMP_PAGES = ["home"]`).
+- R15. Test suite covering all gate scenarios.
+
+**Deferred (Phase 3):**
+- R7. Kumquat CSS vars under `body[data-ui-variant="revamp"]` — **typography now available (Phase 3a)**; color tokens still blocked on Figma access.
+- R8. `@theme inline` extension — typography mappings now available (Phase 3a); `--color-kq-*` color entries still blocked.
+
+## Scope Boundaries
+
+- No per-user opt-in, cookies, or session persistence.
+- No `django-waffle` or percentage rollout — binary per-page gate.
+- `revamp` uses modern-track conventions (`features/` directory, named exports, Tailwind) but is gated by the Django template router, not a separate frontend application. It is a variant of the UI, not a third frontend track — `CONTRIBUTING.md` dual-track architecture (legacy / modern) is unchanged.
+- No middleware — variant resolution is per-view via the helper.
+- Phase 3a (Kumquat typography tokens) is **now in scope** — token definitions received and documented below.
+- Phase 3b (Kumquat color tokens) and Phase 4 (expanding to more pages) remain out of scope — Figma file still inaccessible for colors.
+- The `HomePage` component is scaffolded as a working stub; its visual content is separate design work.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `cms/context_processors.py` — `ui_settings()` function: uses `getattr(request, 'attr', default)` pattern to read request-scoped state set by middleware/view. **Pattern to follow exactly for `UI_VARIANT`.**
+- `cms/settings.py` — `USE_ROUNDED_CORNERS = True` in the `# settings that are related with UX/appearance` block (~line 577): nearest analog for a visual-gate boolean setting. **Pattern to follow for `UI_VARIANT_REVAMP_PAGES`.**
+- `templates/root.html:66` — bare `<body>` with no attributes; confirmed safe to add `data-ui-variant`.
+- `templates/config/index.html` — `var MediaCMS = { ... };` object literal, then includes, then `window.MediaCMS = MediaCMS;`. Add `ui` property inside the literal (the includes add post-literal properties via dot notation — they are separate).
+- `templates/cms/index.html` — extends `base.html`, block `topimports` loads `src/entries/index.js`, block `content` has `<div id="page-home"></div>`. Revamp template mirrors this structure.
+- `frontend/vite.config.js` — `rollupOptions.input`: 29 existing kebab-case entries. Add `'index-revamp': 'src/entries/index-revamp.js'`.
+- `frontend/src/static/js/_helpers.js:6` — `renderPage(idSelector, PageComponent)`: mounts PageHeader, PageSidebar, and the page component. Revamp entries use this directly.
+- `frontend/src/features/notifications/` — canonical modern-track feature: `index.js` (named exports), `components/`, `hooks/`, `stores/`, dedicated `queryClient.js`. **Directory structure to follow.**
+- `frontend/src/entries/notifications.js` — `renderPage('page-notifications', NotificationPage)`. **Entry file pattern to follow.**
+- `frontend/src/features/modern-demo/ModernDemoPage.js` — applies `data-modern-track` on root JSX element. **Pattern for CSS isolation attribute.**
+- `tests/test_index_page_featured.py` — single existing test file at repo root using `django.test.TestCase` and `@override_settings`. **Test file pattern to follow.**
+
+### Institutional Learnings
+
+- None — `docs/solutions/` does not exist in this repo.
+
+### Kumquat Typography Token Definitions (Phase 3a — now available)
+
+Two font families, two-tier type scale. All heading/display use **Barlow Semi Condensed**; all body/caption use **Inter**.
+
+**Note on naming:** Figma class names (e.g., `title-72`) do not always match the actual `font-size` (64px). CSS custom property names use the **actual pixel value** to avoid confusion.
+
+**Font families:**
+```
+--kq-font-family-display: "Barlow Semi Condensed", sans-serif
+--kq-font-family-body: "Inter", sans-serif
+```
+
+**Display/Title scale (Barlow Semi Condensed):**
+| Token slot | font-size | line-height | letter-spacing | Figma class label |
+|---|---|---|---|---|
+| `--kq-font-size-title-64` | 64px | 76px | -0.8px | title-72 |
+| `--kq-font-size-title-56` | 56px | 68px | -0.6px | title-56 |
+
+**Heading scale (Barlow Semi Condensed):**
+| Token slot | font-size | line-height | letter-spacing |
+|---|---|---|---|
+| `--kq-font-size-h1` | 56px | 68px | -0.5px |
+| `--kq-font-size-h2` | 48px | 58px | -0.4px |
+| `--kq-font-size-h3` | 40px | 48px | -0.3px |
+| `--kq-font-size-h4` | 32px | 38px | -0.2px |
+| `--kq-font-size-h5` | 24px | 30px | -0.15px |
+| `--kq-font-size-h6` | 20px | 24px | 0px |
+
+**Body scale (Inter):**
+| Token slot | font-size | line-height |
+|---|---|---|
+| `--kq-font-size-body-18` | 18px | 28px |
+| `--kq-font-size-body-16` | 16px | 24px |
+| `--kq-font-size-body-14` | 14px | 20px |
+| `--kq-font-size-body-12` | 12px | 16px |
+
+**Caption (Inter):**
+| Token slot | font-size | line-height |
+|---|---|---|
+| `--kq-font-size-caption-10` | 10px | 10px |
+
+**Font weights (shared across scales):**
+```
+--kq-font-weight-regular: 400
+--kq-font-weight-medium: 500
+--kq-font-weight-bold: 700
+```
+Note: Figma labels `caption-10-semibold` with `font-weight: 700` — this appears to be a Figma naming error; the token value is 700 (bold), not 600. Use `--kq-font-weight-bold` for this.
+
+**Letter-spacing tokens (for heading scale):**
+```
+--kq-letter-spacing-title-64:  -0.8px
+--kq-letter-spacing-title-56:  -0.6px
+--kq-letter-spacing-h1:        -0.5px
+--kq-letter-spacing-h2:        -0.4px
+--kq-letter-spacing-h3:        -0.3px
+--kq-letter-spacing-h4:        -0.2px
+--kq-letter-spacing-h5:        -0.15px
+--kq-letter-spacing-h6:         0px
+```
+
+**Tailwind `@theme inline` mappings to add (Phase 3a):**
+```css
+/* Font families */
+--font-kq-display: var(--kq-font-family-display);
+--font-kq-body:    var(--kq-font-family-body);
+
+/* Font sizes — generates text-kq-* utilities */
+--text-kq-title-64: var(--kq-font-size-title-64);
+--text-kq-title-56: var(--kq-font-size-title-56);
+--text-kq-h1: var(--kq-font-size-h1);
+--text-kq-h2: var(--kq-font-size-h2);
+--text-kq-h3: var(--kq-font-size-h3);
+--text-kq-h4: var(--kq-font-size-h4);
+--text-kq-h5: var(--kq-font-size-h5);
+--text-kq-h6: var(--kq-font-size-h6);
+--text-kq-body-18: var(--kq-font-size-body-18);
+--text-kq-body-16: var(--kq-font-size-body-16);
+--text-kq-body-14: var(--kq-font-size-body-14);
+--text-kq-body-12: var(--kq-font-size-body-12);
+--text-kq-caption-10: var(--kq-font-size-caption-10);
+
+/* Font weights — generates font-kq-* utilities */
+--font-weight-kq-regular: var(--kq-font-weight-regular);
+--font-weight-kq-medium:  var(--kq-font-weight-medium);
+--font-weight-kq-bold:    var(--kq-font-weight-bold);
+
+/* Tracking (letter-spacing) — generates tracking-kq-* utilities */
+--tracking-kq-title-64: var(--kq-letter-spacing-title-64);
+--tracking-kq-title-56: var(--kq-letter-spacing-title-56);
+--tracking-kq-h1: var(--kq-letter-spacing-h1);
+--tracking-kq-h2: var(--kq-letter-spacing-h2);
+--tracking-kq-h3: var(--kq-letter-spacing-h3);
+--tracking-kq-h4: var(--kq-letter-spacing-h4);
+--tracking-kq-h5: var(--kq-letter-spacing-h5);
+--tracking-kq-h6: var(--kq-letter-spacing-h6);
+
+/* Leading (line-height) — generates leading-kq-* utilities */
+--leading-kq-title-64:  var(--kq-line-height-title-64);   /* 76px */
+--leading-kq-title-56:  var(--kq-line-height-title-56);   /* 68px */
+--leading-kq-h1:        var(--kq-line-height-h1);          /* 68px */
+--leading-kq-h2:        var(--kq-line-height-h2);          /* 58px */
+--leading-kq-h3:        var(--kq-line-height-h3);          /* 48px */
+--leading-kq-h4:        var(--kq-line-height-h4);          /* 38px */
+--leading-kq-h5:        var(--kq-line-height-h5);          /* 30px */
+--leading-kq-h6:        var(--kq-line-height-h6);          /* 24px */
+--leading-kq-body-18:   var(--kq-line-height-body-18);     /* 28px */
+--leading-kq-body-16:   var(--kq-line-height-body-16);     /* 24px */
+--leading-kq-body-14:   var(--kq-line-height-body-14);     /* 20px */
+--leading-kq-body-12:   var(--kq-line-height-body-12);     /* 16px */
+--leading-kq-caption-10: var(--kq-line-height-caption-10); /* 10px */
+```
+
+Revamp components compose typography via Tailwind utilities, e.g.:
+```jsx
+<h1 className="font-kq-display text-kq-h1 leading-kq-h1 tracking-kq-h1 font-kq-bold">
+<p  className="font-kq-body text-kq-body-16 leading-kq-body-16 font-kq-regular">
+```
+
+## Key Technical Decisions
+
+- **`resolve_template()` in `cms/ui_variant.py` (new module)**: Keeps the helper isolated from views and context processors. Views import it explicitly — no magic. The context processor reads `request.ui_variant` set as a side effect. Note: `request.maintenance_remaining` is set by middleware (not a view helper), so this pattern is new in the codebase — valid because Django context processors run after the view returns, but without a direct precedent.
+- **Extend `ui_settings()`, not a new context processor**: Avoids a second entry in `TEMPLATES[0]['OPTIONS']['context_processors']` and keeps all install-level UI flags in one function.
+- **`UI_VARIANT` inside the MediaCMS literal**: The `config/index.html` includes (`api.html`, `url.html`, etc.) add properties via dot notation after the literal closes. Adding `ui` inside the literal keeps initialization atomic and avoids a post-assignment `window.MediaCMS not defined` race.
+- **`data-modern-track` applied in the React component root**: Consistent with `ModernDemoPage.js`. Django templates do not need to know about this; the React component is responsible for its own CSS isolation.
+- **`root.html` edit for body attribute**: The body tag is only in `root.html`. All pages (legacy and revamp) will carry `data-ui-variant="legacy"` or `data-ui-variant="revamp"`. No CSS currently targets `body[data-ui-variant="legacy"]`, so legacy pages are unaffected.
+- **`getattr` safety throughout**: `resolve_template` uses `getattr(settings, 'UI_VARIANT_REVAMP_PAGES', [])` so a missing settings key degrades to legacy. For `request.user`, use `getattr(request, 'user', None)` as the outer guard before checking `is_staff`, so calls from contexts without `AuthenticationMiddleware` (e.g., raw `RequestFactory` in tests) don't raise `AttributeError`. The context processor fallback chain `getattr(request, 'ui_variant', getattr(settings, 'UI_VARIANT_DEFAULT', 'legacy'))` ensures `"legacy"` is always returned when the view skipped `resolve_template()`.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Where is `<body>`?** `root.html:66` — bare, no attributes, safe to edit.
+- **Where does `data-modern-track` go?** In the React component root element (JS), not the Django template. Follows `ModernDemoPage.js` pattern.
+- **Does legacy `index()` view pass context the revamp page needs?** No — context is `{}`. All data is fetched client-side. Rollback guarantee (remove from allowlist = instant rollback) holds.
+- **Where do tests live?** `tests/` at repo root — `tests/test_ui_variant.py`. Uses `django.test.TestCase` + `@override_settings`.
+- **Which staff permission?** `request.user.is_staff` (Django native). May need a data migration if `is_staff` is not populated for the preview audience — document as operational note.
+
+### Deferred to Implementation
+
+- **`HomePage` component visual content**: The scaffold renders a placeholder. Actual design implementation follows separately once Figma is accessible.
+- **Monitoring signals for Phase 2 rollout**: Define 5xx rate and JS error thresholds before enabling `UI_VARIANT_REVAMP_PAGES = ["home"]` in production. Out of scope for this plan.
+- **Kumquat token names**: Figma file was inaccessible during brainstorm. No placeholder `--kq-*` vars should be committed. Phase 3 begins only when token names are confirmed.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```
+HTTP GET /
+
+  ┌─────────────────────────────────────────────────────┐
+  │ files/views.py  index()                             │
+  │                                                     │
+  │  template = resolve_template(                       │
+  │    request, "home",                                 │
+  │    "cms/index.html",          ← legacy              │
+  │    "cms/index_revamp.html"    ← revamp              │
+  │  )                                                  │
+  │                                                     │
+  │  resolve_template logic:                            │
+  │    "home" in REVAMP_PAGES?  ──► revamp              │
+  │    is_staff + ?ui=revamp?   ──► revamp              │
+  │    else                     ──► legacy              │
+  │                                                     │
+  │  side effect: request.ui_variant = "legacy|revamp"  │
+  │  return: render(request, template, {})              │
+  └───────────────────────┬─────────────────────────────┘
+                          │
+  ┌───────────────────────▼─────────────────────────────┐
+  │ cms/context_processors.ui_settings()                │
+  │                                                     │
+  │  "UI_VARIANT": getattr(request, "ui_variant",       │
+  │                         "legacy")                   │
+  └───────────────────────┬─────────────────────────────┘
+                          │ template context
+  ┌───────────────────────▼─────────────────────────────┐
+  │ Template rendering                                  │
+  │                                                     │
+  │  root.html:                                         │
+  │    <body data-ui-variant="{{ UI_VARIANT }}">         │
+  │      ← CSS gate: body[data-ui-variant="revamp"]     │
+  │        activates Kumquat vars (Phase 3)             │
+  │                                                     │
+  │  config/index.html:                                 │
+  │    var MediaCMS = {                                 │
+  │      ui: { variant: "{{ UI_VARIANT }}" },           │
+  │    };                                               │
+  │      ← JS gate: window.MediaCMS.ui.variant          │
+  │                                                     │
+  │  cms/index_revamp.html (when revamp):               │
+  │    {% vite_asset 'src/entries/index-revamp.js' %}   │
+  │    <div id="page-home-revamp"></div>                │
+  └───────────────────────┬─────────────────────────────┘
+                          │
+  ┌───────────────────────▼─────────────────────────────┐
+  │ Browser: React mount                                │
+  │                                                     │
+  │  index-revamp.js:                                   │
+  │    renderPage('page-home-revamp', HomePage)         │
+  │                                                     │
+  │  HomePage root JSX:                                 │
+  │    <div data-modern-track>   ← CSS isolation        │
+  │      ...Tailwind components                         │
+  │    </div>                                           │
+  └─────────────────────────────────────────────────────┘
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: Variant helper and settings**
+
+**Goal:** Create `cms/ui_variant.py` with `resolve_template()` and add `UI_VARIANT_*` settings.
+
+**Requirements:** R1, R3
+
+**Dependencies:** None
+
+**Files:**
+- Create: `cms/ui_variant.py`
+- Modify: `cms/settings.py`
+
+**Approach:**
+- Add two settings in the `# settings that are related with UX/appearance` block (~line 577): `UI_VARIANT_DEFAULT = "legacy"` and `UI_VARIANT_REVAMP_PAGES = []`.
+- `resolve_template(request, page_key, legacy_template, revamp_template)`: read `UI_VARIANT_REVAMP_PAGES` via `getattr(settings, ..., [])`; check allowlist first, then check staff + `?ui=revamp`; set `request.ui_variant` to `"revamp"` or `"legacy"` (always one of these two string literals, never the raw query param value); return the selected template string.
+- Staff check: `getattr(getattr(request, 'user', None), 'is_staff', False)` — double-guarded so it works with `AnonymousUser` and with raw `RequestFactory` requests lacking `request.user`.
+- The helper must not import anything that would cause circular imports — `django.conf.settings` only.
+- `legacy_template` and `revamp_template` arguments must always be string literals at call sites — never constructed from user input or URL segments.
+
+**Patterns to follow:**
+- `cms/context_processors.py` — `getattr(request, 'maintenance_remaining', 0)` pattern for reading request attributes
+- `cms/settings.py` `# settings that are related with UX/appearance` block — setting placement and naming
+
+**Test scenarios:** See Unit 6 for the authoritative list. Unit 1 scenarios (resolve_template unit tests) are a subset of Unit 6's 14 scenarios.
+
+**Verification:**
+- All Unit 5 resolve_template scenarios pass using `RequestFactory`.
+- No import errors from `cms/ui_variant.py`.
+
+---
+
+- [ ] **Unit 2: Context processor extension, body attribute, and bootstrap**
+
+**Goal:** Propagate `UI_VARIANT` to all templates and expose it to CSS (body attribute) and JS (MediaCMS bootstrap).
+
+**Requirements:** R2, R5, R6
+
+**Dependencies:** Unit 1 (needs `request.ui_variant` to be set by views)
+
+**Files:**
+- Modify: `cms/context_processors.py`
+- Modify: `templates/root.html`
+- Modify: `templates/config/index.html`
+
+**Approach:**
+- `cms/context_processors.py` `ui_settings()`: add `"UI_VARIANT": getattr(request, 'ui_variant', getattr(settings, 'UI_VARIANT_DEFAULT', 'legacy'))` to the return dict. Non-migrated pages (no `resolve_template()` call) always default to `"legacy"` — the two-tier fallback guarantees this as long as `UI_VARIANT_DEFAULT` is set to `"legacy"` in `settings.py` (which Unit 1 ensures). Do not set `UI_VARIANT_DEFAULT = "revamp"` — doing so would revamp all non-migrated pages globally.
+- `templates/root.html:66`: change `<body>` to `<body data-ui-variant="{{ UI_VARIANT }}">`. All pages receive this attribute. Legacy pages get `data-ui-variant="legacy"` (currently inert — no CSS targets it). Future CSS rules must use `body[data-ui-variant="revamp"]` selectors only, never `body[data-ui-variant="legacy"]`.
+- `templates/config/index.html`: add `ui: { variant: "{{ UI_VARIANT }}" },` as the **first** property inside the `var MediaCMS = { ... };` object literal (before the conditional `{% if media %}` blocks). Placing it first ensures its trailing comma is always valid — conditional blocks that follow may or may not emit properties, making it unsafe to rely on any conditional block having a trailing comma before `ui`. The value `"{{ UI_VARIANT }}"` is always one of two known safe string literals (`"legacy"` or `"revamp"`) — never the raw query parameter value.
+
+**Security note (Unit 2):** `UI_VARIANT` is interpolated into a JavaScript string literal in `config/index.html`. This is safe only because `resolve_template()` guarantees `request.ui_variant` is always one of `"legacy"` or `"revamp"`. If this invariant ever breaks, XSS is possible. The implementing agent should add a Django system check or assertion that validates `UI_VARIANT_DEFAULT` is `"legacy"` on startup.
+
+**Patterns to follow:**
+- `cms/context_processors.py` existing return dict structure
+- `templates/config/index.html` existing `{% if media %}mediaId: "{{media}}", {% endif %}` pattern for conditional properties
+
+**Test scenarios:**
+- Context processor — `resolve_template()` called with "home" in allowlist → `UI_VARIANT` in template context equals `"revamp"`
+- Context processor — `resolve_template()` not called → `UI_VARIANT` defaults to `"legacy"`
+- Bootstrap HTML — `GET /` response body contains `ui: { variant:` string
+- Body attribute — `GET /` response body contains `data-ui-variant=` attribute on `<body>` tag
+
+**Verification:**
+- Legacy pages (`cms/index.html`) render `data-ui-variant="legacy"` with no visual change.
+- Revamp pages render `data-ui-variant="revamp"`.
+- `window.MediaCMS.ui.variant` is accessible in browser console after page load.
+
+---
+
+- [ ] **Unit 3: Home page pilot — backend template and view**
+
+**Goal:** Wire the `index()` view to `resolve_template()` and create the revamp template.
+
+**Requirements:** R4, R9, R11, R12
+
+**Dependencies:** Unit 1 (resolve_template must exist)
+
+**Files:**
+- Modify: `files/views.py`
+- Create: `templates/cms/index_revamp.html`
+
+**Approach:**
+- `files/views.py` `index()`: import `resolve_template` from `cms.ui_variant`; call `resolve_template(request, "home", "cms/index.html", "cms/index_revamp.html")`; pass returned template name to `render()`. Context dict stays `{}` — no change to legacy behavior.
+- `templates/cms/index_revamp.html`: extends `base.html`, `{% load django_vite %}`, block `topimports` loads `{% vite_asset 'src/entries/index-revamp.js' %}`, block `content` has `<div id="page-home-revamp"></div>`. No `data-modern-track` in the template — that is applied by the React component root (see Unit 4).
+- The legacy `cms/index.html` is NOT modified — rollback is guaranteed.
+
+**Patterns to follow:**
+- `templates/cms/index.html` — block structure, `{% load django_vite %}`, `{% vite_asset %}` tag
+- `files/views.py` existing import pattern for `cms.*` modules
+
+**Test scenarios:**
+- `GET /` with `UI_VARIANT_REVAMP_PAGES = ["home"]` → response uses `cms/index_revamp.html` (check for `index-revamp` in response HTML)
+- `GET /` with `UI_VARIANT_REVAMP_PAGES = []` → response uses `cms/index.html` (legacy unchanged)
+- `GET /?ui=revamp` as staff with `UI_VARIANT_REVAMP_PAGES = []` → response uses `cms/index_revamp.html`
+- `GET /?ui=revamp` as anonymous user → response uses `cms/index.html`
+- Revamp response body contains `data-ui-variant="revamp"` (via body attribute from Unit 2)
+
+**Verification:**
+- `python manage.py check` passes.
+- Legacy `GET /` returns HTTP 200 with no template change when `UI_VARIANT_REVAMP_PAGES = []`.
+
+---
+
+- [ ] **Unit 4: Home page pilot — frontend entry and feature scaffold**
+
+**Goal:** Create the Vite entry point and `features/home/` directory for the revamp home page.
+
+**Requirements:** R10, R11, R13
+
+**Dependencies:** Unit 3 (template must reference the entry path)
+
+**Files:**
+- Create: `frontend/src/entries/index-revamp.js`
+- Modify: `frontend/vite.config.js`
+- Create: `frontend/src/features/home/index.js`
+- Create: `frontend/src/features/home/components/HomePage.jsx`
+
+**Approach:**
+- `frontend/vite.config.js`: add `'index-revamp': 'src/entries/index-revamp.js'` to `rollupOptions.input` after the `'modern-demo'` entry.
+- `frontend/src/entries/index-revamp.js`: import `renderPage` from `../static/js/_helpers.js` and `{ HomePage }` from `../features/home`; call `renderPage('page-home-revamp', HomePage)`. Pattern is identical to `notifications.js`.
+- `frontend/src/features/home/components/HomePage.jsx`: functional React component. The outermost rendered content `div` (not the component function's root node, which may be a Provider wrapper) carries `data-modern-track` as a static JSX attribute: `<div data-modern-track className="...">`. This follows the `ModernDemoPage.js` pattern where the attribute is on the inner content container, not on `QueryClientProvider`. Renders a placeholder layout using existing Tailwind classes from the current `@theme inline` block (e.g., `bg-surface-body`, `text-content-body`). CSS isolation via `all: revert-layer` (the rule that `[data-modern-track]` activates to prevent legacy SCSS from bleeding into the component) will be validated once Phase 3 CSS token rules are defined — not in this phase.
+- `frontend/src/features/home/index.js`: named export `{ HomePage }` from `./components/HomePage`.
+- `stores/` and `hooks/` subdirectories are not created at this stage — the stub component has no data fetching. Add them when implementing actual home page content.
+
+**Patterns to follow:**
+- `frontend/src/entries/notifications.js` — entry file structure
+- `frontend/src/features/notifications/index.js` — named exports pattern
+- `frontend/src/features/modern-demo/ModernDemoPage.js` — `data-modern-track` on root element, Tailwind class usage
+
+**Test scenarios:**
+- Test expectation: none for Vite config registration (build output verification is a CI concern, not a unit test)
+- `HomePage` renders without error when mounted via `renderPage` (smoke test — verify mount point `page-home-revamp` is found and component renders)
+- `HomePage` root element carries `data-modern-track` attribute (DOM assertion)
+
+**Verification:**
+- `cd frontend && npm run build` (or `pnpm run build`) completes without errors and emits `index-revamp.*` chunk in `build/production/static/`.
+- Navigating to `/?ui=revamp` as staff shows the revamp template with the stub `HomePage` rendered. CSS isolation (`all: revert-layer` on `[data-modern-track]`) is not verifiable until Phase 3 CSS rules are added. At this phase, verify only that `data-modern-track` attribute is present on the rendered DOM element.
+
+---
+
+- [ ] **Unit 5 (Phase 3a): Kumquat typography tokens**
+
+**Goal:** Define Kumquat typography CSS custom properties and bridge them into Tailwind, so revamp components can use semantic type utilities.
+
+**Requirements:** R7 (typography portion), R8 (typography portion)
+
+**Dependencies:** Unit 2 (body `data-ui-variant` attribute must exist to scope the selector)
+
+**Files:**
+- Modify: `frontend/src/static/css/config/_light_theme.scss`
+- Modify: `frontend/src/static/css/config/_dark_theme.scss`
+- Modify: `frontend/src/static/css/tailwind.css`
+
+**Approach:**
+- Add a `body[data-ui-variant="revamp"]` block in `_light_theme.scss` defining all `--kq-*` typography custom properties listed in the token table above. Use the same selector in `_dark_theme.scss` — typography values are identical in both themes (no dark-mode override needed for type scale or families).
+- Font family strings: `--kq-font-family-display: "Barlow Semi Condensed", sans-serif` and `--kq-font-family-body: "Inter", sans-serif`. Both fonts must be loaded — add `@import` or `@font-face` for Barlow Semi Condensed if not already available (verify against existing `base.js` or `styles.scss` font loading).
+- Do **not** add color tokens (`--kq-color-*`) — those remain blocked on Figma access.
+- Extend `frontend/src/static/css/tailwind.css` `@theme inline` block with all `--font-kq-*`, `--text-kq-*`, `--leading-kq-*`, `--tracking-kq-*`, and `--font-weight-kq-*` entries listed in the token definitions section. These entries extend (not replace) the existing block.
+- Tailwind utility naming convention: `font-kq-display`, `text-kq-h1`, `leading-kq-h1`, `tracking-kq-h1`, `font-kq-bold` — verified against the `--kq-*` var names in the token table.
+
+**Patterns to follow:**
+- `frontend/src/static/css/config/_light_theme.scss` — `body { --var: value; }` structure; new block follows same pattern under `body[data-ui-variant="revamp"]`
+- `frontend/src/static/css/tailwind.css` `@theme inline` block — existing `--color-brand-primary: var(--btn-primary-bg-color)` entries as the extension pattern
+
+**Test scenarios:**
+- Build — `pnpm run build` completes without errors; Tailwind generates `font-kq-display`, `text-kq-h1`, etc. utility classes in output CSS
+- Scoping — on a legacy page (`data-ui-variant="legacy"`), `--kq-font-family-display` is not defined (selector doesn't match)
+- Scoping — on a revamp page (`data-ui-variant="revamp"`), `--kq-font-family-display` resolves to `"Barlow Semi Condensed", sans-serif`
+- Component — `HomePage.jsx` updated to use `font-kq-display text-kq-h1` on a heading; visually renders Barlow Semi Condensed at 56px
+
+**Verification:**
+- Browser devtools confirm `--kq-font-family-display` resolves only under `body[data-ui-variant="revamp"]`.
+- Legacy pages show no visual change (no `--kq-*` vars resolve on them).
+- `HomePage` heading uses Barlow Semi Condensed, body copy uses Inter.
+
+---
+
+- [ ] **Unit 6: Test suite**
+
+**Goal:** Cover all gate scenarios from R15 in `tests/test_ui_variant.py`.
+
+**Requirements:** R15
+
+**Dependencies:** Units 1–5 complete (Unit 5 typography is needed for `HomePage` component tests)
+
+**Files:**
+- Create: `tests/test_ui_variant.py`
+
+**Approach:**
+- Use `django.test.TestCase` and `django.test.override_settings` consistently with `tests/test_index_page_featured.py`.
+- Create a staff user fixture with `is_staff=True` for staff preview tests.
+- Use `self.client.get('/')` for view-level tests, `self.client.get('/?ui=revamp')` for preview tests.
+- For context processor and bootstrap tests, assert on `response.context['UI_VARIANT']` and `response.content`. `response.context` is populated by Django's test client only when the view uses `render()` or `TemplateResponse` with `RequestContext` — always assert `response.context is not None` before key lookup, and add a belt-and-suspenders assertion on `response.content` for the same invariant.
+- For the `resolve_template` unit tests (Unit 1 scenarios), call the function directly using `RequestFactory` — no full HTTP stack needed.
+
+**Patterns to follow:**
+- `tests/test_index_page_featured.py` — `TestCase`, `override_settings` usage
+- `django.test.RequestFactory` for unit testing `resolve_template()` in isolation
+
+**Test scenarios:**
+- `resolve_template` unit — page_key in allowlist → revamp_template returned, `request.ui_variant == "revamp"`
+- `resolve_template` unit — page_key not in allowlist → legacy_template returned
+- `resolve_template` unit — staff + `?ui=revamp`, not allowlisted → revamp_template
+- `resolve_template` unit — non-staff + `?ui=revamp` → legacy_template
+- `resolve_template` unit — anonymous user + `?ui=revamp` → legacy_template (no exception)
+- `resolve_template` unit — `?ui=garbage` → legacy_template
+- `resolve_template` unit — `UI_VARIANT_REVAMP_PAGES` not in settings → legacy_template (no exception)
+- View integration — `GET /` with `UI_VARIANT_REVAMP_PAGES = ["home"]` → `response.context["UI_VARIANT"] == "revamp"`
+- View integration — `GET /` without `"home"` in allowlist → `response.context["UI_VARIANT"] == "legacy"`
+- Body attribute — `GET /` with revamp active → `b'data-ui-variant="revamp"'` in `response.content`
+- Bootstrap — `GET /` → `b'ui: { variant:'` in `response.content`
+- Staff preview — `GET /?ui=revamp` as staff, page not allowlisted → `response.context["UI_VARIANT"] == "revamp"`
+- Non-staff preview blocked — `GET /?ui=revamp` as regular user → `response.context["UI_VARIANT"] == "legacy"` and response is indistinguishable from a request without the parameter (same template, same status code — no redirect, no error)
+- Template integrity — revamp response HTML contains `index-revamp` (Vite asset reference)
+
+**Verification:**
+- `python manage.py test tests.test_ui_variant` passes all 14 scenarios green.
+- No test modifies global settings state (each test uses `@override_settings` or `with self.settings(...)`).
+
+## System-Wide Impact
+
+- **Interaction graph:** `ui_settings()` context processor runs on every rendered response (all page views, not just migrated pages). The `UI_VARIANT` key is added to every template context. Templates that don't reference `{{ UI_VARIANT }}` are unaffected.
+- **Error propagation:** Missing `UI_VARIANT_REVAMP_PAGES` setting → `getattr` returns `[]` → all pages render legacy (silent degradation). Missing `request.ui_variant` attribute (view didn't call `resolve_template`) → `getattr` returns `"legacy"` → correct behavior.
+- **State lifecycle risks:** `request.ui_variant` is a per-request attribute — no cross-request contamination. If `resolve_template()` is called twice in one request (e.g., in a view that delegates), the last call wins. No view should call it conditionally.
+- **API surface parity:** The body attribute (`data-ui-variant`) is set on every rendered page. No AJAX/JSON endpoints are affected — those don't render `root.html`.
+- **Integration coverage:** Cross-layer: the body attribute and `window.MediaCMS.ui.variant` must both reflect the same variant. These are verified in R15 test scenarios.
+- **Unchanged invariants:** Legacy pages continue to receive `cms/index.html` when `"home"` is not in `UI_VARIANT_REVAMP_PAGES`. The `renderPage` helper's behavior (mounts PageHeader, PageSidebar) is unchanged. The `CONTRIBUTING.md` dual-track architecture (legacy track in `src/static/js/`, modern track in `src/features/`) is unchanged.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| `is_staff` not populated for preview audience | Document as operational prerequisite. Run a query before enabling preview to confirm the intended staff accounts have `is_staff=True`. A data migration is a separate operational step. |
+| Legacy SCSS `!important` declarations breaking `all: revert-layer` isolation in `HomePage` | Before Phase 2 ships, grep legacy SCSS for `!important` and verify none apply to elements that appear in the revamp page root. If collisions exist, scope the affected rule more tightly in legacy SCSS. |
+| Vite entry registration not picked up by `django-vite` in dev mode | Restart the Vite dev server after adding `'index-revamp'` to `vite.config.js`. The dev server does not hot-reload config changes. |
+| Phase 3 token naming locked by Phase 1 placeholders | **No placeholder `--kq-*` CSS vars should be committed.** Phase 3 begins only once Figma is accessible and token names are confirmed. Do not add a `body[data-ui-variant="revamp"]` selector stub in this phase — adding an empty selector creates false signal that Phase 3 has started. The CSS hook is the `data-ui-variant` body attribute (added in Unit 2); no SCSS rule is needed until Phase 3. |
+| Binary gate: no partial rollback lever for production incidents | Before adding `"home"` to `UI_VARIANT_REVAMP_PAGES`, agree on monitoring thresholds (5xx rate, JS error rate). Rollback procedure: remove `"home"` from `local_settings.py` (no deploy required if using `local_settings.py` override). |
+
+## Documentation / Operational Notes
+
+- **Enabling the home page**: Add `UI_VARIANT_REVAMP_PAGES = ["home"]` to `cms/local_settings.py` (no deploy required) or `cms/settings.py` (requires deploy). Prefer `local_settings.py` for staged environments.
+- **Staff preview setup**: Ensure staff accounts intended for preview have `is_staff=True` in the Django admin before testing `/?ui=revamp`.
+- **Phase 3 start condition**: Figma file (`qU7x9Qp9jDAVXzydgwQNjM`) must be accessible and token names extracted before any `--kq-*` CSS vars are committed. The plan for Phase 3 is a separate planning exercise.
+- **Expanding to more pages (Phase 4)**: For each new page — add revamp template, add Vite entry + register in config, add feature directory, update view to call `resolve_template()`, add page key to `UI_VARIANT_REVAMP_PAGES`. No changes to `cms/ui_variant.py` or the context processor.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-04-19-ui-variant-gate-requirements.md](docs/brainstorms/2026-04-19-ui-variant-gate-requirements.md)
+- Existing context processor: `cms/context_processors.py`
+- Body tag location: `templates/root.html:66`
+- Bootstrap script: `templates/config/index.html`
+- Modern-track feature reference: `frontend/src/features/notifications/`
+- CSS isolation reference: `frontend/src/features/modern-demo/ModernDemoPage.js`
+- Vite config: `frontend/vite.config.js`
+- Test pattern: `tests/test_index_page_featured.py`
+- renderPage helper: `frontend/src/static/js/_helpers.js:6`

--- a/files/views.py
+++ b/files/views.py
@@ -34,6 +34,7 @@ from rest_framework.views import APIView
 
 from actions.models import USER_MEDIA_ACTIONS, MediaAction
 from cms.custom_pagination import FastPaginationWithoutCount
+from cms.ui_variant import resolve_template
 from cms.permissions import (
     IsAuthorizedToAdd,
     IsUserOrEditor,
@@ -124,9 +125,9 @@ logger = logging.getLogger(__name__)
 
 
 def index(request):
-    # Index view
     context = {}
-    return render(request, "cms/index.html", context)
+    template = resolve_template(request, "home", "cms/index.html", "cms/index_revamp.html")
+    return render(request, template, context)
 
 
 def tos(request):

--- a/frontend/src/entries/index-revamp.js
+++ b/frontend/src/entries/index-revamp.js
@@ -1,0 +1,4 @@
+import { renderPage } from '../static/js/_helpers.js';
+import { HomePage } from '../features/home';
+
+renderPage('page-home-revamp', HomePage);

--- a/frontend/src/features/home/components/HomePage.jsx
+++ b/frontend/src/features/home/components/HomePage.jsx
@@ -1,0 +1,16 @@
+import '../../static/css/tailwind.css';
+
+export function HomePage() {
+	return (
+		<div data-modern-track className="bg-surface-body min-h-screen">
+			<main className="mx-auto max-w-7xl px-4 py-16">
+				<h1 className="font-kq-display text-kq-h1 leading-kq-h1 tracking-kq-h1 font-kq-bold text-content-body">
+					Cinemata
+				</h1>
+				<p className="font-kq-body text-kq-body-18 leading-kq-body-18 font-kq-regular text-content-body mt-4">
+					A platform for social and environmental films about the Asia-Pacific.
+				</p>
+			</main>
+		</div>
+	);
+}

--- a/frontend/src/features/home/index.js
+++ b/frontend/src/features/home/index.js
@@ -1,0 +1,1 @@
+export { HomePage } from './components/HomePage';

--- a/frontend/src/static/css/config/_dark_theme.scss
+++ b/frontend/src/static/css/config/_dark_theme.scss
@@ -392,3 +392,68 @@ body.dark_theme {
 	--site-featured-bg-color: #0b3144;
 	--site-player-accent-color: #026690;
 }
+
+/* ── Kumquat design system — typography tokens (dark mode) ───────────────────
+ * Typography values are theme-independent — identical to light mode.
+ */
+body.dark_theme[data-ui-variant="revamp"] {
+	/* Font families */
+	--kq-font-family-display: "Barlow Semi Condensed", sans-serif;
+	--kq-font-family-body: "Inter", sans-serif;
+
+	/* Font weights */
+	--kq-font-weight-regular: 400;
+	--kq-font-weight-medium: 500;
+	--kq-font-weight-bold: 700;
+
+	/* Display / Title scale */
+	--kq-font-size-title-64: 64px;
+	--kq-line-height-title-64: 76px;
+	--kq-letter-spacing-title-64: -0.8px;
+
+	--kq-font-size-title-56: 56px;
+	--kq-line-height-title-56: 68px;
+	--kq-letter-spacing-title-56: -0.6px;
+
+	/* Heading scale */
+	--kq-font-size-h1: 56px;
+	--kq-line-height-h1: 68px;
+	--kq-letter-spacing-h1: -0.5px;
+
+	--kq-font-size-h2: 48px;
+	--kq-line-height-h2: 58px;
+	--kq-letter-spacing-h2: -0.4px;
+
+	--kq-font-size-h3: 40px;
+	--kq-line-height-h3: 48px;
+	--kq-letter-spacing-h3: -0.3px;
+
+	--kq-font-size-h4: 32px;
+	--kq-line-height-h4: 38px;
+	--kq-letter-spacing-h4: -0.2px;
+
+	--kq-font-size-h5: 24px;
+	--kq-line-height-h5: 30px;
+	--kq-letter-spacing-h5: -0.15px;
+
+	--kq-font-size-h6: 20px;
+	--kq-line-height-h6: 24px;
+	--kq-letter-spacing-h6: 0px;
+
+	/* Body scale */
+	--kq-font-size-body-18: 18px;
+	--kq-line-height-body-18: 28px;
+
+	--kq-font-size-body-16: 16px;
+	--kq-line-height-body-16: 24px;
+
+	--kq-font-size-body-14: 14px;
+	--kq-line-height-body-14: 20px;
+
+	--kq-font-size-body-12: 12px;
+	--kq-line-height-body-12: 16px;
+
+	/* Caption */
+	--kq-font-size-caption-10: 10px;
+	--kq-line-height-caption-10: 10px;
+}

--- a/frontend/src/static/css/config/_light_theme.scss
+++ b/frontend/src/static/css/config/_light_theme.scss
@@ -391,3 +391,70 @@ body {
 	--site-featured-bg-color: #dfeff4;
 	--site-player-accent-color: #026690;
 }
+
+/* ── Kumquat design system — typography tokens ───────────────────────────────
+ * Scoped to revamp pages only. Legacy pages are unaffected.
+ * Note: Figma class "title-72" has font-size 64px — vars use the actual size.
+ * Note: "caption-10-semibold" has font-weight 700 — mapped to --kq-font-weight-bold.
+ */
+body[data-ui-variant="revamp"] {
+	/* Font families */
+	--kq-font-family-display: "Barlow Semi Condensed", sans-serif;
+	--kq-font-family-body: "Inter", sans-serif;
+
+	/* Font weights */
+	--kq-font-weight-regular: 400;
+	--kq-font-weight-medium: 500;
+	--kq-font-weight-bold: 700;
+
+	/* Display / Title scale */
+	--kq-font-size-title-64: 64px;
+	--kq-line-height-title-64: 76px;
+	--kq-letter-spacing-title-64: -0.8px;
+
+	--kq-font-size-title-56: 56px;
+	--kq-line-height-title-56: 68px;
+	--kq-letter-spacing-title-56: -0.6px;
+
+	/* Heading scale */
+	--kq-font-size-h1: 56px;
+	--kq-line-height-h1: 68px;
+	--kq-letter-spacing-h1: -0.5px;
+
+	--kq-font-size-h2: 48px;
+	--kq-line-height-h2: 58px;
+	--kq-letter-spacing-h2: -0.4px;
+
+	--kq-font-size-h3: 40px;
+	--kq-line-height-h3: 48px;
+	--kq-letter-spacing-h3: -0.3px;
+
+	--kq-font-size-h4: 32px;
+	--kq-line-height-h4: 38px;
+	--kq-letter-spacing-h4: -0.2px;
+
+	--kq-font-size-h5: 24px;
+	--kq-line-height-h5: 30px;
+	--kq-letter-spacing-h5: -0.15px;
+
+	--kq-font-size-h6: 20px;
+	--kq-line-height-h6: 24px;
+	--kq-letter-spacing-h6: 0px;
+
+	/* Body scale */
+	--kq-font-size-body-18: 18px;
+	--kq-line-height-body-18: 28px;
+
+	--kq-font-size-body-16: 16px;
+	--kq-line-height-body-16: 24px;
+
+	--kq-font-size-body-14: 14px;
+	--kq-line-height-body-14: 20px;
+
+	--kq-font-size-body-12: 12px;
+	--kq-line-height-body-12: 16px;
+
+	/* Caption */
+	--kq-font-size-caption-10: 10px;
+	--kq-line-height-caption-10: 10px;
+}

--- a/frontend/src/static/css/tailwind.css
+++ b/frontend/src/static/css/tailwind.css
@@ -370,6 +370,66 @@
 	--color-site-form-btn: var(--site-form-btn-bg-color);
 	--color-site-featured-bg: var(--site-featured-bg-color);
 	--color-site-player-accent: var(--site-player-accent-color);
+
+	/* ── Kumquat typography — font families ──────────────────────────────────
+	 * Generates: font-kq-display, font-kq-body
+	 * Only resolve on body[data-ui-variant="revamp"] via CSS custom properties.
+	 */
+	--font-kq-display: var(--kq-font-family-display);
+	--font-kq-body: var(--kq-font-family-body);
+
+	/* ── Kumquat typography — font sizes ─────────────────────────────────────
+	 * Generates: text-kq-title-64, text-kq-h1, text-kq-body-16, etc.
+	 */
+	--text-kq-title-64: var(--kq-font-size-title-64);
+	--text-kq-title-56: var(--kq-font-size-title-56);
+	--text-kq-h1: var(--kq-font-size-h1);
+	--text-kq-h2: var(--kq-font-size-h2);
+	--text-kq-h3: var(--kq-font-size-h3);
+	--text-kq-h4: var(--kq-font-size-h4);
+	--text-kq-h5: var(--kq-font-size-h5);
+	--text-kq-h6: var(--kq-font-size-h6);
+	--text-kq-body-18: var(--kq-font-size-body-18);
+	--text-kq-body-16: var(--kq-font-size-body-16);
+	--text-kq-body-14: var(--kq-font-size-body-14);
+	--text-kq-body-12: var(--kq-font-size-body-12);
+	--text-kq-caption-10: var(--kq-font-size-caption-10);
+
+	/* ── Kumquat typography — line heights ───────────────────────────────────
+	 * Generates: leading-kq-h1, leading-kq-body-16, etc.
+	 */
+	--leading-kq-title-64: var(--kq-line-height-title-64);
+	--leading-kq-title-56: var(--kq-line-height-title-56);
+	--leading-kq-h1: var(--kq-line-height-h1);
+	--leading-kq-h2: var(--kq-line-height-h2);
+	--leading-kq-h3: var(--kq-line-height-h3);
+	--leading-kq-h4: var(--kq-line-height-h4);
+	--leading-kq-h5: var(--kq-line-height-h5);
+	--leading-kq-h6: var(--kq-line-height-h6);
+	--leading-kq-body-18: var(--kq-line-height-body-18);
+	--leading-kq-body-16: var(--kq-line-height-body-16);
+	--leading-kq-body-14: var(--kq-line-height-body-14);
+	--leading-kq-body-12: var(--kq-line-height-body-12);
+	--leading-kq-caption-10: var(--kq-line-height-caption-10);
+
+	/* ── Kumquat typography — letter spacing ─────────────────────────────────
+	 * Generates: tracking-kq-h1, tracking-kq-title-64, etc.
+	 */
+	--tracking-kq-title-64: var(--kq-letter-spacing-title-64);
+	--tracking-kq-title-56: var(--kq-letter-spacing-title-56);
+	--tracking-kq-h1: var(--kq-letter-spacing-h1);
+	--tracking-kq-h2: var(--kq-letter-spacing-h2);
+	--tracking-kq-h3: var(--kq-letter-spacing-h3);
+	--tracking-kq-h4: var(--kq-letter-spacing-h4);
+	--tracking-kq-h5: var(--kq-letter-spacing-h5);
+	--tracking-kq-h6: var(--kq-letter-spacing-h6);
+
+	/* ── Kumquat typography — font weights ───────────────────────────────────
+	 * Generates: font-weight-kq-regular, font-weight-kq-medium, font-weight-kq-bold
+	 */
+	--font-weight-kq-regular: var(--kq-font-weight-regular);
+	--font-weight-kq-medium: var(--kq-font-weight-medium);
+	--font-weight-kq-bold: var(--kq-font-weight-bold);
 }
 
 /*

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -109,6 +109,7 @@ export default defineConfig({
 				error: 'src/entries/error.js',
 				'modern-demo': 'src/entries/modern-demo.js',
 				notifications: 'src/entries/notifications.js',
+				'index-revamp': 'src/entries/index-revamp.js',
 			},
 			output: {
 				globals: {

--- a/templates/cms/index_revamp.html
+++ b/templates/cms/index_revamp.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+{% load static %}
+{% load django_vite %}
+
+{% block headermeta %}
+
+<meta name="description" content="Cinemata is a platform for social and environmental films about the Asia-Pacific. The open-source video website highlights essential yet underheard stories, increasing filmmakers' reach, engagement, and impact.">
+
+<!-- Google / Search Engine Tags -->
+<meta itemprop="name" content="{{PORTAL_NAME}}">
+<meta itemprop="description" content="Cinemata is a platform for social and environmental films about the Asia-Pacific. The open-source video website highlights essential yet underheard stories, increasing filmmakers' reach, engagement, and impact.">
+<meta itemprop="image" content="{{FRONTEND_HOST}}/media/userlogos/cinemata_share_banner-01.png">
+
+<!-- Facebook Meta Tags -->
+<meta property="og:url" content="{{FRONTEND_HOST}}">
+<meta property="og:type" content="website">
+<meta property="og:title" content="{{PORTAL_NAME}}">
+<meta property="og:description" content="Cinemata is a platform for social and environmental films about the Asia-Pacific. The open-source video website highlights essential yet underheard stories, increasing filmmakers' reach, engagement, and impact.">
+<meta property="og:image" content="{{FRONTEND_HOST}}/media/userlogos/cinemata_share_banner-01.png">
+
+<!-- Twitter Meta Tags -->
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="{{PORTAL_NAME}}">
+<meta name="twitter:description" content="Cinemata is a platform for social and environmental films about the Asia-Pacific. The open-source video website highlights essential yet underheard stories, increasing filmmakers' reach, engagement, and impact.">
+<meta name="twitter:image" content="{{FRONTEND_HOST}}/media/userlogos/cinemata_share_banner-01.png">
+
+{% endblock headermeta %}
+
+{% block topimports %}{% vite_asset 'src/entries/index-revamp.js' %}{% endblock topimports %}
+
+{% block content %}<div id="page-home-revamp"></div>{% endblock %}

--- a/templates/config/index.html
+++ b/templates/config/index.html
@@ -1,6 +1,7 @@
 <script type="text/javascript">
 	
 	var MediaCMS = {
+		ui: { variant: "{{ UI_VARIANT }}" },
 		{% if media %}mediaId: "{{media}}", {% endif %}
 		{% if user %}profileId: "{{user.username}}", {% endif %}
 		{% if playlist %}playlistId: "{{playlist.friendly_token}}", {% endif %}

--- a/templates/root.html
+++ b/templates/root.html
@@ -18,6 +18,13 @@
 
         {% block externallinks %}{% endblock externallinks %}
 
+        {% if UI_VARIANT == "revamp" %}
+        {# Kumquat design system fonts — Barlow Semi Condensed (display) and Inter (body) #}
+        <link rel="preconnect" href="https://fonts.googleapis.com">
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+        <link href="https://fonts.googleapis.com/css2?family=Barlow+Semi+Condensed:wght@400;500;700&family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
+        {% endif %}
+
         {% include "common/head-links.html" %}
 
         {# Import map — must appear before any <script type="module"> so the browser #}
@@ -63,7 +70,7 @@
     {% endblock head %}
 </head>
 
-<body>
+<body data-ui-variant="{{ UI_VARIANT }}">
 
     {% block beforecontent %}{% endblock %}
 

--- a/tests/test_ui_variant.py
+++ b/tests/test_ui_variant.py
@@ -1,0 +1,192 @@
+from django.test import RequestFactory, TestCase, override_settings
+from django.contrib.auth import get_user_model
+
+from cms.ui_variant import resolve_template
+
+User = get_user_model()
+
+
+# ---------------------------------------------------------------------------
+# resolve_template() unit tests — no HTTP stack, uses RequestFactory
+# ---------------------------------------------------------------------------
+
+
+class ResolveTemplateTests(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def _make_request(self, query_string="", is_staff=False, anonymous=False):
+        request = self.factory.get("/", QUERY_STRING=query_string)
+        if anonymous:
+            from django.contrib.auth.models import AnonymousUser
+
+            request.user = AnonymousUser()
+        else:
+            request.user = User(is_staff=is_staff)
+        return request
+
+    @override_settings(UI_VARIANT_REVAMP_PAGES=["home"])
+    def test_allowlisted_page_returns_revamp(self):
+        request = self._make_request()
+        result = resolve_template(request, "home", "cms/index.html", "cms/index_revamp.html")
+        self.assertEqual(result, "cms/index_revamp.html")
+        self.assertEqual(request.ui_variant, "revamp")
+
+    @override_settings(UI_VARIANT_REVAMP_PAGES=[])
+    def test_non_allowlisted_page_returns_legacy(self):
+        request = self._make_request()
+        result = resolve_template(request, "home", "cms/index.html", "cms/index_revamp.html")
+        self.assertEqual(result, "cms/index.html")
+        self.assertEqual(request.ui_variant, "legacy")
+
+    @override_settings(UI_VARIANT_REVAMP_PAGES=[])
+    def test_staff_preview_param_returns_revamp(self):
+        request = self._make_request(query_string="ui=revamp", is_staff=True)
+        result = resolve_template(request, "home", "cms/index.html", "cms/index_revamp.html")
+        self.assertEqual(result, "cms/index_revamp.html")
+        self.assertEqual(request.ui_variant, "revamp")
+
+    @override_settings(UI_VARIANT_REVAMP_PAGES=[])
+    def test_non_staff_preview_param_ignored(self):
+        request = self._make_request(query_string="ui=revamp", is_staff=False)
+        result = resolve_template(request, "home", "cms/index.html", "cms/index_revamp.html")
+        self.assertEqual(result, "cms/index.html")
+        self.assertEqual(request.ui_variant, "legacy")
+
+    @override_settings(UI_VARIANT_REVAMP_PAGES=[])
+    def test_anonymous_user_preview_param_ignored(self):
+        request = self._make_request(query_string="ui=revamp", anonymous=True)
+        result = resolve_template(request, "home", "cms/index.html", "cms/index_revamp.html")
+        self.assertEqual(result, "cms/index.html")
+        self.assertEqual(request.ui_variant, "legacy")
+
+    @override_settings(UI_VARIANT_REVAMP_PAGES=[])
+    def test_invalid_param_value_ignored(self):
+        request = self._make_request(query_string="ui=garbage", is_staff=True)
+        result = resolve_template(request, "home", "cms/index.html", "cms/index_revamp.html")
+        self.assertEqual(result, "cms/index.html")
+        self.assertEqual(request.ui_variant, "legacy")
+
+    def test_missing_setting_degrades_to_legacy(self):
+        """UI_VARIANT_REVAMP_PAGES absent from settings → no AttributeError, returns legacy."""
+        from django.test import override_settings as _os
+
+        with _os(UI_VARIANT_REVAMP_PAGES=None):
+            # Simulate missing by patching directly
+            pass
+        # Use override_settings to delete the key entirely
+        from unittest import mock
+
+        with mock.patch("cms.ui_variant.settings") as mock_settings:
+            del mock_settings.UI_VARIANT_REVAMP_PAGES
+            mock_settings.configure_mock(**{"UI_VARIANT_REVAMP_PAGES": AttributeError})
+            # Use getattr directly to confirm the helper won't blow up
+            import cms.ui_variant as uv
+
+            original = uv.settings
+            try:
+                mock_obj = mock.MagicMock(spec=[])  # no attributes
+                uv.settings = mock_obj
+                request = self._make_request()
+                result = resolve_template(request, "home", "cms/index.html", "cms/index_revamp.html")
+                self.assertEqual(result, "cms/index.html")
+                self.assertEqual(request.ui_variant, "legacy")
+            finally:
+                uv.settings = original
+
+    @override_settings(UI_VARIANT_REVAMP_PAGES=["home"])
+    def test_staff_plus_allowlisted_returns_revamp(self):
+        """Allowlist wins regardless of staff status — both paths return revamp."""
+        request = self._make_request(query_string="ui=revamp", is_staff=True)
+        result = resolve_template(request, "home", "cms/index.html", "cms/index_revamp.html")
+        self.assertEqual(result, "cms/index_revamp.html")
+        self.assertEqual(request.ui_variant, "revamp")
+
+    def test_no_user_attribute_on_request_returns_legacy(self):
+        """Request without .user attribute (raw RequestFactory, no auth middleware) doesn't raise."""
+        request = self.factory.get("/?ui=revamp")
+        # Deliberately do NOT set request.user
+        result = resolve_template(request, "home", "cms/index.html", "cms/index_revamp.html")
+        self.assertEqual(result, "cms/index.html")
+        self.assertEqual(request.ui_variant, "legacy")
+
+
+# ---------------------------------------------------------------------------
+# View integration tests — full HTTP stack via test client
+# ---------------------------------------------------------------------------
+
+
+class UIVariantViewIntegrationTests(TestCase):
+    def setUp(self):
+        self.staff_user = User.objects.create_user(
+            username="staffuser",
+            password="testpass",
+            is_staff=True,
+        )
+        self.regular_user = User.objects.create_user(
+            username="regularuser",
+            password="testpass",
+            is_staff=False,
+        )
+
+    @override_settings(UI_VARIANT_REVAMP_PAGES=["home"])
+    def test_allowlisted_page_serves_revamp_template(self):
+        response = self.client.get("/")
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNotNone(response.context)
+        self.assertEqual(response.context["UI_VARIANT"], "revamp")
+        self.assertIn(b"index-revamp", response.content)
+
+    @override_settings(UI_VARIANT_REVAMP_PAGES=[])
+    def test_non_allowlisted_page_serves_legacy_template(self):
+        response = self.client.get("/")
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNotNone(response.context)
+        self.assertEqual(response.context["UI_VARIANT"], "legacy")
+
+    @override_settings(UI_VARIANT_REVAMP_PAGES=["home"])
+    def test_revamp_page_has_data_ui_variant_attribute(self):
+        response = self.client.get("/")
+        self.assertIn(b'data-ui-variant="revamp"', response.content)
+
+    @override_settings(UI_VARIANT_REVAMP_PAGES=[])
+    def test_legacy_page_has_data_ui_variant_legacy(self):
+        response = self.client.get("/")
+        self.assertIn(b'data-ui-variant="legacy"', response.content)
+
+    def test_bootstrap_contains_mediaCMS_ui_variant(self):
+        response = self.client.get("/")
+        self.assertIn(b"ui:", response.content)
+        self.assertIn(b"variant:", response.content)
+
+    @override_settings(UI_VARIANT_REVAMP_PAGES=[])
+    def test_staff_preview_param_returns_revamp(self):
+        self.client.login(username="staffuser", password="testpass")
+        response = self.client.get("/?ui=revamp")
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNotNone(response.context)
+        self.assertEqual(response.context["UI_VARIANT"], "revamp")
+
+    @override_settings(UI_VARIANT_REVAMP_PAGES=[])
+    def test_non_staff_preview_param_returns_legacy_indistinguishable(self):
+        """Non-staff ?ui=revamp → legacy, same status as normal request (no redirect/error)."""
+        self.client.login(username="regularuser", password="testpass")
+        response = self.client.get("/?ui=revamp")
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNotNone(response.context)
+        self.assertEqual(response.context["UI_VARIANT"], "legacy")
+
+    @override_settings(UI_VARIANT_REVAMP_PAGES=[])
+    def test_anonymous_preview_param_returns_legacy(self):
+        response = self.client.get("/?ui=revamp")
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNotNone(response.context)
+        self.assertEqual(response.context["UI_VARIANT"], "legacy")
+
+    @override_settings(UI_VARIANT_REVAMP_PAGES=[])
+    def test_ui_variant_missing_from_context_when_no_resolve_call(self):
+        """Non-home pages that don't call resolve_template get UI_VARIANT='legacy'."""
+        # /about or similar — as long as index() is wired this test uses /
+        # For pages not yet wired, the context processor defaults to legacy
+        response = self.client.get("/")
+        self.assertEqual(response.context["UI_VARIANT"], "legacy")

--- a/tests/test_ui_variant.py
+++ b/tests/test_ui_variant.py
@@ -69,30 +69,27 @@ class ResolveTemplateTests(TestCase):
 
     def test_missing_setting_degrades_to_legacy(self):
         """UI_VARIANT_REVAMP_PAGES absent from settings → no AttributeError, returns legacy."""
-        from django.test import override_settings as _os
-
-        with _os(UI_VARIANT_REVAMP_PAGES=None):
-            # Simulate missing by patching directly
-            pass
-        # Use override_settings to delete the key entirely
+        import cms.ui_variant as uv
         from unittest import mock
 
-        with mock.patch("cms.ui_variant.settings") as mock_settings:
-            del mock_settings.UI_VARIANT_REVAMP_PAGES
-            mock_settings.configure_mock(**{"UI_VARIANT_REVAMP_PAGES": AttributeError})
-            # Use getattr directly to confirm the helper won't blow up
-            import cms.ui_variant as uv
+        original = uv.settings
+        try:
+            # MagicMock(spec=[]) has no attributes, so getattr returns the default
+            uv.settings = mock.MagicMock(spec=[])
+            request = self._make_request()
+            result = resolve_template(request, "home", "cms/index.html", "cms/index_revamp.html")
+            self.assertEqual(result, "cms/index.html")
+            self.assertEqual(request.ui_variant, "legacy")
+        finally:
+            uv.settings = original
 
-            original = uv.settings
-            try:
-                mock_obj = mock.MagicMock(spec=[])  # no attributes
-                uv.settings = mock_obj
-                request = self._make_request()
-                result = resolve_template(request, "home", "cms/index.html", "cms/index_revamp.html")
-                self.assertEqual(result, "cms/index.html")
-                self.assertEqual(request.ui_variant, "legacy")
-            finally:
-                uv.settings = original
+    @override_settings(UI_VARIANT_REVAMP_PAGES=None)
+    def test_none_allowlist_degrades_to_legacy(self):
+        """UI_VARIANT_REVAMP_PAGES=None (explicit None) → no TypeError, returns legacy."""
+        request = self._make_request()
+        result = resolve_template(request, "home", "cms/index.html", "cms/index_revamp.html")
+        self.assertEqual(result, "cms/index.html")
+        self.assertEqual(request.ui_variant, "legacy")
 
     @override_settings(UI_VARIANT_REVAMP_PAGES=["home"])
     def test_staff_plus_allowlisted_returns_revamp(self):
@@ -156,8 +153,9 @@ class UIVariantViewIntegrationTests(TestCase):
 
     def test_bootstrap_contains_mediaCMS_ui_variant(self):
         response = self.client.get("/")
-        self.assertIn(b"ui:", response.content)
-        self.assertIn(b"variant:", response.content)
+        # Assert the specific MediaCMS.ui bootstrap structure is present
+        self.assertIn(b'ui: { variant:', response.content)
+        self.assertIn(b'"legacy"', response.content)
 
     @override_settings(UI_VARIANT_REVAMP_PAGES=[])
     def test_staff_preview_param_returns_revamp(self):


### PR DESCRIPTION
## Summary

Introduces a server-side UI variant gate that lets CinemataCMS incrementally roll out the Kumquat redesign page-by-page — no big-bang switch, no per-user toggle, no separate frontend track.

When a page is added to `UI_VARIANT_REVAMP_PAGES`, all users see the new design. Before that, staff can preview via `?ui=revamp`. Removing the key rolls back immediately with no deploy required.

## What changed

### Backend gate (`cms/ui_variant.py`)

`resolve_template(request, page_key, legacy, revamp)` resolves which template to render:

```
page_key in UI_VARIANT_REVAMP_PAGES?  ──► revamp (all users)
request.user.is_staff + ?ui=revamp?   ──► revamp (staff preview)
else                                  ──► legacy
```

Sets `request.ui_variant` as a side effect so the context processor and templates downstream can read it. The `_SAFE_VARIANTS` frozenset (`{"legacy", "revamp"}`) is wired into the context processor to clamp `UI_VARIANT` before it reaches the JS bootstrap — guarding against a misconfigured `UI_VARIANT_DEFAULT` in `local_settings.py` producing XSS via the JS string literal.

### CSS and JS gates

Two complementary runtime signals let CSS and React code know which variant is active:

- **`<body data-ui-variant="...">` (CSS gate):** Kumquat CSS token rules are scoped under `body[data-ui-variant="revamp"]`, so both palettes coexist in the same build without conflict.
- **`window.MediaCMS.ui.variant` (JS gate):** Added as the first property in the `MediaCMS` object literal in `templates/config/index.html` so the value is available atomically at initialization.

### Home page pilot

`files/views.py` now calls `resolve_template()` for the home page. `templates/cms/index_revamp.html` loads `index-revamp.js`, which mounts `features/home/HomePage` — a working stub using existing Tailwind surface tokens. The legacy `cms/index.html` is untouched; removing `"home"` from the allowlist fully restores it.

### Phase 3a: Kumquat typography tokens

Barlow Semi Condensed (display/headings) and Inter (body/caption) are defined as `--kq-*` CSS custom properties under `body[data-ui-variant="revamp"]` in both `_light_theme.scss` and `_dark_theme.scss`. The `@theme inline` block in `tailwind.css` is extended with `font-kq-*`, `text-kq-*`, `leading-kq-*`, `tracking-kq-*`, and `font-weight-kq-*` mappings.

Color tokens (Phase 3b) remain blocked on Figma access.

## Enabling a page

```python
# cms/local_settings.py — no deploy required
UI_VARIANT_REVAMP_PAGES = ["home"]
```

To roll back: remove the key. The response changes immediately.

## Request flow

```
GET /
  │
  ▼
files/views.py index()
  resolve_template(request, "home", legacy, revamp)
    ├── "home" in REVAMP_PAGES → revamp template
    ├── is_staff + ?ui=revamp → revamp template (preview)
    └── else → legacy template
    │
    └─ sets request.ui_variant = "legacy"|"revamp"
  │
  ▼
cms/context_processors.ui_settings()
  UI_VARIANT = clamped(request.ui_variant or settings.UI_VARIANT_DEFAULT)
  │
  ▼
Template rendering
  root.html:          <body data-ui-variant="{{ UI_VARIANT }}">
  config/index.html:  MediaCMS = { ui: { variant: "{{ UI_VARIANT }}" }, … }
  index_revamp.html:  {% vite_asset 'src/entries/index-revamp.js' %}
```

## Test plan

19 tests in `tests/test_ui_variant.py`:

- `resolve_template()` unit tests via `RequestFactory` (allowlist, staff preview, non-staff blocked, anonymous, invalid param, `None` allowlist guard, missing-setting degradation)
- View integration tests via test client (template selection, body attribute, JS bootstrap, staff session, non-staff indistinguishable response)

```bash
python manage.py test tests.test_ui_variant
# Ran 19 tests in 2.4s — OK
```

## Residual work

One `gated_auto` finding not yet applied: add `Cache-Control: private` to the revamp response in `index()` to prevent a proxy cache keyed on URI from serving the staff-preview HTML to non-staff users. Low risk today (no proxy cache in the default deploy), but should be addressed before any CDN is placed in front of the site.

## Post-deploy monitoring

After adding `"home"` to `UI_VARIANT_REVAMP_PAGES`:
- Watch 5xx error rate and JS console errors on `/`
- Rollback trigger: revert rate or JS errors spike vs baseline
- Rollback: remove `"home"` from `local_settings.py` — no deploy needed

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Claude_Code-Sonnet_4.6_(200K)-D97757?logo=claude&logoColor=white)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced UI Variant Gate for incremental frontend design rollout between legacy and new design versions
  * Redesigned home page with new typography design system and styling
  * Added staff-only preview capability to test new design variants via query parameter
  * Exposed UI variant information to templates and frontend for design-aware rendering

* **Documentation**
  * Added design specifications and implementation plan for UI variant gate rollout strategy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->