### PR TITLE
feat(manage): add Restricted state filter and open filters by default

### DIFF
--- a/files/management_views.py
+++ b/files/management_views.py
@@ -46,7 +46,7 @@ class MediaList(APIView):
         if media_type not in ["video", "image", "audio", "pdf"]:
             media_type = None
 
-        if state not in ["private", "public", "unlisted"]:
+        if state not in ["private", "public", "restricted", "unlisted"]:
             state = None
 
         if encoding_status not in ["pending", "running", "fail", "success"]:
@@ -113,7 +113,7 @@ class MyUploadsList(APIView):
             sort_by = "add_date"
         ordering = "" if ordering == "asc" else "-"
 
-        if state not in ["private", "public", "unlisted"]:
+        if state not in ["private", "public", "restricted", "unlisted"]:
             state = None
 
         if encoding_status not in ["pending", "running", "fail", "success"]:

--- a/files/management_views.py
+++ b/files/management_views.py
@@ -13,6 +13,8 @@ from .models import Comment, Media
 from .permissions import IsManageUploadsUser, IsMediacmsEditor
 from .serializers import CommentSerializer, ManageUploadSerializer, MediaSerializer
 
+VALID_MEDIA_STATES = ["private", "public", "restricted", "unlisted"]
+
 
 class MediaList(APIView):
     permission_classes = (IsMediacmsEditor,)
@@ -46,7 +48,7 @@ class MediaList(APIView):
         if media_type not in ["video", "image", "audio", "pdf"]:
             media_type = None
 
-        if state not in ["private", "public", "restricted", "unlisted"]:
+        if state not in VALID_MEDIA_STATES:
             state = None
 
         if encoding_status not in ["pending", "running", "fail", "success"]:
@@ -113,7 +115,7 @@ class MyUploadsList(APIView):
             sort_by = "add_date"
         ordering = "" if ordering == "asc" else "-"
 
-        if state not in ["private", "public", "restricted", "unlisted"]:
+        if state not in VALID_MEDIA_STATES:
             state = None
 
         if encoding_status not in ["pending", "running", "fail", "success"]:

--- a/files/tests/test_my_uploads.py
+++ b/files/tests/test_my_uploads.py
@@ -195,6 +195,21 @@ class MyUploadsOwnershipTests(TestCase):
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]["friendly_token"], self.media_a2.friendly_token)
 
+    def test_filter_by_state_restricted(self):
+        """Filtering by state=restricted returns only restricted media (#508)."""
+        restricted_media = create_test_media(
+            user=self.user_a,
+            title="User A Restricted Video",
+            media_type="video",
+            state="restricted",
+        )
+        self.client.login(username="usera", password="testpass123")
+        response = self.client.get("/api/v1/my_uploads?state=restricted")
+        data = response.json()
+        results = data.get("results", [])
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["friendly_token"], restricted_media.friendly_token)
+
     def test_search_by_title(self):
         """Searching by title returns matching items."""
         self.client.login(username="usera", password="testpass123")

--- a/frontend/src/static/js/pages/ManageUploadsPage/components/UploadFilters.jsx
+++ b/frontend/src/static/js/pages/ManageUploadsPage/components/UploadFilters.jsx
@@ -11,6 +11,7 @@ const filters = {
 		{ id: 'all', title: 'All' },
 		{ id: 'public', title: 'Public' },
 		{ id: 'private', title: 'Private' },
+		{ id: 'restricted', title: 'Restricted' },
 		{ id: 'unlisted', title: 'Unlisted' },
 	],
 	encoding_status: [

--- a/frontend/src/static/js/pages/ManageUploadsPage/index.jsx
+++ b/frontend/src/static/js/pages/ManageUploadsPage/index.jsx
@@ -31,7 +31,7 @@ export class ManageUploadsPage extends Page {
 			currentPage: 1,
 			requestUrl: ApiUrlContext._currentValue.manage.myUploads,
 			pageTitle: props.title,
-			hiddenFilters: true,
+			hiddenFilters: false,
 			filterArgs: '',
 			sortingArgs: '',
 			sortBy: 'add_date',


### PR DESCRIPTION
## Description

Two UX improvements to the `/manage/uploads` page:

1. **Add "Restricted" to the STATE filter panel** — the "restricted" state (password-protected media) is a valid model state but was missing from the filter options, so users couldn't find their restricted media.
2. **Show filters panel open by default** — previously collapsed, requiring an extra click every time.

Backend validation in both `MyUploadsList.get` and `MediaList.get` is updated to accept `"restricted"` as a valid filter parameter.

No "Make Restricted" bulk action is added — restricted media requires a password, making it unsuitable for bulk state changes.

## Related Issue

Fixes #508

## Motivation and Context

Users who set media to "restricted" (password-protected) had no way to filter for those items in the manage uploads view. The collapsed-by-default filter panel also added unnecessary friction.

## How Has This Been Tested?

- All pre-commit hooks pass (ruff, ruff-format, prettier, django-upgrade, etc.)
- Tested locally on `http://localhost:8000/manage/uploads`:
  - Filters panel opens by default on page load (no click required)
  - STATE filter shows all 5 options: All, Public, Private, Restricted, Unlisted
  - Clicking "Restricted" selects the filter (shows × dismiss icon) and triggers API request with `state=restricted`
  - Filter toggle button still collapses/expands the panel correctly
  - Other filters (encoding status, search) continue to work as before

## Screenshots (if appropriate):

**Filters open by default with "Restricted" option visible:**
<img width="1800" height="1043" alt="image" src="https://github.com/user-attachments/assets/78ebdb30-da73-4568-acec-39b49dc83d55" />

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):

- [x] I have not imported `flux` in a new component
- [x] If adding a new feature, I used Modern Track patterns
- [x] New features do not create new SCSS files (use Tailwind instead)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Restricted" as a filterable status option for uploads and media.
  * Upload filters now display by default for easier access to filtering options.
  * Filtering now correctly returns items with the "Restricted" status when selected.

* **Tests**
  * Added a test to verify the "Restricted" filter returns only restricted uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->