### PR TITLE
fix(notifications): show not-allowed cursor on disabled Reset/Save buttons (#506)

### DIFF
--- a/frontend/src/features/user-settings/components/NotificationPreferencesForm.jsx
+++ b/frontend/src/features/user-settings/components/NotificationPreferencesForm.jsx
@@ -138,6 +138,11 @@ export function NotificationPreferencesForm() {
 		if (isSuccess || isSaveError) reset();
 	}
 
+	// Global _buttons.scss forces `cursor: pointer` on `button` and
+	// `cursor: default` on `button:disabled`, which beats Tailwind's
+	// `disabled:cursor-not-allowed` utility. Inline styles win.
+	const disabledActionStyle = { cursor: !isDirty || isPending ? 'not-allowed' : 'pointer' };
+
 	function renderControl(row) {
 		if (row.status === 'coming_soon') return <StatusPill>Coming soon</StatusPill>;
 		if (row.status === 'always_on') return <StatusPill tone="accent">Always on</StatusPill>;
@@ -199,18 +204,19 @@ export function NotificationPreferencesForm() {
 					type="button"
 					onClick={handleReset}
 					disabled={!isDirty || isPending}
-					className="border-0 bg-transparent p-0 cursor-pointer text-sm text-content-link hover:underline disabled:opacity-40 disabled:cursor-not-allowed"
+					className="border-0 bg-transparent p-0 text-sm text-content-link hover:underline disabled:opacity-40"
+					style={disabledActionStyle}
 				>
 					Reset
 				</button>
 				{/* Inline styles on the save button are required because global
                     _buttons.scss overrides Tailwind @layer utilities for
-                    background-color, color, padding, border-radius and font on
-                    all button elements (see NotificationPage.jsx). */}
+                    background-color, color, padding, border-radius, font, and
+                    cursor on all button elements (see NotificationPage.jsx). */}
 				<button
 					type="submit"
 					disabled={!isDirty || isPending}
-					className="cursor-pointer transition-all disabled:opacity-40 disabled:cursor-not-allowed"
+					className="transition-all disabled:opacity-40"
 					style={{
 						padding: '6px 18px',
 						borderRadius: '9999px',
@@ -220,6 +226,7 @@ export function NotificationPreferencesForm() {
 						backgroundColor: 'var(--btn-primary-bg-color)',
 						color: '#fff',
 						boxShadow: '0 1px 3px rgba(0,0,0,.2)',
+						...disabledActionStyle,
 					}}
 				>
 					{isPending ? 'Saving…' : 'Save changes'}


### PR DESCRIPTION
## Description
Fixes a cosmetic regression in the notification preferences form: the **Reset** and **Save changes** buttons rendered with a `cursor: pointer` while disabled, contradicting their faded-out (`opacity-40`) appearance. They now show `cursor: not-allowed` whenever they are disabled and `cursor: pointer` when actionable.

## Related Issue
Follow-up to #506 (PR #601). Addresses the post-merge QA feedback:

> the "Reset" and "Save Changes" being faded out should also imply that these links/buttons should not have a cursor pointer when hovered over unless changes are being made.

## Motivation and Context
The form already used Tailwind's `disabled:cursor-not-allowed` utility, but it was silently losing the cascade to the project-wide `frontend/src/static/css/includes/form_controls/_buttons.scss`, which globally sets `cursor: pointer` on every `button` element and `cursor: default` (not `not-allowed`) on `button:disabled`. This is the same root cause that already required the **Save changes** button to use inline styles for `background-color`, `padding`, `border-radius`, and font properties — see the existing comment in `NotificationPreferencesForm.jsx` and `NotificationPage.jsx`. The fix follows that established pattern: drive `cursor` from an inline `style` so it wins the cascade. The Tailwind `cursor-pointer` / `disabled:cursor-not-allowed` classes that no longer have any effect are removed, and the inline-styles comment on the save button is updated to also list `cursor`.

## How Has This Been Tested?
Manual browser testing on the Preferences tab (`/notifications/#preferences`):

- Pristine load → Reset and Save changes are faded; hovering each shows `cursor: not-allowed`.
- Change a dropdown → both buttons un-fade; hovering shows `cursor: pointer`.
- Click Save → while the request is in flight (`isPending`), both buttons show `cursor: not-allowed`.
- Click Reset (when dirty) → form returns to pristine and cursor immediately reverts to `not-allowed` on both.

All other QA scenarios from #506 still pass (unaffected by this change — only the cursor declarations were modified).

## Screenshots (if appropriate):
<img width="2879" height="1451" alt="image" src="https://github.com/user-attachments/assets/274934e6-9689-4eb4-97da-7b2585bb824e" />

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):
- [x] I have not imported `flux` in a new component
- [x] If adding a new feature, I used Modern Track patterns
- [x] New features do not create new SCSS files (use Tailwind instead)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined cursor interaction feedback on buttons in the notification preferences form for improved visual consistency during form state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->