### PR TITLE
feat: add django-waffle feature flag framework (#565)

### DIFF
--- a/cms/dev_settings.py
+++ b/cms/dev_settings.py
@@ -305,17 +305,16 @@ FILE_STORAGE = "django.core.files.storage.DefaultStorage"
 # valid options: content, author
 RELATED_MEDIA_STRATEGY = "content"
 
-# These are passed on every request
-LOAD_FROM_CDN = False  # if set to True will fetch external content from CDNs
-LOGIN_ALLOWED = True  # whether the login button appears
-REGISTER_ALLOWED = True  # whether the register button appears
-UPLOAD_MEDIA_ALLOWED = True  # whether the upload media button appears
-CAN_LIKE_MEDIA = True  # whether the like media appears
-CAN_DISLIKE_MEDIA = True  # whether the dislike media appears
-CAN_REPORT_MEDIA = True  # whether the report media appears
-CAN_SHARE_MEDIA = True  # whether the share media appears
-
-# experimental functionality for user ratings
+# DEPRECATED: These flags are migrated to waffle switches (managed via Django admin).
+# These settings are no longer read. Remove after confirming waffle switches work in production.
+LOAD_FROM_CDN = False
+LOGIN_ALLOWED = True
+REGISTER_ALLOWED = True
+UPLOAD_MEDIA_ALLOWED = True
+CAN_LIKE_MEDIA = True
+CAN_DISLIKE_MEDIA = True
+CAN_REPORT_MEDIA = True
+CAN_SHARE_MEDIA = True
 ALLOW_RATINGS = False
 ALLOW_RATINGS_CONFIRMED_EMAIL_ONLY = False
 

--- a/cms/dev_settings.py
+++ b/cms/dev_settings.py
@@ -378,7 +378,8 @@ CKEDITOR_CONFIGS = {
 }
 
 # settings that are related with UX/appearance
-# whether a featured item appears enlarged with player on index page
+# DEPRECATED: Migrated to waffle switch "video_player_featured_video_on_index_page".
+# This setting is no longer read. Remove after confirming waffle switch works in production.
 VIDEO_PLAYER_FEATURED_VIDEO_ON_INDEX_PAGE = False
 
 CELERY_BEAT_SCHEDULE = {}

--- a/cms/settings.py
+++ b/cms/settings.py
@@ -75,6 +75,7 @@ INSTALLED_APPS = [
     "django_recaptcha",
     "corsheaders",
     "maintenance_mode",
+    "waffle",
 ]
 
 MIDDLEWARE = [
@@ -90,6 +91,7 @@ MIDDLEWARE = [
     "users.middleware.AdminMFAMiddleware",
     "cms.middleware.MaintenanceTimingMiddleware",  # Track maintenance mode timing
     "maintenance_mode.middleware.MaintenanceModeMiddleware",
+    "waffle.middleware.WaffleMiddleware",
 ]
 
 ROOT_URLCONF = "cms.urls"
@@ -592,7 +594,8 @@ TINYMCE_DEFAULT_CONFIG = {
 }
 
 # settings that are related with UX/appearance
-# whether a featured item appears enlarged with player on index page
+# DEPRECATED: Migrated to waffle switch "video_player_featured_video_on_index_page".
+# This setting is no longer read. Remove after confirming waffle switch works in production.
 VIDEO_PLAYER_FEATURED_VIDEO_ON_INDEX_PAGE = False
 
 # Video UI/UX settings
@@ -602,6 +605,9 @@ USE_ROUNDED_CORNERS = True  # Default: rounded corners enabled
 UI_VARIANT_DEFAULT = "revamp"
 UI_VARIANT_ALLOWED = ["legacy", "revamp"]
 UI_VARIANT_REVAMP_PAGES = []  # Add page keys here as they are migrated, e.g. ["home"]
+
+# django-waffle feature flag settings
+WAFFLE_CREATE_MISSING_SWITCHES = True
 
 # allow option to override the default admin url
 DJANGO_ADMIN_URL = "admin/"

--- a/cms/settings.py
+++ b/cms/settings.py
@@ -497,17 +497,16 @@ FILE_STORAGE = "django.core.files.storage.DefaultStorage"
 # valid options: content, author
 RELATED_MEDIA_STRATEGY = "content"
 
-# These are passed on every request
-LOAD_FROM_CDN = False  # if set to True will fetch external content from CDNs
-LOGIN_ALLOWED = True  # whether the login button appears
-REGISTER_ALLOWED = True  # whether the register button appears
-UPLOAD_MEDIA_ALLOWED = True  # whether the upload media button appears
-CAN_LIKE_MEDIA = True  # whether the like media appears
-CAN_DISLIKE_MEDIA = True  # whether the dislike media appears
-CAN_REPORT_MEDIA = True  # whether the report media appears
-CAN_SHARE_MEDIA = True  # whether the share media appears
-
-# experimental functionality for user ratings
+# DEPRECATED: These flags are migrated to waffle switches (managed via Django admin).
+# These settings are no longer read. Remove after confirming waffle switches work in production.
+LOAD_FROM_CDN = False
+LOGIN_ALLOWED = True
+REGISTER_ALLOWED = True
+UPLOAD_MEDIA_ALLOWED = True
+CAN_LIKE_MEDIA = True
+CAN_DISLIKE_MEDIA = True
+CAN_REPORT_MEDIA = True
+CAN_SHARE_MEDIA = True
 ALLOW_RATINGS = False
 ALLOW_RATINGS_CONFIRMED_EMAIL_ONLY = False
 

--- a/docs/features/feature_flags.md
+++ b/docs/features/feature_flags.md
@@ -47,7 +47,7 @@ The setting `WAFFLE_CREATE_MISSING_SWITCHES = True` is enabled. If code checks a
    ret["YOUR_FLAG"] = _switch("your_switch_name", "YOUR_SETTINGS_FALLBACK")
    ```
 3. The switch will auto-create as inactive on first request
-4. Optionally, add a data migration to seed it with a specific default value and description
+4. Optionally, add it to the `seed_waffle_switches` management command with a specific default value and description
 
 ## Configuration
 
@@ -66,6 +66,16 @@ MIDDLEWARE = [
 
 WAFFLE_CREATE_MISSING_SWITCHES = True
 ```
+
+## Seeding Switches
+
+After deploying, run the seed command to create all switches with their correct defaults from settings:
+
+```bash
+python manage.py seed_waffle_switches
+```
+
+This uses `update_or_create` so it is safe to run multiple times — it will correct any auto-created switches that have wrong defaults.
 
 ## Migration from Settings
 

--- a/docs/features/feature_flags.md
+++ b/docs/features/feature_flags.md
@@ -9,6 +9,7 @@ CinemataCMS uses [django-waffle](https://waffle.readthedocs.io/) to manage featu
 3. Toggle any switch on or off
 4. Changes take effect immediately (subject to cache TTL)
 
+
 ## Available Switches
 
 | Switch name | Default | Description |

--- a/docs/features/feature_flags.md
+++ b/docs/features/feature_flags.md
@@ -1,0 +1,72 @@
+# Feature Flags
+
+CinemataCMS uses [django-waffle](https://waffle.readthedocs.io/) to manage feature flags. Flags are stored as **Switches** (simple on/off booleans) in the database and can be toggled via the Django admin panel without redeploying.
+
+## Managing Flags
+
+1. Log in to Django admin at `/admin/`
+2. Navigate to **Waffle** > **Switches**
+3. Toggle any switch on or off
+4. Changes take effect immediately (subject to cache TTL)
+
+## Available Switches
+
+| Switch name | Default | Description |
+|---|---|---|
+| `load_from_cdn` | Off | Fetch external content (CSS/JS) from CDNs instead of serving locally |
+| `login_allowed` | On | Show the login button on the site |
+| `register_allowed` | On | Show the registration button on the site |
+| `upload_media_allowed` | On | Show the upload media button on the site |
+| `can_like_media` | On | Show the like button on media pages |
+| `can_dislike_media` | On | Show the dislike button on media pages |
+| `can_report_media` | On | Show the report button on media pages |
+| `can_share_media` | On | Show the share button on media pages |
+| `allow_ratings` | Off | Enable the experimental user ratings feature |
+| `allow_ratings_confirmed_email_only` | Off | Restrict ratings to users with verified emails |
+| `video_player_featured_video_on_index_page` | Off | Show a featured video enlarged with a player on the index page |
+
+## How It Works
+
+Switches are checked at runtime via `waffle.switch_is_active("switch_name")`. The result is a boolean (`True`/`False`).
+
+Most switches are read in `files/context_processors.py` and exposed to templates as context variables (e.g., `CAN_LIKE_MEDIA`, `CAN_LOGIN`). The `allow_ratings` switch is also checked directly in `files/models.py` (the `Media.ratings_info` property).
+
+### Fallback Behavior
+
+If the waffle database tables do not exist yet (e.g., code is deployed before migrations have run), all switch lookups fall back to the deprecated settings values in `cms/settings.py`. This prevents 500 errors during the deployment window between code deploy and migration.
+
+### Auto-Creation of Missing Switches
+
+The setting `WAFFLE_CREATE_MISSING_SWITCHES = True` is enabled. If code checks a switch that does not exist in the database, waffle automatically creates it with `active=False`. This means new switches can be added in code without requiring a migration — they will appear in the admin panel on first check.
+
+## Adding a New Switch
+
+1. Use `waffle.switch_is_active("your_switch_name")` in your code
+2. Wrap the call in the `_switch()` helper (defined in `files/context_processors.py`) if you need a settings-based fallback:
+   ```python
+   ret["YOUR_FLAG"] = _switch("your_switch_name", "YOUR_SETTINGS_FALLBACK")
+   ```
+3. The switch will auto-create as inactive on first request
+4. Optionally, add a data migration to seed it with a specific default value and description
+
+## Configuration
+
+All waffle-related Django settings are in `cms/settings.py`:
+
+```python
+INSTALLED_APPS = [
+    ...
+    "waffle",
+]
+
+MIDDLEWARE = [
+    ...
+    "waffle.middleware.WaffleMiddleware",
+]
+
+WAFFLE_CREATE_MISSING_SWITCHES = True
+```
+
+## Migration from Settings
+
+These switches were previously hardcoded boolean settings in `cms/settings.py` (e.g., `CAN_LIKE_MEDIA = True`). The old settings are kept as deprecated fallbacks and will be removed once the waffle switches are confirmed working in production.

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,7 @@ Welcome to the comprehensive documentation for CinemataCMS - a platform for show
 - [🔐 Permission System](admin-guides/permission_system.md)
 - [📊 User Roles Permission Matrix](admin-guides/cinematacms-roles-permission-matrix.md)
 - [🗣️ Language Setup and Configuration](admin-guides/languages.md)
+- [🚩 Feature Flags Management](features/feature_flags.md)
 
 ## 🎨 Customization
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -86,6 +86,7 @@ Welcome to the comprehensive documentation for CinemataCMS - a platform for show
 - [📱 Mobile Interface](features/mobile_interface.md)
 - [♿ Accessibility & Keyboard Shortcuts](features/Cinemata_Accessibility_Keyboard_Shortcuts.md)
 - [🎙️ Automatic Transcription](features/automatic_transcription.md)
+- [🚩 Feature Flags](features/feature_flags.md)
 
 ---
 

--- a/files/context_processors.py
+++ b/files/context_processors.py
@@ -2,6 +2,7 @@ import json
 
 import waffle
 from django.conf import settings
+from django.db import DatabaseError
 
 from .lists import UNUSUAL_COUNTRIES
 from .methods import can_manage_uploads, can_upload_media, is_curator, is_mediacms_editor, is_mediacms_manager
@@ -17,7 +18,7 @@ from .models import HomepagePopup, TopMessage
 def _switch(name, fallback_setting):
     try:
         return waffle.switch_is_active(name)
-    except Exception:
+    except DatabaseError:
         return getattr(settings, fallback_setting, False)
 
 

--- a/files/context_processors.py
+++ b/files/context_processors.py
@@ -1,5 +1,6 @@
 import json
 
+import waffle
 from django.conf import settings
 
 from .lists import UNUSUAL_COUNTRIES
@@ -46,7 +47,7 @@ def stuff(request):
     ret["CAN_MANAGE_UPLOADS"] = can_manage_uploads(request.user)
     ret["ALLOW_RATINGS"] = settings.ALLOW_RATINGS
     ret["ALLOW_RATINGS_CONFIRMED_EMAIL_ONLY"] = settings.ALLOW_RATINGS_CONFIRMED_EMAIL_ONLY
-    ret["VIDEO_PLAYER_FEATURED_VIDEO_ON_INDEX_PAGE"] = settings.VIDEO_PLAYER_FEATURED_VIDEO_ON_INDEX_PAGE
+    ret["VIDEO_PLAYER_FEATURED_VIDEO_ON_INDEX_PAGE"] = waffle.switch_is_active("video_player_featured_video_on_index_page")
     ret["RSS_URL"] = "/rss"
 
     top_message = TopMessage.objects.filter(active=True).order_by("-add_date").first()

--- a/files/context_processors.py
+++ b/files/context_processors.py
@@ -32,7 +32,7 @@ def stuff(request):
     ret["LOAD_FROM_CDN"] = _switch("load_from_cdn", "LOAD_FROM_CDN")
     ret["CAN_LOGIN"] = _switch("login_allowed", "LOGIN_ALLOWED")
     ret["CAN_REGISTER"] = _switch("register_allowed", "REGISTER_ALLOWED")
-    ret["CAN_UPLOAD_MEDIA"] = can_upload_media(request.user)
+    ret["CAN_UPLOAD_MEDIA"] = _switch("upload_media_allowed", "UPLOAD_MEDIA_ALLOWED") and can_upload_media(request.user)
     ret["CAN_LIKE_MEDIA"] = _switch("can_like_media", "CAN_LIKE_MEDIA")
     ret["CAN_DISLIKE_MEDIA"] = _switch("can_dislike_media", "CAN_DISLIKE_MEDIA")
     ret["CAN_REPORT_MEDIA"] = _switch("can_report_media", "CAN_REPORT_MEDIA")

--- a/files/context_processors.py
+++ b/files/context_processors.py
@@ -14,6 +14,13 @@ from .models import HomepagePopup, TopMessage
 # that can be used in the templates
 
 
+def _switch(name, fallback_setting):
+    try:
+        return waffle.switch_is_active(name)
+    except Exception:
+        return getattr(settings, fallback_setting, False)
+
+
 def stuff(request):
     ret = {}
     if request.is_secure():
@@ -21,14 +28,14 @@ def stuff(request):
     else:
         ret["FRONTEND_HOST"] = settings.FRONTEND_HOST
     ret["PORTAL_NAME"] = settings.PORTAL_NAME
-    ret["LOAD_FROM_CDN"] = settings.LOAD_FROM_CDN
-    ret["CAN_LOGIN"] = settings.LOGIN_ALLOWED
-    ret["CAN_REGISTER"] = settings.REGISTER_ALLOWED
+    ret["LOAD_FROM_CDN"] = _switch("load_from_cdn", "LOAD_FROM_CDN")
+    ret["CAN_LOGIN"] = _switch("login_allowed", "LOGIN_ALLOWED")
+    ret["CAN_REGISTER"] = _switch("register_allowed", "REGISTER_ALLOWED")
     ret["CAN_UPLOAD_MEDIA"] = can_upload_media(request.user)
-    ret["CAN_LIKE_MEDIA"] = settings.CAN_LIKE_MEDIA
-    ret["CAN_DISLIKE_MEDIA"] = settings.CAN_DISLIKE_MEDIA
-    ret["CAN_REPORT_MEDIA"] = settings.CAN_REPORT_MEDIA
-    ret["CAN_SHARE_MEDIA"] = settings.CAN_SHARE_MEDIA
+    ret["CAN_LIKE_MEDIA"] = _switch("can_like_media", "CAN_LIKE_MEDIA")
+    ret["CAN_DISLIKE_MEDIA"] = _switch("can_dislike_media", "CAN_DISLIKE_MEDIA")
+    ret["CAN_REPORT_MEDIA"] = _switch("can_report_media", "CAN_REPORT_MEDIA")
+    ret["CAN_SHARE_MEDIA"] = _switch("can_share_media", "CAN_SHARE_MEDIA")
     ret["UPLOAD_MAX_SIZE"] = settings.UPLOAD_MAX_SIZE
 
     if request.user.is_authenticated and request.user.advancedUser:
@@ -45,16 +52,13 @@ def stuff(request):
     ret["IS_MEDIACMS_MANAGER"] = is_mediacms_manager(request.user)
     ret["IS_CURATOR"] = is_curator(request.user)
     ret["CAN_MANAGE_UPLOADS"] = can_manage_uploads(request.user)
-    ret["ALLOW_RATINGS"] = settings.ALLOW_RATINGS
-    ret["ALLOW_RATINGS_CONFIRMED_EMAIL_ONLY"] = settings.ALLOW_RATINGS_CONFIRMED_EMAIL_ONLY
-    try:
-        ret["VIDEO_PLAYER_FEATURED_VIDEO_ON_INDEX_PAGE"] = waffle.switch_is_active(
-            "video_player_featured_video_on_index_page"
-        )
-    except Exception:
-        ret["VIDEO_PLAYER_FEATURED_VIDEO_ON_INDEX_PAGE"] = getattr(
-            settings, "VIDEO_PLAYER_FEATURED_VIDEO_ON_INDEX_PAGE", False
-        )
+    ret["ALLOW_RATINGS"] = _switch("allow_ratings", "ALLOW_RATINGS")
+    ret["ALLOW_RATINGS_CONFIRMED_EMAIL_ONLY"] = _switch(
+        "allow_ratings_confirmed_email_only", "ALLOW_RATINGS_CONFIRMED_EMAIL_ONLY"
+    )
+    ret["VIDEO_PLAYER_FEATURED_VIDEO_ON_INDEX_PAGE"] = _switch(
+        "video_player_featured_video_on_index_page", "VIDEO_PLAYER_FEATURED_VIDEO_ON_INDEX_PAGE"
+    )
     ret["RSS_URL"] = "/rss"
 
     top_message = TopMessage.objects.filter(active=True).order_by("-add_date").first()

--- a/files/context_processors.py
+++ b/files/context_processors.py
@@ -47,7 +47,14 @@ def stuff(request):
     ret["CAN_MANAGE_UPLOADS"] = can_manage_uploads(request.user)
     ret["ALLOW_RATINGS"] = settings.ALLOW_RATINGS
     ret["ALLOW_RATINGS_CONFIRMED_EMAIL_ONLY"] = settings.ALLOW_RATINGS_CONFIRMED_EMAIL_ONLY
-    ret["VIDEO_PLAYER_FEATURED_VIDEO_ON_INDEX_PAGE"] = waffle.switch_is_active("video_player_featured_video_on_index_page")
+    try:
+        ret["VIDEO_PLAYER_FEATURED_VIDEO_ON_INDEX_PAGE"] = waffle.switch_is_active(
+            "video_player_featured_video_on_index_page"
+        )
+    except Exception:
+        ret["VIDEO_PLAYER_FEATURED_VIDEO_ON_INDEX_PAGE"] = getattr(
+            settings, "VIDEO_PLAYER_FEATURED_VIDEO_ON_INDEX_PAGE", False
+        )
     ret["RSS_URL"] = "/rss"
 
     top_message = TopMessage.objects.filter(active=True).order_by("-add_date").first()

--- a/files/management/commands/seed_waffle_switches.py
+++ b/files/management/commands/seed_waffle_switches.py
@@ -1,5 +1,15 @@
+"""
+Django Management Command: seed_waffle_switches
+
+Seeds waffle switches from their corresponding Django settings values.
+Run after migrating to ensure all switches exist with correct defaults.
+
+Usage:
+    python manage.py seed_waffle_switches
+"""
+
 from django.conf import settings
-from django.db import migrations
+from django.core.management.base import BaseCommand
 
 SWITCHES = [
     ("load_from_cdn", "LOAD_FROM_CDN", "Fetch external content from CDNs"),
@@ -24,30 +34,22 @@ SWITCHES = [
 ]
 
 
-def seed_switches(apps, schema_editor):
-    Switch = apps.get_model("waffle", "Switch")
-    for name, setting, note in SWITCHES:
-        Switch.objects.get_or_create(
-            name=name,
-            defaults={
-                "active": getattr(settings, setting, False),
-                "note": note,
-            },
-        )
+class Command(BaseCommand):
+    help = "Seed waffle switches from Django settings values"
 
+    def handle(self, *args, **options):
+        from waffle.models import Switch
 
-def unseed_switches(apps, schema_editor):
-    Switch = apps.get_model("waffle", "Switch")
-    switch_names = [name for name, _, _ in SWITCHES]
-    Switch.objects.filter(name__in=switch_names).delete()
+        for name, setting, note in SWITCHES:
+            _, created = Switch.objects.update_or_create(
+                name=name,
+                defaults={
+                    "active": getattr(settings, setting, False),
+                    "note": note,
+                },
+            )
+            status = "created" if created else "updated"
+            active = getattr(settings, setting, False)
+            self.stdout.write(f"  {name}: active={active} ({status})")
 
-
-class Migration(migrations.Migration):
-    dependencies = [
-        ("files", "0021_widen_password_field"),
-        ("waffle", "0004_update_everyone_nullbooleanfield"),
-    ]
-
-    operations = [
-        migrations.RunPython(seed_switches, unseed_switches),
-    ]
+        self.stdout.write(self.style.SUCCESS(f"Seeded {len(SWITCHES)} waffle switches"))

--- a/files/migrations/0022_seed_featured_video_switch.py
+++ b/files/migrations/0022_seed_featured_video_switch.py
@@ -1,0 +1,29 @@
+from django.conf import settings
+from django.db import migrations
+
+
+def seed_switch(apps, schema_editor):
+    Switch = apps.get_model("waffle", "Switch")
+    Switch.objects.get_or_create(
+        name="video_player_featured_video_on_index_page",
+        defaults={
+            "active": getattr(settings, "VIDEO_PLAYER_FEATURED_VIDEO_ON_INDEX_PAGE", False),
+            "note": "Whether a featured item appears enlarged with player on index page",
+        },
+    )
+
+
+def unseed_switch(apps, schema_editor):
+    Switch = apps.get_model("waffle", "Switch")
+    Switch.objects.filter(name="video_player_featured_video_on_index_page").delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("files", "0021_widen_password_field"),
+        ("waffle", "0004_update_everyone_nullbooleanfield"),
+    ]
+
+    operations = [
+        migrations.RunPython(seed_switch, unseed_switch),
+    ]

--- a/files/migrations/0022_seed_featured_video_switch.py
+++ b/files/migrations/0022_seed_featured_video_switch.py
@@ -1,21 +1,45 @@
 from django.conf import settings
 from django.db import migrations
 
+SWITCHES = [
+    ("load_from_cdn", "LOAD_FROM_CDN", "Fetch external content from CDNs"),
+    ("login_allowed", "LOGIN_ALLOWED", "Whether the login button appears"),
+    ("register_allowed", "REGISTER_ALLOWED", "Whether the register button appears"),
+    ("upload_media_allowed", "UPLOAD_MEDIA_ALLOWED", "Whether the upload media button appears"),
+    ("can_like_media", "CAN_LIKE_MEDIA", "Whether the like button appears"),
+    ("can_dislike_media", "CAN_DISLIKE_MEDIA", "Whether the dislike button appears"),
+    ("can_report_media", "CAN_REPORT_MEDIA", "Whether the report button appears"),
+    ("can_share_media", "CAN_SHARE_MEDIA", "Whether the share button appears"),
+    ("allow_ratings", "ALLOW_RATINGS", "Enable user ratings (experimental)"),
+    (
+        "allow_ratings_confirmed_email_only",
+        "ALLOW_RATINGS_CONFIRMED_EMAIL_ONLY",
+        "Restrict ratings to verified emails",
+    ),
+    (
+        "video_player_featured_video_on_index_page",
+        "VIDEO_PLAYER_FEATURED_VIDEO_ON_INDEX_PAGE",
+        "Whether a featured item appears enlarged with player on index page",
+    ),
+]
 
-def seed_switch(apps, schema_editor):
+
+def seed_switches(apps, schema_editor):
     Switch = apps.get_model("waffle", "Switch")
-    Switch.objects.get_or_create(
-        name="video_player_featured_video_on_index_page",
-        defaults={
-            "active": getattr(settings, "VIDEO_PLAYER_FEATURED_VIDEO_ON_INDEX_PAGE", False),
-            "note": "Whether a featured item appears enlarged with player on index page",
-        },
-    )
+    for name, setting, note in SWITCHES:
+        Switch.objects.get_or_create(
+            name=name,
+            defaults={
+                "active": getattr(settings, setting, False),
+                "note": note,
+            },
+        )
 
 
-def unseed_switch(apps, schema_editor):
+def unseed_switches(apps, schema_editor):
     Switch = apps.get_model("waffle", "Switch")
-    Switch.objects.filter(name="video_player_featured_video_on_index_page").delete()
+    switch_names = [name for name, _, _ in SWITCHES]
+    Switch.objects.filter(name__in=switch_names).delete()
 
 
 class Migration(migrations.Migration):
@@ -25,5 +49,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(seed_switch, unseed_switch),
+        migrations.RunPython(seed_switches, unseed_switches),
     ]

--- a/files/models.py
+++ b/files/models.py
@@ -9,6 +9,7 @@ import time
 import uuid
 
 import m3u8
+import waffle
 from django.conf import settings
 from django.contrib.postgres.indexes import GinIndex
 from django.contrib.postgres.search import SearchVectorField
@@ -1071,7 +1072,11 @@ class Media(models.Model):
     def ratings_info(self):
         # to be used if user ratings are allowed
         ret = []
-        if not settings.ALLOW_RATINGS:
+        try:
+            ratings_enabled = waffle.switch_is_active("allow_ratings")
+        except Exception:
+            ratings_enabled = getattr(settings, "ALLOW_RATINGS", False)
+        if not ratings_enabled:
             return []
         for category in self.category.all():
             ratings = RatingCategory.objects.filter(category=category, enabled=True)

--- a/files/models.py
+++ b/files/models.py
@@ -15,7 +15,7 @@ from django.contrib.postgres.indexes import GinIndex
 from django.contrib.postgres.search import SearchVectorField
 from django.core.files import File
 from django.core.validators import RegexValidator
-from django.db import connection, models
+from django.db import DatabaseError, connection, models
 from django.db.models import Q
 from django.db.models.signals import (
     m2m_changed,
@@ -1074,7 +1074,7 @@ class Media(models.Model):
         ret = []
         try:
             ratings_enabled = waffle.switch_is_active("allow_ratings")
-        except Exception:
+        except DatabaseError:
             ratings_enabled = getattr(settings, "ALLOW_RATINGS", False)
         if not ratings_enabled:
             return []

--- a/files/views.py
+++ b/files/views.py
@@ -7,13 +7,14 @@ import shutil
 from datetime import datetime, timedelta
 from pathlib import Path
 
+import waffle
 from allauth.mfa.utils import is_mfa_enabled
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.postgres.search import SearchQuery
 from django.core.mail import EmailMessage
-from django.db import models, transaction
+from django.db import DatabaseError, models, transaction
 from django.db.models import Case, Exists, F, OuterRef, Q, Value, When
 from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
@@ -385,7 +386,11 @@ def upload_media(request):
     form = LoginForm()
     context = {}
     context["form"] = form
-    context["can_add"] = can_upload_media(request.user)
+    try:
+        upload_allowed = waffle.switch_is_active("upload_media_allowed")
+    except DatabaseError:
+        upload_allowed = getattr(settings, "UPLOAD_MEDIA_ALLOWED", True)
+    context["can_add"] = upload_allowed and can_upload_media(request.user)
     can_upload_exp = settings.CANNOT_ADD_MEDIA_MESSAGE
     context["can_upload_exp"] = can_upload_exp
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "django-tinymce==5.0.0",
     "django-maintenance-mode==0.22.0",
     "django-vite>=3.1.0",
+    "django-waffle>=4.2.0,<5.0",
     "prometheus-client>=0.25.0",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -65,6 +65,7 @@ django==5.2.13
     #   django-silk
     #   django-tinymce
     #   django-vite
+    #   django-waffle
     #   djangorestframework
 django-allauth==65.16.1
     # via cinemata
@@ -101,6 +102,8 @@ django-silk==5.5.0
 django-tinymce @ git+https://github.com/jazzband/django-tinymce.git@6b413f4e9bdedb9268c8ef25886fdfc994780097
     # via cinemata
 django-vite==3.1.0
+    # via cinemata
+django-waffle==4.2.0
     # via cinemata
 djangorestframework==3.17.1
     # via cinemata

--- a/uv.lock
+++ b/uv.lock
@@ -347,6 +347,7 @@ dependencies = [
     { name = "django-silk" },
     { name = "django-tinymce" },
     { name = "django-vite" },
+    { name = "django-waffle" },
     { name = "djangorestframework" },
     { name = "fido2" },
     { name = "filetype" },
@@ -399,6 +400,7 @@ requires-dist = [
     { name = "django-silk", specifier = "==5.5.0" },
     { name = "django-tinymce", git = "https://github.com/jazzband/django-tinymce.git?rev=6b413f4e9bdedb9268c8ef25886fdfc994780097" },
     { name = "django-vite", specifier = ">=3.1.0" },
+    { name = "django-waffle", specifier = ">=4.2.0,<5.0" },
     { name = "djangorestframework", specifier = "==3.17.1" },
     { name = "fido2", specifier = "==2.2.0" },
     { name = "filetype", specifier = "==1.2.0" },
@@ -789,6 +791,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/23/fe/4be07f538bbf9bf8bf73b045552ec2a1b4fba67e3176abb30490b643368e/django_vite-3.1.0.tar.gz", hash = "sha256:8b4ffe4a9fa81ff568bfb195e74dde8694aaf13fd4b656ae60bf59cce08b85e8", size = 25434, upload-time = "2025-02-23T15:32:07.914Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/30/59/7df4b1077fa41b43b4e542696d75138dbb86a65f44248c607b3e0f1014ce/django_vite-3.1.0-py3-none-any.whl", hash = "sha256:4e46572bd6b1ce70784be129205dc2ffcbc7a3c19fea50bebfb72b327bbde5fc", size = 23579, upload-time = "2025-02-23T15:32:06.603Z" },
+]
+
+[[package]]
+name = "django-waffle"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/4b/3189241d51f582f1447ad528ed11fffad138d7d9ca3f931220a0da387e3e/django_waffle-4.2.0.tar.gz", hash = "sha256:97709550f4e75ce2a20b13e29f39777e1439a968569f2ee89398ca368afd586c", size = 36538, upload-time = "2024-11-15T17:33:31.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/64/d9d77ae9fdf00e16cd75199a28c40937e5584992cd6c7763b4f2c1bceadd/django_waffle-4.2.0-py3-none-any.whl", hash = "sha256:774f45b929627c9d303620c85419ce1da54066f2082d741af014f5bbd747e372", size = 46785, upload-time = "2024-11-15T17:33:30.094Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description
Add django-waffle as a lightweight feature flag framework and migrate **all 11** boolean feature flags from hardcoded settings to waffle Switches, togglable via Django admin (`/admin/waffle/switch/`) without redeploying.

**Migrated flags:**
| Switch name | Old setting | Default |
|---|---|---|
| `load_from_cdn` | `LOAD_FROM_CDN` | `False` |
| `login_allowed` | `LOGIN_ALLOWED` | `True` |
| `register_allowed` | `REGISTER_ALLOWED` | `True` |
| `upload_media_allowed` | `UPLOAD_MEDIA_ALLOWED` | `True` |
| `can_like_media` | `CAN_LIKE_MEDIA` | `True` |
| `can_dislike_media` | `CAN_DISLIKE_MEDIA` | `True` |
| `can_report_media` | `CAN_REPORT_MEDIA` | `True` |
| `can_share_media` | `CAN_SHARE_MEDIA` | `True` |
| `allow_ratings` | `ALLOW_RATINGS` | `False` |
| `allow_ratings_confirmed_email_only` | `ALLOW_RATINGS_CONFIRMED_EMAIL_ONLY` | `False` |
| `video_player_featured_video_on_index_page` | `VIDEO_PLAYER_FEATURED_VIDEO_ON_INDEX_PAGE` | `False` |

## Related Issue
Fixes #565

## Motivation and Context
CinemataCMS had ~20 boolean settings in `cms/settings.py` acting as feature flags. These were hardcoded, required a deploy to change, and had no admin UI. Feature flags are the primary risk mitigation tool for the Main-First workflow — this adds the framework and migrates all boolean flags.

**Design decisions:**
- **Switches only** (not Flags or Samples) — simple on/off. Per-user or percentage rollouts can be added later.
- **`_switch()` helper with try/except DatabaseError fallback** — if waffle tables don't exist yet (code deployed before `migrate`), falls back to the deprecated setting instead of 500ing.
- **`WAFFLE_CREATE_MISSING_SWITCHES = True`** — auto-creates missing switches as inactive when checked in code.
- **`seed_waffle_switches` management command** — uses `update_or_create` to seed switches from settings, safe to run multiple times and fixes any auto-created switches with wrong defaults.
- **`upload_media_allowed` wired into both context processor and upload view** — toggling the switch actually disables upload entry points.
- **Old settings kept as deprecated** — fallback values during the transition. Remove after confirming waffle works in production.

## How Has This Been Tested?
- [x] `python manage.py check` — Django system checks pass (0 issues)
- [x] Migration graph verified — clean after removing data migration
- [x] All pre-commit hooks pass (ruff, ruff-format, django-upgrade, etc.)
- [ ] Full integration test on dev server with Postgres (toggle switches in admin, verify UI behavior changes)

## Screenshots
<img width="1200" height="1032" alt="waffle-switch-edit" src="https://github.com/user-attachments/assets/7633722b-31e6-497c-a7fe-4ad92dbd36a7" />
<img width="1200" height="1174" alt="waffle-switch-list" src="https://github.com/user-attachments/assets/2470ac00-ddd0-424e-a0b8-6c49f6ef9d7a" />


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Deploy notes
After deploy:
1. `python manage.py migrate` — creates waffle tables
2. `python manage.py seed_waffle_switches` — seeds all 11 switches from settings values

Switches appear at `/admin/waffle/switch/`.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):
- [x] I have not imported `flux` in a new component
- [x] If adding a new feature, I used Modern Track patterns
- [x] New features do not create new SCSS files (use Tailwind instead)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Feature flags system now enabled, allowing runtime toggling of platform features without server restart via Django admin.
  * Multiple features migrated to feature switches: CDN loading, authentication, media uploads, ratings, and video player settings.

* **Documentation**
  * Added comprehensive feature flags documentation explaining configuration and usage.

* **Chores**
  * Added django-waffle dependency.
  * Deprecated hardcoded feature settings in favor of runtime switches with automatic fallback support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EngageMedia-video/cinematacms/pull/658)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->