### PR TITLE
feat(manage): add thumbnail column to media and uploads tables

### DIFF
--- a/files/serializers.py
+++ b/files/serializers.py
@@ -99,9 +99,13 @@ class MediaSerializer(serializers.ModelSerializer):
 
 class ManageUploadSerializer(serializers.ModelSerializer):
     url = serializers.SerializerMethodField()
+    thumbnail_url = serializers.SerializerMethodField()
 
     def get_url(self, obj):
         return self.context["request"].build_absolute_uri(obj.get_absolute_url())
+
+    def get_thumbnail_url(self, obj):
+        return self.context["request"].build_absolute_uri(obj.thumbnail_url)
 
     class Meta:
         model = Media
@@ -109,6 +113,7 @@ class ManageUploadSerializer(serializers.ModelSerializer):
             "friendly_token",
             "title",
             "url",
+            "thumbnail_url",
             "add_date",
             "media_type",
             "encoding_status",

--- a/files/serializers.py
+++ b/files/serializers.py
@@ -35,6 +35,8 @@ class MediaSerializer(serializers.ModelSerializer):
         return self.context["request"].build_absolute_uri(obj.get_absolute_url(api=True))
 
     def get_thumbnail_url(self, obj):
+        if not obj.thumbnail_url:
+            return None
         return self.context["request"].build_absolute_uri(obj.thumbnail_url)
 
     def get_author_profile(self, obj):
@@ -105,6 +107,8 @@ class ManageUploadSerializer(serializers.ModelSerializer):
         return self.context["request"].build_absolute_uri(obj.get_absolute_url())
 
     def get_thumbnail_url(self, obj):
+        if not obj.thumbnail_url:
+            return None
         return self.context["request"].build_absolute_uri(obj.thumbnail_url)
 
     class Meta:

--- a/frontend/src/static/js/components/-NEW-/ManageItem/ManageMediaItem.js
+++ b/frontend/src/static/js/components/-NEW-/ManageItem/ManageMediaItem.js
@@ -194,6 +194,13 @@ export function ManageMediaItem(props) {
 			<div className="mi-checkbox">
 				<input type="checkbox" checked={selected} onChange={onRowCheck} />
 			</div>
+			<div className="mi-thumb">
+				{props.thumbnail_url ? (
+					<img src={props.thumbnail_url} alt="" />
+				) : (
+					<span className="mi-thumb-placeholder" />
+				)}
+			</div>
 			<div className="mi-title">
 				<ManageItemTitle title={props.title} url={props.url} />
 				{props.hideDeleteAction ? null : (

--- a/frontend/src/static/js/components/-NEW-/ManageItem/ManageMediaItemHeader.js
+++ b/frontend/src/static/js/components/-NEW-/ManageItem/ManageMediaItemHeader.js
@@ -13,6 +13,7 @@ export function ManageMediaItemHeader(props) {
 			<div className="mi-checkbox">
 				<input type="checkbox" checked={isSelected} onChange={checkAll} />
 			</div>
+			<div className="mi-thumb"></div>
 			<div
 				id="title"
 				onClick={sortByColumn}

--- a/frontend/src/static/js/components/-NEW-/ManageItem/ManageUploadItem.js
+++ b/frontend/src/static/js/components/-NEW-/ManageItem/ManageUploadItem.js
@@ -166,6 +166,13 @@ export function ManageUploadItem(props) {
 			<div className="mi-checkbox">
 				<input type="checkbox" checked={selected} onChange={onRowCheck} />
 			</div>
+			<div className="mi-thumb">
+				{props.thumbnail_url ? (
+					<img src={props.thumbnail_url} alt="" />
+				) : (
+					<span className="mi-thumb-placeholder" />
+				)}
+			</div>
 			<div className="mi-title">
 				<ManageItemTitle title={props.title} url={props.url} />
 				{props.hideDeleteAction ? null : (
@@ -199,6 +206,7 @@ export function ManageUploadItem(props) {
 }
 
 ManageUploadItem.propTypes = {
+	thumbnail_url: PropTypes.string,
 	token: PropTypes.string,
 	title: PropTypes.string,
 	url: PropTypes.string,

--- a/frontend/src/static/js/components/-NEW-/ManageItem/ManageUploadItemHeader.js
+++ b/frontend/src/static/js/components/-NEW-/ManageItem/ManageUploadItemHeader.js
@@ -15,6 +15,7 @@ export function ManageUploadItemHeader(props) {
 			<div className="mi-checkbox">
 				<input type="checkbox" checked={isSelected} onChange={checkAll} />
 			</div>
+			<div className="mi-thumb"></div>
 			<div
 				id="title"
 				onClick={sortByColumn}

--- a/frontend/src/static/js/components/-NEW-/ManageItemList/includes/functions.js
+++ b/frontend/src/static/js/components/-NEW-/ManageItemList/includes/functions.js
@@ -89,6 +89,7 @@ function ListManageUploadItem(props) {
 
 	const args = {
 		...itemProps,
+		thumbnail_url: itemData.thumbnail_url,
 		title: itemData.title,
 		url: itemData.url.replace(' ', '%20'),
 		add_date: itemData.add_date,

--- a/frontend/src/static/js/components/styles/ManageItemList.scss
+++ b/frontend/src/static/js/components/styles/ManageItemList.scss
@@ -281,6 +281,32 @@
 			width: 48px;
 		}
 
+		.mi-thumb {
+			min-width: 120px;
+			width: 120px;
+			padding: 8px 12px;
+
+			img {
+				display: block;
+				width: 120px;
+				height: 68px;
+				object-fit: cover;
+				border-radius: 2px;
+			}
+
+			.mi-thumb-placeholder {
+				display: block;
+				width: 120px;
+				height: 68px;
+				background-color: #e0e0e0;
+				border-radius: 2px;
+
+				.dark_theme & {
+					background-color: #333;
+				}
+			}
+		}
+
 		.mi-title {
 			min-width: 240px;
 			width: 100%;

--- a/frontend/src/static/js/components/styles/ManageItemList.scss
+++ b/frontend/src/static/js/components/styles/ManageItemList.scss
@@ -258,7 +258,7 @@
 
 	&.manage-media-item {
 		> * {
-			width: (100/10) * 1%;
+			width: (100/11) * 1%;
 			text-align: center;
 		}
 

--- a/frontend/src/static/js/pages/ManageUploadsPage/ManageUploadsPage.scss
+++ b/frontend/src/static/js/pages/ManageUploadsPage/ManageUploadsPage.scss
@@ -31,7 +31,7 @@
 
 	.manage-upload-item {
 		> * {
-			width: (100/8) * 1%;
+			width: (100/9) * 1%;
 			text-align: center;
 		}
 
@@ -51,6 +51,32 @@
 		.mi-checkbox {
 			min-width: 48px;
 			width: 48px;
+		}
+
+		.mi-thumb {
+			min-width: 120px;
+			width: 120px;
+			padding: 8px 12px;
+
+			img {
+				display: block;
+				width: 120px;
+				height: 68px;
+				object-fit: cover;
+				border-radius: 2px;
+			}
+
+			.mi-thumb-placeholder {
+				display: block;
+				width: 120px;
+				height: 68px;
+				background-color: #e0e0e0;
+				border-radius: 2px;
+
+				.dark_theme & {
+					background-color: #333;
+				}
+			}
 		}
 
 		.mi-title {


### PR DESCRIPTION
## Description
Add a 16:9 thumbnail column (120×68px) to both `/manage/media` and `/manage/uploads` table views. The column is placed after the checkbox and before the title, making it faster for admins to visually identify videos at a glance. Uses existing auto-generated thumbnails — no additional processing required.

## Related Issue
Fixes #510

## Motivation and Context
The manage pages were text-only, requiring admins to read titles to identify media. Adding thumbnails provides instant visual recognition, especially useful when managing large volumes of content.

## How Has This Been Tested?
- Ran `npx vite build` — frontend build passes cleanly
- Started `make frontend-dev` and `make dev-server`
- Navigated to `/manage/media` as an admin user — thumbnails display correctly between checkbox and title columns
- Navigated to `/manage/uploads` — same thumbnail column works with data from the updated serializer
- Verified gray placeholder appears for media without thumbnails
- Verified table horizontal scroll still works on narrow viewports
- Verified no new console errors introduced

## Screenshots (if appropriate):
<img width="1800" height="1089" alt="image" src="https://github.com/user-attachments/assets/ce35d2c7-ecc2-4763-ad72-b825276b7e25" />


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):
- [x] I have not imported `flux` in a new component
- [x] If adding a new feature, I used Modern Track patterns
- [ ] New features do not create new SCSS files (use Tailwind instead)