### PR TITLE
fix(manage): align thumbnail column header at narrow viewports

### DIFF
--- a/frontend/src/static/js/components/styles/ManageItemList.scss
+++ b/frontend/src/static/js/components/styles/ManageItemList.scss
@@ -281,8 +281,8 @@
 		}
 
 		.mi-thumb {
-			min-width: 120px;
-			width: 120px;
+			min-width: 144px;
+			width: 144px;
 			padding: 8px 12px;
 
 			img {

--- a/frontend/src/static/js/pages/ManageUploadsPage/ManageUploadsPage.scss
+++ b/frontend/src/static/js/pages/ManageUploadsPage/ManageUploadsPage.scss
@@ -54,8 +54,8 @@
 		}
 
 		.mi-thumb {
-			min-width: 120px;
-			width: 120px;
+			min-width: 144px;
+			width: 144px;
 			padding: 8px 12px;
 
 			img {


### PR DESCRIPTION
## Description
Fix thumbnail column header/data cell misalignment at viewport widths below 1024px. The `.mi-thumb` cell had `min-width: 120px` / `width: 120px` but with `padding: 8px 12px` the actual computed width was 144px, causing a gap between the header and data rows.

## Related Issue
Fixes #510 (follow-up to PR #635)

## Motivation and Context
QA reported (https://github.com/EngageMedia-video/cinematacms/issues/510#issuecomment-4364084681) that at narrow viewports the thumbnail header cell was narrower than the data cells, breaking column alignment. The root cause was that `min-width`/`width` didn't account for horizontal padding.

## How Has This Been Tested?
- `npx vite build` passes
- Verified locally that header and data cells align at all viewport widths including below 1024px

## Screenshots (if appropriate):
_See QA screenshot in the issue comment linked above for the before state._

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):
- [x] I have not imported `flux` in a new component
- [x] If adding a new feature, I used Modern Track patterns
- [x] New features do not create new SCSS files (use Tailwind instead)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
* Updated thumbnail and checkbox dimensions in the media uploads management interface for improved visual clarity and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->