### PR TITLE
chore: add Makefile test/lint targets and pre-commit CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,3 +70,39 @@ jobs:
       - name: Build frontend
         working-directory: frontend
         run: npm run build
+
+  pre-commit:
+    name: Pre-commit (lint & format)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Install Python 3.10
+        run: uv python install 3.10
+
+      - name: Setup Node.js (for Prettier hook)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Cache pre-commit hook environments
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            pre-commit-${{ runner.os }}-
+
+      - name: Install Python dependencies
+        run: uv sync --all-extras
+
+      - name: Run pre-commit (make lint)
+        run: make lint

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: docker-up docker-down docker-restart docker-logs docker-ps docker-clean docker-build docker-shell-db docker-shell-redis sync help dev-server start-celery-beat stop-celery-beat start-celery-long stop-celery-long start-celery-short stop-celery-short start-celery-whisper stop-celery-whisper celery-beat-start celery-beat-stop celery-beat-restart celery-long-start celery-long-stop celery-long-restart celery-short-start celery-short-stop celery-short-restart celery-whisper-start celery-whisper-stop celery-whisper-restart celery-start-all celery-stop-all celery-restart-all celery-status frontend-build frontend-dev frontend-clean quick-build
+.PHONY: docker-up docker-down docker-restart docker-logs docker-ps docker-clean docker-build docker-shell-db docker-shell-redis sync help dev-server start-celery-beat stop-celery-beat start-celery-long stop-celery-long start-celery-short stop-celery-short start-celery-whisper stop-celery-whisper celery-beat-start celery-beat-stop celery-beat-restart celery-long-start celery-long-stop celery-long-restart celery-short-start celery-short-stop celery-short-restart celery-whisper-start celery-whisper-stop celery-whisper-restart celery-start-all celery-stop-all celery-restart-all celery-status frontend-build frontend-dev frontend-clean quick-build test lint test-ci
 
 # Docker compose file to use
 COMPOSE_FILE = docker-compose.dev.yml
@@ -44,6 +44,11 @@ help:
 	@echo "  make frontend-dev    - Start frontend development server"
 	@echo "  make frontend-clean  - Clean frontend build directories"
 	@echo "  make quick-build     - Quick frontend build (main app only)"
+	@echo ""
+	@echo "Quality & Tests:"
+	@echo "  make test            - Run Django test suite (verbose)"
+	@echo "  make lint            - Run pre-commit on all files"
+	@echo "  make test-ci         - Run tests with --keepdb --parallel (CI mode)"
 	@echo ""
 	@echo "Celery Commands:"
 	@echo "  make celery-beat-start    - Start Celery beat scheduler"
@@ -244,3 +249,16 @@ quick-build:
 	cd frontend && npm run build
 	python manage.py collectstatic --noinput
 	@echo "Quick build complete!"
+
+## Quality & Tests
+test:
+	@echo "Running Django test suite..."
+	uv run python manage.py test --verbosity=2
+
+lint:
+	@echo "Running pre-commit on all files..."
+	uv run pre-commit run --all-files --show-diff-on-failure
+
+test-ci:
+	@echo "Running tests with --keepdb --parallel..."
+	uv run python manage.py test --keepdb --parallel --verbosity=2


### PR DESCRIPTION
## Description

Add `test`, `lint`, and `test-ci` Makefile targets so contributors have a stable command surface instead of remembering raw `uv run` invocations. Add a `pre-commit` CI job that runs `make lint` to enforce Ruff, Prettier, django-upgrade, and file-hygiene hooks on every PR.

## Related Issue

Fixes #566
Fixes #561

## Motivation and Context

Two developer-experience gaps: (1) the Makefile had no test/lint targets, forcing contributors to remember full invocations, and (2) `.pre-commit-config.yaml` was configured but had no CI gate — contributors who skip `pre-commit install` could land unformatted code.

## How Has This Been Tested?

- `make help` — shows new "Quality & Tests" section
- `make lint` — invokes pre-commit, exits 0 after format-the-world PR (#620)
- CI — `pre-commit` job runs green on this PR

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.