### PR TITLE
fix: prevent debug_toolbar crash during test runs

### DIFF
--- a/cms/settings.py
+++ b/cms/settings.py
@@ -657,8 +657,15 @@ NEWSLETTER_LIST_IDS = [2]
 
 from .local_settings import *
 
-# Add debug_toolbar to INSTALLED_APPS if DEBUG is True
-if DEBUG:
+import sys
+
+_is_testing = "test" in sys.argv or "pytest" in sys.modules
+
+# Add debug_toolbar for local dev only — not during test runs.
+# Django's test runner sets DEBUG=False at runtime, but MIDDLEWARE is already
+# populated at import time, so the toolbar middleware would crash with
+# KeyError: 'djdt' because the URL patterns are guarded by `if settings.DEBUG`.
+if DEBUG and not _is_testing:
     if "debug_toolbar" not in INSTALLED_APPS:
         INSTALLED_APPS.append("debug_toolbar")
     if "debug_toolbar.middleware.DebugToolbarMiddleware" not in MIDDLEWARE:

--- a/cms/settings.py
+++ b/cms/settings.py
@@ -655,9 +655,9 @@ NEWSLETTER_API_URL = "https://mailer.cinemata.org/wp-json/newsletter/v1/subscrib
 # Newsletter list ID(s) to subscribe users to (Cinemata Newsletter = list 2)
 NEWSLETTER_LIST_IDS = [2]
 
-from .local_settings import *
-
 import sys
+
+from .local_settings import *
 
 _is_testing = "test" in sys.argv or "pytest" in sys.modules
 


### PR DESCRIPTION
## Description

Guard the `debug_toolbar` setup in `cms/settings.py` with a test-runner detection so the middleware is never installed during test runs.

When `local_settings.py` sets `DEBUG=True`, `settings.py` injects `debug_toolbar.middleware.DebugToolbarMiddleware` into `MIDDLEWARE` at **import time**. Django's test runner later sets `DEBUG=False` at runtime, but `MIDDLEWARE` is already populated. The toolbar middleware runs, calls `reverse('djdt:...')`, and crashes with `KeyError: 'djdt'` because `cms/urls.py` guards the URL patterns with `if settings.DEBUG:` (now `False`).

This is the last remaining item from issue #594. The other two items were already fixed on `main`:
- **Item 1** (index drift): indexes declared at `files/models.py:348-349`
- **Item 2** (raw SQL `is_encrypted`): test file rewritten to use ORM-based `create_test_media`

## Related Issue

Fixes #594

## Motivation and Context

Any developer running tests locally with `DEBUG=True` in `local_settings.py` hits the `KeyError: 'djdt'` crash. CI is not affected because `ci_settings.py` sets `DEBUG=False` before the `if DEBUG:` block runs.

Note: The `IS_RUNNING_TESTS: True` approach suggested in the issue does not work with django-debug-toolbar 6.x — it raises a system check error (`debug_toolbar.E001: The Django Debug Toolbar can't be used with tests`), blocking the test run entirely.

## How Has This Been Tested?

- `uv run python manage.py test files.tests.test_migrations -v2` — 6/6 passed, no `KeyError: 'djdt'`
- `DJANGO_SETTINGS_MODULE=cms.ci_settings uv run python manage.py test files.tests -v2` — 168/168 passed, no regression

## Screenshots (if appropriate):

N/A — backend-only change.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):

N/A — no frontend changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test execution stability by preventing middleware configuration conflicts that occurred when settings changed at runtime during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->