### PR TITLE
chore(ops): add automated rollback script (#569)

### DIFF
--- a/restart_script.sh
+++ b/restart_script.sh
@@ -18,9 +18,24 @@ source /home/cinemata/bin/activate
 # Navigate to cinematacms directory
 cd cinematacms
 
+# Record current commit so rollback.sh can find the previous deployment.
+DEPLOY_LOG=/var/log/cinemata/deploy.log
+mkdir -p "$(dirname "$DEPLOY_LOG")"
+PREV_SHA=$(git rev-parse HEAD)
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
 # Pull latest changes from git
 echo "Pulling latest changes from git repository..."
 git pull
+
+# Append a deploy-log entry only when the pull actually advanced HEAD.
+NEW_SHA=$(git rev-parse HEAD)
+if [ "$NEW_SHA" != "$PREV_SHA" ]; then
+  printf '%s\t%s\t%s\t%s\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$PREV_SHA" "$NEW_SHA" "$BRANCH" \
+    >> "$DEPLOY_LOG"
+  echo "Recorded deploy in $DEPLOY_LOG (was $PREV_SHA, now $NEW_SHA)."
+fi
 
 # Install any new requirements
 echo "Installing any new requirements..."

--- a/rollback.sh
+++ b/rollback.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+# Cinemata rollback script — emergency brake.
+# Reverts the most recent deploy by reading /var/log/cinemata/deploy.log
+# and checking out the commit that was HEAD before the last successful
+# `git pull` performed by restart_script.sh, then re-runs the build and
+# service restart sequence.
+#
+# Does NOT run `manage.py migrate`. If migrations changed between deploys
+# the operator must reverse them by hand after rollback (see the warning
+# block this script prints).
+#
+# Run as root.
+
+set -Eeuo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+trap 'echo -e "${RED}Error at ${BASH_SOURCE[0]}:${LINENO}${NC}" >&2; exit 1' ERR
+
+DEPLOY_LOG=/var/log/cinemata/deploy.log
+CINEMATA_HOME=/home/cinemata
+REPO_DIR="${CINEMATA_HOME}/cinematacms"
+DRY_RUN=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    -h|--help)
+      cat <<USAGE
+Usage: sudo $0 [--dry-run]
+
+Rolls back the most recent Cinemata deploy by checking out the commit that
+was HEAD before the last successful 'git pull' run by restart_script.sh,
+then re-runs the build + service restart sequence.
+
+Does NOT run 'manage.py migrate' on the rolled-back code. If migrations
+changed between deploys, you must reverse them manually after rollback.
+
+Options:
+  --dry-run   Show what would happen without making any changes.
+USAGE
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $arg (try --help)" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo -e "${RED}Please run as root.${NC}" >&2
+  exit 1
+fi
+
+echo -e "${GREEN}Starting Cinemata rollback...${NC}"
+
+cd "$CINEMATA_HOME"
+# shellcheck disable=SC1091
+source "${CINEMATA_HOME}/bin/activate"
+cd "$REPO_DIR"
+
+if [ ! -s "$DEPLOY_LOG" ]; then
+  echo -e "${RED}No deploy log at $DEPLOY_LOG (or empty). Cannot rollback.${NC}" >&2
+  echo -e "${YELLOW}A deploy log entry is written by restart_script.sh on each forward deploy.${NC}" >&2
+  exit 1
+fi
+
+LAST_LINE=$(tail -n 1 "$DEPLOY_LOG")
+LOG_TS=$(printf '%s' "$LAST_LINE" | cut -f1)
+TARGET_SHA=$(printf '%s' "$LAST_LINE" | cut -f2)
+DEPLOYED_SHA=$(printf '%s' "$LAST_LINE" | cut -f3)
+DEPLOYED_BRANCH=$(printf '%s' "$LAST_LINE" | cut -f4)
+
+if [ -z "$TARGET_SHA" ]; then
+  echo -e "${RED}Malformed deploy log entry: '$LAST_LINE'${NC}" >&2
+  exit 1
+fi
+
+if ! git cat-file -e "${TARGET_SHA}^{commit}" 2>/dev/null; then
+  echo -e "${RED}Target commit $TARGET_SHA is not present in the local repo.${NC}" >&2
+  echo -e "${YELLOW}It may have been pruned. Try 'git fetch --all' and retry, or check out manually.${NC}" >&2
+  exit 1
+fi
+
+CURRENT_SHA=$(git rev-parse HEAD)
+
+if [ "$CURRENT_SHA" = "$TARGET_SHA" ]; then
+  echo -e "${YELLOW}HEAD is already at $TARGET_SHA. Nothing to roll back.${NC}"
+  exit 0
+fi
+
+echo -e "${YELLOW}Most recent deploy log entry:${NC}"
+echo "  Timestamp:  $LOG_TS"
+echo "  Branch:     $DEPLOYED_BRANCH"
+echo "  Was:        $TARGET_SHA"
+echo "  Deployed:   $DEPLOYED_SHA"
+echo
+echo -e "${YELLOW}Commits that will be reverted (${TARGET_SHA}..HEAD):${NC}"
+git log --oneline "${TARGET_SHA}..HEAD" || true
+echo
+
+MIGRATION_DIFF=$(git diff --name-only "${TARGET_SHA}" HEAD -- '*/migrations/*.py' || true)
+DRIFT_APPS=""
+if [ -n "$MIGRATION_DIFF" ]; then
+  DRIFT_APPS=$(printf '%s\n' "$MIGRATION_DIFF" | awk -F/ '{print $1}' | sort -u | tr '\n' ' ')
+  echo -e "${RED}WARNING: Database migrations changed between $TARGET_SHA and HEAD.${NC}"
+  echo -e "${RED}Affected apps:${NC} $DRIFT_APPS"
+  echo -e "${YELLOW}This script does NOT run 'migrate'. After rollback, if any of those${NC}"
+  echo -e "${YELLOW}migrations modified the schema, you must reverse them by hand:${NC}"
+  echo -e "${YELLOW}  python manage.py migrate <app> <previous_migration_name>${NC}"
+  echo -e "${YELLOW}Use 'python manage.py showmigrations <app>' to find the right target.${NC}"
+  echo
+fi
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo -e "${GREEN}Dry run complete. No changes made.${NC}"
+  exit 0
+fi
+
+ans=""
+read -r -p "Proceed with rollback to $TARGET_SHA? [y/N] " ans || true
+case "$ans" in
+  y|Y|yes|YES) ;;
+  *)
+    echo "Aborted by operator."
+    exit 1
+    ;;
+esac
+
+PRE_ROLLBACK_SHA=$(git rev-parse HEAD)
+
+echo -e "${YELLOW}Checking out $TARGET_SHA (detached HEAD)...${NC}"
+git checkout --detach "$TARGET_SHA"
+
+echo -e "${YELLOW}Reinstalling Python requirements...${NC}"
+pip install -r requirements.txt
+
+echo -e "${YELLOW}Rebuilding frontend...${NC}"
+if ! make quick-build; then
+  echo -e "${RED}Frontend build failed at rolled-back commit.${NC}" >&2
+  echo -e "${RED}You are now on detached HEAD $TARGET_SHA with a partial deploy.${NC}" >&2
+  exit 1
+fi
+
+echo -e "${YELLOW}Updating ownership...${NC}"
+chown -R www-data. "$CINEMATA_HOME/"
+
+echo -e "${YELLOW}Reloading systemd daemon...${NC}"
+systemctl daemon-reload
+
+echo -e "${YELLOW}Restarting services...${NC}"
+systemctl restart celery_long
+systemctl restart celery_short
+systemctl restart celery_beat
+systemctl restart mediacms.service
+systemctl restart celery_whisper.service
+systemctl restart nginx
+
+# Audit entry so a subsequent rollback (or the next forward deploy) can
+# trace the chain. Field 4 is "rollback" instead of a branch name.
+printf '%s\t%s\t%s\t%s\n' \
+  "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$PRE_ROLLBACK_SHA" "$TARGET_SHA" "rollback" \
+  >> "$DEPLOY_LOG"
+
+echo
+echo -e "${GREEN}Rollback complete.${NC}"
+echo "  HEAD now at: $(git rev-parse HEAD)"
+echo "  Audit entry appended to $DEPLOY_LOG."
+if [ -n "$DRIFT_APPS" ]; then
+  echo
+  echo -e "${RED}REMINDER: Migrations changed in apps:${NC} $DRIFT_APPS"
+  echo -e "${RED}If any touched the schema, reverse them manually with${NC}"
+  echo -e "${RED}'python manage.py migrate <app> <previous_migration_name>'.${NC}"
+fi

--- a/rollback.sh
+++ b/rollback.sh
@@ -75,7 +75,7 @@ TARGET_SHA=$(printf '%s' "$LAST_LINE" | cut -f2)
 DEPLOYED_SHA=$(printf '%s' "$LAST_LINE" | cut -f3)
 DEPLOYED_BRANCH=$(printf '%s' "$LAST_LINE" | cut -f4)
 
-if [ -z "$TARGET_SHA" ]; then
+if [ -z "$TARGET_SHA" ] || [ -z "$DEPLOYED_SHA" ]; then
   echo -e "${RED}Malformed deploy log entry: '$LAST_LINE'${NC}" >&2
   exit 1
 fi
@@ -91,6 +91,23 @@ CURRENT_SHA=$(git rev-parse HEAD)
 if [ "$CURRENT_SHA" = "$TARGET_SHA" ]; then
   echo -e "${YELLOW}HEAD is already at $TARGET_SHA. Nothing to roll back.${NC}"
   exit 0
+fi
+
+# Sanity guard: the deploy log says the last forward deploy left HEAD at
+# $DEPLOYED_SHA. If HEAD is somewhere else now, someone moved it out of
+# band (manual git checkout, ad-hoc pull, an earlier rollback that wasn't
+# logged) and the "previous deploy" recorded in the log may no longer be
+# the right rollback target. Refuse to act and let the operator decide.
+if [ "$CURRENT_SHA" != "$DEPLOYED_SHA" ]; then
+  echo -e "${RED}Repository state has shifted since the last logged deploy.${NC}" >&2
+  echo -e "${RED}  HEAD now:        $CURRENT_SHA${NC}" >&2
+  echo -e "${RED}  Last deployed:   $DEPLOYED_SHA  (per $DEPLOY_LOG)${NC}" >&2
+  echo -e "${RED}  Rollback target: $TARGET_SHA${NC}" >&2
+  echo -e "${YELLOW}Refusing to roll back from a HEAD the deploy log does not know about.${NC}" >&2
+  echo -e "${YELLOW}If you intended to roll back from the last deploy, run:${NC}" >&2
+  echo -e "${YELLOW}  git fetch --all && git checkout $DEPLOYED_SHA${NC}" >&2
+  echo -e "${YELLOW}then re-run this script. Otherwise check out the desired target manually.${NC}" >&2
+  exit 1
 fi
 
 echo -e "${YELLOW}Most recent deploy log entry:${NC}"


### PR DESCRIPTION
## PR description

## Description

Adds a single new operations script, `rollback.sh`, at the repo root, plus a ~15-line addition to `restart_script.sh` that gives the rollback script a deploy log to read from.

**`rollback.sh`** is an emergency-brake script. With no arguments, it:

1. Reads the most recent line of `/var/log/cinemata/deploy.log`.
2. Identifies the commit that was HEAD *before* the last successful `git pull` (field 2 of the log line).
3. Verifies that commit is still reachable in the local repo.
4. Sanity-checks that current HEAD matches the SHA the deploy log says was last deployed (field 3). If it doesn't — meaning someone moved HEAD out of band via manual `git checkout`, ad-hoc pull, or an unlogged earlier rollback — refuses to run and prints the `git fetch && git checkout <deployed_sha>` command the operator should run before retrying. Catches stale deploy logs before they cause a wrong-target rollback.
5. Shows a summary: timestamp of the deploy being reverted, branch, the SHA pair, and `git log --oneline target..HEAD` so the operator can see what is being undone.
6. Detects whether any Django migrations changed between target and HEAD; if so, prints a prominent warning listing the affected apps and the manual `migrate <app> <name>` command the operator must run *after* rollback.
7. Asks for explicit `[y/N]` confirmation, then performs `git checkout --detach <target>`, reinstalls requirements, rebuilds the frontend with `make quick-build`, fixes ownership, reloads systemd, and restarts the same six services that `restart_script.sh` restarts.
8. Appends a `rollback`-tagged audit entry to the deploy log so the chain is traceable.

`--dry-run` performs steps 1–6 and exits before touching anything. `--help` prints usage.

**`restart_script.sh`** gains a 15-line block that appends a tab-separated line to `/var/log/cinemata/deploy.log` after every successful `git pull` that actually advances HEAD:

```
<ISO8601-UTC>\t<previous_HEAD_sha>\t<new_HEAD_sha>\t<branch>
```

No-op pulls (HEAD didn't move) do not produce a log entry. The directory is `mkdir -p`'d on first run.

**Files changed**

- `restart_script.sh` — adds the deploy-log writer (15 lines added, no other behavior changed).
- `rollback.sh` *(new, executable)* — the rollback script described above.

## Related Issue

Fixes #569

## Motivation and Context

The project had **no rollback mechanism** beyond manual SSH + `git checkout` + manually re-running build/restart commands. When a forward-fix is too slow — broken homepage after a release, regression in upload, a bad migration that didn't get caught in CI — the operator needs an emergency brake that runs in seconds, not minutes of recall-the-runbook.

Issue #569 asks for exactly that, and is tagged P1, Size S, Q2-075 (Tier 3 / WI-12) in the Developer Experience Improvement epic.

The issue declares dependencies on Q2-066 (deploy workflow) and Q2-076 (deploy audit trail). Q2-076 is the audit trail this script reads from; **it has not landed yet**. Two paths were available:

1. **Block #569 on Q2-076.** Slower, leaves prod with no rollback for longer.
2. **Ship a minimum coherent audit trail alongside the rollback script.** A single tab-separated line per deploy is the smallest possible source of truth the script needs. Q2-076 can extend the format later without breaking the rollback parser (it reads only fields 1–4 by tab position).

This PR takes path 2. The deploy-log writer in `restart_script.sh` is intentionally minimal — no JSON, no structured logger, no rotation policy — so Q2-076 has a clean canvas to extend. Once Q2-076 lands, the rollback script does not need to change.

**Why migrations are not auto-rolled-back**

Django migrations can be reversed (`manage.py migrate <app> <previous_name>`), but only when every operation in the forward migration has a defined reverse. In practice many real-world migrations don't: data migrations using `RunPython` without `reverse_code`, schema changes that drop columns, and migrations that depend on application logic that has since changed. Silently running `migrate` on the rolled-back code in an emergency is more likely to corrupt the database than to recover from the outage.

The script therefore takes the conservative, industry-standard approach (Heroku, Capistrano, Kubernetes deploy controllers all do the same): warn loudly, list the affected apps, and let the operator decide whether to reverse migrations manually. The warning prints both before the rollback (during the summary) and again at the very end so it's the last thing on the operator's screen.

**Explicit out-of-scope**

- **Migration auto-rollback.** Decided above.
- **Multi-step rollback (`--steps N`, `--to <sha>`).** The issue describes an emergency brake — the previous deploy is the relevant target 99% of the time. Adding flag combinations expands the surface for mistakes during an incident.
- **Rich audit trail (JSON manifest, who-deployed-what, deploy duration).** That's Q2-076's scope. This PR ships the minimum that #569 requires.
- **Slack/email/PagerDuty notification on rollback.** No notification system exists in the repo today; out of scope.
- **Health-check verification post-rollback.** The `/health/ready` endpoints landed in #560/#612 but wiring them into rollback (e.g., abort if readiness doesn't recover within N seconds) is a follow-up.

## How Has This Been Tested?

**Syntax / static checks**

```
bash -n restart_script.sh   # OK
bash -n rollback.sh         # OK
```

`shellcheck` is not installed in this environment; the script is written to `set -Eeuo pipefail` discipline modeled on `scripts/build_frontend.sh` and follows the same color/trap conventions.

**Smoke test of the deploy-log format**

A throwaway repo (`/tmp/rollback-smoke`) was initialised with two commits. The exact `printf` and `cut` pipeline used by both scripts was exercised in isolation:

```bash
printf '%s\t%s\t%s\t%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$SHA1" "$SHA2" main >> deploy.log
tail -n 1 deploy.log | cut -f2     # -> $SHA1, matches expected
```

The format round-trips cleanly: field 1 is the timestamp, field 2 is the rollback target, field 3 is what was deployed, field 4 is the branch.

**What was not tested in this session**

- **End-to-end rollback on a real server.** The script has external dependencies (the `/home/cinemata` venv layout, systemd units, root permissions) that don't exist in the development environment. Recommended first run on the production box: `sudo ./rollback.sh --dry-run` immediately after the next forward deploy to confirm the deploy-log line was written and parsed correctly. No state is changed by `--dry-run`.
- **Service-restart sequence.** Same reason — no systemd units in the dev environment. The sequence mirrors `restart_script.sh` exactly, so any divergence would also affect forward deploys.

**Operator runbook**

```bash
# 1. After the very next forward deploy, on the prod host, sanity-check the
#    log was written.
sudo tail -n 1 /var/log/cinemata/deploy.log
# Expect: a tab-separated line with timestamp, two SHAs, and branch.

# 2. Dry-run the rollback. Reports the target SHA and any migration drift,
#    makes no changes.
sudo /home/cinemata/cinematacms/rollback.sh --dry-run

# 3. Real rollback (only when forward-fixing is too slow).
sudo /home/cinemata/cinematacms/rollback.sh

# 4. If the dry-run reported migration drift, run the suggested
#    'manage.py migrate <app> <previous_name>' commands inside the
#    activated venv after the rollback completes.
```

**Testing environment:** Ubuntu on WSL2 (Linux 6.6.87.2), bash 5.x. Production target is the existing `/home/cinemata` deployment described in `restart_script.sh` and `deploy/README.md`.

## Screenshots (if appropriate):

N/A — operations tooling, no UI.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):

- [x] I have not imported `flux` in a new component
- [x] If adding a new feature, I used Modern Track patterns
- [x] New features do not create new SCSS files (use Tailwind instead)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployment operations now log Git commit and branch information for audit purposes.
  * New rollback feature enables reverting to previous deployment versions with safeguards including dry-run mode, migration detection warnings, and operator confirmation prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->