### PR TITLE
feat: Color mapping

### DIFF
--- a/frontend/src/features/shared/components/Avatar/Avatar.jsx
+++ b/frontend/src/features/shared/components/Avatar/Avatar.jsx
@@ -118,7 +118,7 @@ export function Avatar({
 			role={showImage ? undefined : 'img'}
 			aria-label={showImage ? undefined : accessibleName}
 		>
-			<span className="inline-flex h-full w-full select-none items-center justify-center overflow-hidden rounded-full bg-cinemata-neutral-50 text-cinemata-neutral-600">
+			<span className="inline-flex h-full w-full select-none items-center justify-center overflow-hidden rounded-full bg-cinemata-neutral-200 dark:bg-cinemata-neutral-50 text-cinemata-neutral-600">
 				{showImage ? (
 					<img
 						src={src}
@@ -141,7 +141,7 @@ export function Avatar({
 			{resolvedBadgeIcon ? (
 				<span
 					className={joinClasses(
-						'absolute right-[-8px] bottom-[-20px] inline-flex items-center justify-center rounded-full border-[3px] border-cinemata-pacific-deep-900 p-[7px] text-cinemata-strait-blue-100',
+						'absolute right-[-8px] bottom-[-20px] inline-flex items-center justify-center rounded-full border-[3px] border-cinemata-white dark:border-cinemata-pacific-deep-900 p-[7px] text-cinemata-strait-blue-600p dark:text-cinemata-strait-blue-100',
 						badgeVariant?.className || 'bg-cinemata-strait-blue-900'
 					)}
 					style={{

--- a/frontend/src/features/shared/components/Avatar/Avatar.stories.jsx
+++ b/frontend/src/features/shared/components/Avatar/Avatar.stories.jsx
@@ -171,7 +171,7 @@ export const CustomBadgeIcon = {
 
 export const BadgeTypes = {
 	render: () => (
-		<div className="inline-flex gap-12 bg-cinemata-pacific-deep-950 p-8">
+		<div className="inline-flex gap-12 bg-cinemata-neutral-100 p-8 dark:bg-cinemata-pacific-deep-950">
 			<Avatar name="Tariq Akbar" src={sampleAvatars[0].src} size="lg" badgeType="comment" label="Comment" />
 			<Avatar
 				name="Layla Hart"
@@ -187,7 +187,7 @@ export const BadgeTypes = {
 
 export const Gallery = {
 	render: () => (
-		<div className="inline-grid grid-cols-2 gap-x-12 gap-y-10 bg-cinemata-pacific-deep-950 p-8">
+		<div className="inline-grid grid-cols-2 gap-x-12 gap-y-10 bg-cinemata-neutral-100 p-8 dark:bg-cinemata-pacific-deep-950">
 			{sampleAvatars.map((avatar) => (
 				<div key={avatar.name + avatar.src} className="contents">
 					<Avatar name={avatar.name} src={avatar.src} size="sm" />

--- a/frontend/src/features/shared/components/Badge/Badge.stories.jsx
+++ b/frontend/src/features/shared/components/Badge/Badge.stories.jsx
@@ -38,7 +38,7 @@ const meta = {
 		},
 	},
 	render: (args) => (
-		<div className="inline-flex bg-cinemata-pacific-deep-950 p-6">
+		<div className="inline-flex bg-cinemata-neutral-100 p-6 dark:bg-cinemata-pacific-deep-950">
 			<Badge {...args} />
 		</div>
 	),

--- a/frontend/src/features/shared/components/Button/Button.jsx
+++ b/frontend/src/features/shared/components/Button/Button.jsx
@@ -1,27 +1,35 @@
 const VARIANT_CLASSES = {
 	primary:
-		'border border-transparent bg-cinemata-strait-blue-600p text-cinemata-white hover:bg-cinemata-strait-blue-800',
+		'border border-transparent bg-cinemata-strait-blue-600p text-cinemata-white hover:bg-cinemata-strait-blue-800 dark:bg-cinemata-strait-blue-600p dark:text-cinemata-white dark:hover:bg-cinemata-strait-blue-800',
 	secondary:
-		'border border-transparent bg-cinemata-sunset-horizon-500 text-cinemata-white hover:bg-cinemata-sunset-horizon-700',
+		'border border-transparent bg-cinemata-sunset-horizon-500 text-cinemata-white hover:bg-cinemata-sunset-horizon-700 dark:bg-cinemata-sunset-horizon-500 dark:text-cinemata-white dark:hover:bg-cinemata-sunset-horizon-700',
 	special:
-		'border border-transparent bg-cinemata-pacific-deep-950 text-cinemata-white hover:bg-cinemata-pacific-deep-900',
+		'border border-transparent bg-cinemata-pacific-deep-600p text-cinemata-white hover:bg-cinemata-pacific-deep-700 dark:bg-cinemata-pacific-deep-950 dark:text-cinemata-white dark:hover:bg-cinemata-pacific-deep-900',
 	'primary-outline':
-		'border border-cinemata-strait-blue-600p bg-transparent text-cinemata-strait-blue-600p hover:bg-cinemata-strait-blue-600p hover:text-cinemata-white',
+		'border border-cinemata-strait-blue-600p bg-transparent text-cinemata-strait-blue-600p hover:bg-cinemata-strait-blue-600p hover:text-cinemata-white dark:border-cinemata-strait-blue-600p dark:text-cinemata-strait-blue-600p dark:hover:bg-cinemata-strait-blue-600p dark:hover:text-cinemata-white',
 	'secondary-outline':
-		'border border-cinemata-sunset-horizon-500 bg-transparent text-cinemata-sunset-horizon-500 hover:bg-cinemata-sunset-horizon-500 hover:text-cinemata-white',
+		'border border-cinemata-sunset-horizon-500 bg-transparent text-cinemata-sunset-horizon-500 hover:bg-cinemata-sunset-horizon-500 hover:text-cinemata-white dark:border-cinemata-sunset-horizon-500 dark:text-cinemata-sunset-horizon-500 dark:hover:bg-cinemata-sunset-horizon-500 dark:hover:text-cinemata-white',
 	text: 'border-none bg-transparent',
 	icon: 'border-none bg-transparent',
 };
 
 const TEXT_COLOR_CLASSES = {
-	'strait-blue-600p': 'text-cinemata-strait-blue-600p hover:text-cinemata-strait-blue-800',
-	'sunset-horizon-300': 'text-cinemata-sunset-horizon-300 hover:text-cinemata-sunset-horizon-500',
-	'sunset-horizon-500': 'text-cinemata-sunset-horizon-500 hover:text-cinemata-sunset-horizon-700',
-	'pacific-deep-950': 'text-cinemata-pacific-deep-950 hover:text-cinemata-pacific-deep-900',
-	'red-500': 'text-cinemata-red-500 hover:text-cinemata-red-600',
-	'strait-blue-100': 'text-cinemata-strait-blue-100 hover:text-cinemata-strait-blue-400',
-	'strait-blue-400': 'text-cinemata-strait-blue-400 hover:text-cinemata-strait-blue-600p',
-	'neutral-600': 'text-cinemata-neutral-600 hover:text-cinemata-neutral-700',
+	'strait-blue-600p':
+		'text-cinemata-strait-blue-600p hover:text-cinemata-strait-blue-800 dark:text-cinemata-strait-blue-600p dark:hover:text-cinemata-strait-blue-800',
+	'sunset-horizon-300':
+		'text-cinemata-sunset-horizon-500 hover:text-cinemata-sunset-horizon-700 dark:text-cinemata-sunset-horizon-300 dark:hover:text-cinemata-sunset-horizon-500',
+	'sunset-horizon-500':
+		'text-cinemata-sunset-horizon-500 hover:text-cinemata-sunset-horizon-700 dark:text-cinemata-sunset-horizon-500 dark:hover:text-cinemata-sunset-horizon-700',
+	'pacific-deep-950':
+		'text-cinemata-pacific-deep-600p hover:text-cinemata-pacific-deep-700 dark:text-cinemata-pacific-deep-950 dark:hover:text-cinemata-pacific-deep-900',
+	'red-500':
+		'text-cinemata-red-500 hover:text-cinemata-red-600 dark:text-cinemata-red-500 dark:hover:text-cinemata-red-600',
+	'strait-blue-100':
+		'text-cinemata-strait-blue-600p hover:text-cinemata-strait-blue-800 dark:text-cinemata-strait-blue-100 dark:hover:text-cinemata-strait-blue-400',
+	'strait-blue-400':
+		'text-cinemata-strait-blue-600p hover:text-cinemata-strait-blue-800 dark:text-cinemata-strait-blue-400 dark:hover:text-cinemata-strait-blue-600p',
+	'neutral-600':
+		'text-cinemata-neutral-600 hover:text-cinemata-neutral-700 dark:text-cinemata-neutral-600 dark:hover:text-cinemata-neutral-700',
 };
 
 function getTextColorClasses(color) {
@@ -70,9 +78,7 @@ export function Button({
 			type={type}
 			className={joinClasses(
 				'body-body-14-bold inline-flex items-center justify-center transition-colors duration-200 disabled:cursor-not-allowed disabled:opacity-60',
-				isIconOnlyVariant(variant)
-					? 'gap-0 p-0'
-					: 'gap-(--space-xs) rounded-(--radius-4) px-(--space-base) py-(--size-10)',
+				isIconOnlyVariant(variant) ? 'gap-0 p-0' : 'gap-space-xs rounded-ds-4 px-space-base py-size-10',
 				getVariantClasses(variant, color),
 				'cursor-pointer',
 				className

--- a/frontend/src/features/shared/components/Button/Button.stories.jsx
+++ b/frontend/src/features/shared/components/Button/Button.stories.jsx
@@ -198,7 +198,8 @@ export const IconText = {
 		color: 'sunset-horizon-300',
 		icon: <PauseIcon />,
 		iconPosition: 'left',
-		className: 'rounded-none bg-cinemata-neutral-200 px-3 py-2 hover:bg-cinemata-neutral-300 dark:bg-cinemata-pacific-deep-900 dark:hover:bg-cinemata-pacific-deep-950',
+		className:
+			'rounded-none bg-cinemata-neutral-200 px-3 py-2 hover:bg-cinemata-neutral-300 dark:bg-cinemata-pacific-deep-900 dark:hover:bg-cinemata-pacific-deep-950',
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);

--- a/frontend/src/features/shared/components/Button/Button.stories.jsx
+++ b/frontend/src/features/shared/components/Button/Button.stories.jsx
@@ -198,7 +198,7 @@ export const IconText = {
 		color: 'sunset-horizon-300',
 		icon: <PauseIcon />,
 		iconPosition: 'left',
-		className: 'rounded-none bg-cinemata-pacific-deep-900 px-3 py-2 hover:bg-cinemata-pacific-deep-950',
+		className: 'rounded-none bg-cinemata-neutral-200 px-3 py-2 hover:bg-cinemata-neutral-300 dark:bg-cinemata-pacific-deep-900 dark:hover:bg-cinemata-pacific-deep-950',
 	},
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement);

--- a/frontend/src/features/shared/components/CheckboxButton/CheckboxButton.jsx
+++ b/frontend/src/features/shared/components/CheckboxButton/CheckboxButton.jsx
@@ -42,7 +42,7 @@ export function CheckboxButton({
 
 			<span
 				className={joinClasses(
-					'inline-flex shrink-0 items-center justify-center bg-cinemata-pacific-deep-900 transition-colors duration-200 peer-checked:bg-cinemata-sunset-horizon-400p peer-focus-visible:ring-2 peer-focus-visible:ring-cinemata-sunset-horizon-400p peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-cinemata-pacific-deep-900'
+					'inline-flex shrink-0 items-center justify-center bg-cinemata-neutral-300 dark:bg-cinemata-pacific-deep-900 transition-colors duration-200 peer-checked:bg-cinemata-sunset-horizon-400p peer-focus-visible:ring-2 peer-focus-visible:ring-cinemata-sunset-horizon-400p peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-cinemata-white dark:peer-focus-visible:ring-offset-cinemata-pacific-deep-900'
 				)}
 				style={{ width: 18, height: 18 }}
 				aria-hidden="true"
@@ -53,12 +53,12 @@ export function CheckboxButton({
 					size={14}
 					className={joinClasses(
 						'transition-opacity duration-200',
-						checked ? 'text-cinemata-pacific-deep-900 opacity-100' : 'opacity-0'
+						checked ? 'text-cinemata-white dark:text-cinemata-pacific-deep-900 opacity-100' : 'opacity-0'
 					)}
 				/>
 			</span>
 
-			{children && <span className="body-body-16-regular text-cinemata-strait-blue-50">{children}</span>}
+			{children && <span className="body-body-16-regular text-cinemata-neutral-900 dark:text-cinemata-strait-blue-50">{children}</span>}
 		</label>
 	);
 }

--- a/frontend/src/features/shared/components/CheckboxButton/CheckboxButton.jsx
+++ b/frontend/src/features/shared/components/CheckboxButton/CheckboxButton.jsx
@@ -58,7 +58,11 @@ export function CheckboxButton({
 				/>
 			</span>
 
-			{children && <span className="body-body-16-regular text-cinemata-neutral-900 dark:text-cinemata-strait-blue-50">{children}</span>}
+			{children && (
+				<span className="body-body-16-regular text-cinemata-neutral-900 dark:text-cinemata-strait-blue-50">
+					{children}
+				</span>
+			)}
 		</label>
 	);
 }

--- a/frontend/src/features/shared/components/ConfirmationDialog/ConfirmationDialogContent.jsx
+++ b/frontend/src/features/shared/components/ConfirmationDialog/ConfirmationDialogContent.jsx
@@ -22,13 +22,7 @@ export function ConfirmationDialogContent({
 			{...props}
 			className={joinClasses('max-w-[520px] min-w-2xl bg-transparent p-0 text-left shadow-none', className)}
 		>
-			<div
-				className="relative overflow-hidden p-[26px] border-[0.5px] rounded-2xl  border-cinemata-strait-blue-300"
-				style={{
-					background:
-						'linear-gradient(135deg, var(--cinemata-pacific-deep-900) 0%, var(--cinemata-pacific-deep-950) 100%)',
-				}}
-			>
+			<div className="relative overflow-hidden p-[26px] border-[0.5px] rounded-2xl border-cinemata-neutral-300 bg-linear-to-br from-cinemata-white to-cinemata-neutral-50 dark:border-cinemata-strait-blue-300 dark:from-cinemata-pacific-deep-900 dark:to-cinemata-pacific-deep-950">
 				{decorationSrc ? (
 					<img
 						src={decorationSrc}
@@ -41,8 +35,12 @@ export function ConfirmationDialogContent({
 				<div className="relative z-10 flex flex-col">
 					<div className="flex flex-col items-start text-left">
 						<Icon name={iconName} size={68} decorative className="shrink-0" />
-						<h2 className="heading-h5-24-medium p-0 m-0 mt-4 text-cinemata-strait-blue-50">{title}</h2>
-						<p className="body-body-16-regular p-0 m-0 mt-2 text-cinemata-pacific-deep-300">{subtitle}</p>
+						<h2 className="heading-h5-24-medium p-0 m-0 mt-4 text-cinemata-neutral-900 dark:text-cinemata-strait-blue-50">
+							{title}
+						</h2>
+						<p className="body-body-16-regular p-0 m-0 mt-2 text-cinemata-neutral-500 dark:text-cinemata-pacific-deep-300">
+							{subtitle}
+						</p>
 					</div>
 
 					{children ? <div className="relative z-10 mt-8">{children}</div> : null}

--- a/frontend/src/features/shared/components/Dialog/Dialog.jsx
+++ b/frontend/src/features/shared/components/Dialog/Dialog.jsx
@@ -233,6 +233,7 @@ export function DialogContent({
 		<div className="fixed inset-0 z-50 flex items-center justify-center p-4">
 			<div
 				aria-hidden="true"
+				data-dialog-overlay
 				className={joinClasses(
 					'absolute inset-0 bg-cinemata-black/40 dark:bg-cinemata-pacific-deep-950 dark:opacity-80',
 					overlayClassName

--- a/frontend/src/features/shared/components/Dialog/Dialog.jsx
+++ b/frontend/src/features/shared/components/Dialog/Dialog.jsx
@@ -233,7 +233,10 @@ export function DialogContent({
 		<div className="fixed inset-0 z-50 flex items-center justify-center p-4">
 			<div
 				aria-hidden="true"
-				className={joinClasses('absolute inset-0 bg-cinemata-pacific-deep-950 opacity-80', overlayClassName)}
+				className={joinClasses(
+					'absolute inset-0 bg-cinemata-black/40 dark:bg-cinemata-pacific-deep-950 dark:opacity-80',
+					overlayClassName
+				)}
 				onClick={() => {
 					if (closeOnOverlayClick) {
 						setOpen(false);
@@ -249,10 +252,7 @@ export function DialogContent({
 				aria-label={ariaLabel}
 				tabIndex={-1}
 				data-state="open"
-				className={joinClasses(
-					'relative z-10 w-full max-w-[480px] rounded-[8px] bg-cinemata-pacific-deep-800 p-6 text-cinemata-strait-blue-50 outline-none',
-					className
-				)}
+				className={joinClasses('relative z-10 outline-none', className)}
 			>
 				{children}
 			</div>

--- a/frontend/src/features/shared/components/Dialog/Dialog.stories.jsx
+++ b/frontend/src/features/shared/components/Dialog/Dialog.stories.jsx
@@ -54,10 +54,13 @@ export const Default = {
 					<Button>OPEN DIALOG</Button>
 				</DialogTrigger>
 
-				<DialogContent aria-label="Upload dialog">
+				<DialogContent
+					aria-label="Upload dialog"
+					className="w-full max-w-[480px] rounded-[8px] bg-cinemata-white p-6 dark:bg-cinemata-pacific-deep-800"
+				>
 					<div className="space-y-2">
-						<h2 className="heading-h4 text-cinemata-white">Upload confirmation</h2>
-						<p className="body-body-16-regular text-cinemata-strait-blue-50">
+						<h2 className="heading-h4 text-cinemata-neutral-900 dark:text-cinemata-white">Upload confirmation</h2>
+						<p className="body-body-16-regular text-cinemata-neutral-600 dark:text-cinemata-strait-blue-50">
 							Your media is ready to be reviewed before publishing.
 						</p>
 					</div>
@@ -80,10 +83,13 @@ export const OpenPreview = {
 	},
 	render: (args) => (
 		<Dialog {...args}>
-			<DialogContent aria-label="Invite dialog">
+			<DialogContent
+				aria-label="Invite dialog"
+				className="w-full max-w-[480px] rounded-[8px] bg-cinemata-white p-6 dark:bg-cinemata-pacific-deep-800"
+			>
 				<div className="space-y-2">
-					<h2 className="heading-h4 text-cinemata-white">Invite collaborators</h2>
-					<p className="body-body-16-regular text-cinemata-strait-blue-50">
+					<h2 className="heading-h4 text-cinemata-neutral-900 dark:text-cinemata-white">Invite collaborators</h2>
+					<p className="body-body-16-regular text-cinemata-neutral-600 dark:text-cinemata-strait-blue-50">
 						Share this workspace with the editorial team to continue the review together.
 					</p>
 				</div>
@@ -110,10 +116,13 @@ export const Controlled = {
 						<Button variant="secondary">SHOW DETAILS</Button>
 					</DialogTrigger>
 
-					<DialogContent aria-label="Details dialog">
+					<DialogContent
+						aria-label="Details dialog"
+						className="w-full max-w-[480px] rounded-[8px] bg-cinemata-white p-6 dark:bg-cinemata-pacific-deep-800"
+					>
 						<div className="space-y-2">
-							<h2 className="heading-h4 text-cinemata-white">Review details</h2>
-							<p className="body-body-16-regular text-cinemata-strait-blue-50">
+							<h2 className="heading-h4 text-cinemata-neutral-900 dark:text-cinemata-white">Review details</h2>
+							<p className="body-body-16-regular text-cinemata-neutral-600 dark:text-cinemata-strait-blue-50">
 								This example is controlled by external component state.
 							</p>
 						</div>

--- a/frontend/src/features/shared/components/Dialog/Dialog.stories.jsx
+++ b/frontend/src/features/shared/components/Dialog/Dialog.stories.jsx
@@ -59,7 +59,9 @@ export const Default = {
 					className="w-full max-w-[480px] rounded-[8px] bg-cinemata-white p-6 dark:bg-cinemata-pacific-deep-800"
 				>
 					<div className="space-y-2">
-						<h2 className="heading-h4 text-cinemata-neutral-900 dark:text-cinemata-white">Upload confirmation</h2>
+						<h2 className="heading-h4 text-cinemata-neutral-900 dark:text-cinemata-white">
+							Upload confirmation
+						</h2>
 						<p className="body-body-16-regular text-cinemata-neutral-600 dark:text-cinemata-strait-blue-50">
 							Your media is ready to be reviewed before publishing.
 						</p>
@@ -88,7 +90,9 @@ export const OpenPreview = {
 				className="w-full max-w-[480px] rounded-[8px] bg-cinemata-white p-6 dark:bg-cinemata-pacific-deep-800"
 			>
 				<div className="space-y-2">
-					<h2 className="heading-h4 text-cinemata-neutral-900 dark:text-cinemata-white">Invite collaborators</h2>
+					<h2 className="heading-h4 text-cinemata-neutral-900 dark:text-cinemata-white">
+						Invite collaborators
+					</h2>
 					<p className="body-body-16-regular text-cinemata-neutral-600 dark:text-cinemata-strait-blue-50">
 						Share this workspace with the editorial team to continue the review together.
 					</p>
@@ -121,7 +125,9 @@ export const Controlled = {
 						className="w-full max-w-[480px] rounded-[8px] bg-cinemata-white p-6 dark:bg-cinemata-pacific-deep-800"
 					>
 						<div className="space-y-2">
-							<h2 className="heading-h4 text-cinemata-neutral-900 dark:text-cinemata-white">Review details</h2>
+							<h2 className="heading-h4 text-cinemata-neutral-900 dark:text-cinemata-white">
+								Review details
+							</h2>
 							<p className="body-body-16-regular text-cinemata-neutral-600 dark:text-cinemata-strait-blue-50">
 								This example is controlled by external component state.
 							</p>

--- a/frontend/src/features/shared/components/Dialog/Dialog.test.jsx
+++ b/frontend/src/features/shared/components/Dialog/Dialog.test.jsx
@@ -26,7 +26,7 @@ describe('Dialog', () => {
 		const dialog = screen.getByRole('dialog', { name: 'Upload dialog' });
 
 		expect(dialog).toBeVisible();
-		expect(document.body.querySelector('.bg-cinemata-pacific-deep-950')).not.toBeNull();
+		expect(document.body.querySelector('[data-dialog-overlay]')).not.toBeNull();
 	});
 
 	it('closes when the overlay is clicked', async () => {
@@ -38,7 +38,7 @@ describe('Dialog', () => {
 			</Dialog>
 		);
 
-		const overlay = document.body.querySelector('.bg-cinemata-pacific-deep-950');
+		const overlay = document.body.querySelector('[data-dialog-overlay]');
 		expect(screen.getByRole('dialog', { name: 'Upload dialog' })).toBeVisible();
 
 		await user.click(overlay);
@@ -63,7 +63,7 @@ describe('Dialog', () => {
 
 		render(<ControlledDialog />);
 
-		const overlay = document.body.querySelector('.bg-cinemata-pacific-deep-950');
+		const overlay = document.body.querySelector('[data-dialog-overlay]');
 		await user.click(overlay);
 
 		expect(handleOpenChange).toHaveBeenCalledWith(false);

--- a/frontend/src/features/shared/components/Dropdown/Dropdown.jsx
+++ b/frontend/src/features/shared/components/Dropdown/Dropdown.jsx
@@ -283,7 +283,7 @@ export function Dropdown({
 					<span
 						aria-hidden="true"
 						className={joinClasses(
-							'inline-flex h-6 w-6 shrink-0 items-center justify-center self-center text-cinemata-strait-blue-50 transition-transform duration-200',
+							'inline-flex h-6 w-6 shrink-0 items-center justify-center self-center text-cinemata-neutral-900 dark:text-cinemata-strait-blue-50 transition-transform duration-200',
 							open ? 'rotate-180' : ''
 						)}
 					>

--- a/frontend/src/features/shared/components/FollowButton/FollowButton.jsx
+++ b/frontend/src/features/shared/components/FollowButton/FollowButton.jsx
@@ -1,6 +1,9 @@
-import { useMemo, useState } from 'react';
 import { Icon } from '../Icon';
 import { Button } from '../Button';
+
+function joinClasses(...classes) {
+	return classes.filter(Boolean).join(' ');
+}
 
 function getLabel(personName, followed) {
 	if (followed) {
@@ -18,45 +21,18 @@ export function FollowButton({
 	onMouseLeave,
 	...props
 }) {
-	const [hovered, setHovered] = useState(false);
 	const label = getLabel(personName, followed);
-
-	const style = useMemo(() => {
-		if (followed) {
-			return {
-				backgroundColor: 'transparent',
-				borderColor: 'var(--cinemata-sunset-horizon-500)',
-				borderStyle: 'solid',
-				borderWidth: '1px',
-				color: 'var(--cinemata-sunset-horizon-500)',
-			};
-		}
-
-		return {
-			backgroundColor: hovered ? 'var(--cinemata-sunset-horizon-700)' : 'var(--cinemata-sunset-horizon-500)',
-			borderColor: 'transparent',
-			borderStyle: 'solid',
-			borderWidth: '1px',
-			color: 'var(--cinemata-neutral-50)',
-		};
-	}, [followed, hovered]);
 
 	return (
 		<Button
-			variant="text"
+			variant={followed ? 'secondary-outline' : 'secondary'}
 			icon={<Icon name="followUser" decorative data-testid="follow-icon" size="sm" />}
-			className={className}
+			className={joinClasses('border', className)}
 			aria-label={props['aria-label'] ?? label}
 			aria-pressed={followed}
-			style={style}
-			onMouseEnter={(event) => {
-				setHovered(true);
-				onMouseEnter?.(event);
-			}}
-			onMouseLeave={(event) => {
-				setHovered(false);
-				onMouseLeave?.(event);
-			}}
+			onMouseEnter={onMouseEnter}
+			onMous
+			eLeave={onMouseLeave}
 			{...props}
 		>
 			{label}

--- a/frontend/src/features/shared/components/FollowButton/FollowButton.jsx
+++ b/frontend/src/features/shared/components/FollowButton/FollowButton.jsx
@@ -31,8 +31,7 @@ export function FollowButton({
 			aria-label={props['aria-label'] ?? label}
 			aria-pressed={followed}
 			onMouseEnter={onMouseEnter}
-			onMous
-			eLeave={onMouseLeave}
+			onMouseLeave={onMouseLeave}
 			{...props}
 		>
 			{label}

--- a/frontend/src/features/shared/components/FollowButton/FollowButton.test.jsx
+++ b/frontend/src/features/shared/components/FollowButton/FollowButton.test.jsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { FollowButton } from './FollowButton';
 
 describe('FollowButton', () => {
@@ -10,10 +9,8 @@ describe('FollowButton', () => {
 
 		expect(button).toHaveAttribute('aria-pressed', 'false');
 		expect(screen.getByTestId('follow-icon')).toBeInTheDocument();
-		expect(button).toHaveStyle({
-			backgroundColor: 'var(--cinemata-sunset-horizon-500)',
-			color: 'var(--cinemata-neutral-50)',
-		});
+		expect(button.className).toContain('bg-cinemata-sunset-horizon-500');
+		expect(button.className).toContain('text-cinemata-white');
 	});
 
 	it('switches to followed treatment', () => {
@@ -22,25 +19,16 @@ describe('FollowButton', () => {
 		const button = screen.getByRole('button', { name: 'Following' });
 
 		expect(button).toHaveAttribute('aria-pressed', 'true');
-		expect(button.style.backgroundColor).toBe('transparent');
-		expect(button.style.borderColor).toBe('var(--cinemata-sunset-horizon-500)');
-		expect(button.style.color).toBe('var(--cinemata-sunset-horizon-500)');
+		expect(button.className).toContain('border-cinemata-sunset-horizon-500');
+		expect(button.className).toContain('text-cinemata-sunset-horizon-500');
+		expect(button.className).toContain('bg-transparent');
 	});
 
-	it('uses hover color when unfollowed', async () => {
-		const user = userEvent.setup();
+	it('has hover class when unfollowed', () => {
 		render(<FollowButton personName="Alexandra" />);
 
 		const button = screen.getByRole('button', { name: 'Follow Alexandra' });
 
-		await user.hover(button);
-		expect(button).toHaveStyle({
-			backgroundColor: 'var(--cinemata-sunset-horizon-700)',
-		});
-
-		await user.unhover(button);
-		expect(button).toHaveStyle({
-			backgroundColor: 'var(--cinemata-sunset-horizon-500)',
-		});
+		expect(button.className).toContain('hover:bg-cinemata-sunset-horizon-700');
 	});
 });

--- a/frontend/src/features/shared/components/GetNotifiedButton/GetNotifiedButton.jsx
+++ b/frontend/src/features/shared/components/GetNotifiedButton/GetNotifiedButton.jsx
@@ -1,9 +1,12 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { Icon } from '../Icon';
 import { Button } from '../Button';
 
+function joinClasses(...classes) {
+	return classes.filter(Boolean).join(' ');
+}
+
 export function GetNotifiedButton({ notified = false, className = '', onMouseEnter, onMouseLeave, ...props }) {
-	const [hovered, setHovered] = useState(false);
 	const bellIconRef = useRef(null);
 	const previousNotifiedRef = useRef(notified);
 
@@ -27,31 +30,14 @@ export function GetNotifiedButton({ notified = false, className = '', onMouseEnt
 		previousNotifiedRef.current = notified;
 	}, [notified]);
 
-	const style = useMemo(() => {
-		return {
-			backgroundColor: hovered ? 'var(--cinemata-strait-blue-800)' : 'var(--cinemata-strait-blue-700)',
-			borderColor: 'transparent',
-			borderStyle: 'solid',
-			borderWidth: '1px',
-			color: 'var(--cinemata-neutral-50)',
-		};
-	}, [hovered]);
-
 	return (
 		<Button
-			variant="text"
-			className={className}
+			variant="primary"
+			className={joinClasses(className)}
 			aria-label={props['aria-label'] ?? 'Get Notified'}
 			aria-pressed={notified}
-			style={style}
-			onMouseEnter={(event) => {
-				setHovered(true);
-				onMouseEnter?.(event);
-			}}
-			onMouseLeave={(event) => {
-				setHovered(false);
-				onMouseLeave?.(event);
-			}}
+			onMouseEnter={onMouseEnter}
+			onMouseLeave={onMouseLeave}
 			{...props}
 		>
 			<span className="inline-flex items-center justify-center gap-(--space-xs) leading-none">
@@ -72,7 +58,7 @@ export function GetNotifiedButton({ notified = false, className = '', onMouseEnt
 						<Icon name="check" decorative data-testid="check-icon" size="sm" />
 					</span>
 				) : (
-					<span>Get Notified</span>
+					<span className="body-body-14-bold">GET NOTIFIED</span>
 				)}
 			</span>
 		</Button>

--- a/frontend/src/features/shared/components/GetNotifiedButton/GetNotifiedButton.test.jsx
+++ b/frontend/src/features/shared/components/GetNotifiedButton/GetNotifiedButton.test.jsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { GetNotifiedButton } from './GetNotifiedButton';
 
 describe('GetNotifiedButton', () => {
@@ -10,11 +9,8 @@ describe('GetNotifiedButton', () => {
 
 		expect(button).toHaveAttribute('aria-pressed', 'false');
 		expect(screen.getByTestId('bell-icon')).toBeInTheDocument();
-		expect(screen.getByText('Get Notified')).toBeInTheDocument();
-		expect(button).toHaveStyle({
-			backgroundColor: 'var(--cinemata-strait-blue-700)',
-			color: 'var(--cinemata-neutral-50)',
-		});
+		expect(screen.getByText('GET NOTIFIED')).toBeInTheDocument();
+		expect(button.className).toContain('bg-cinemata-strait-blue-600p');
 	});
 
 	it('renders active bell plus right check state', () => {
@@ -25,28 +21,16 @@ describe('GetNotifiedButton', () => {
 		expect(button).toHaveAttribute('aria-pressed', 'true');
 		expect(screen.getByTestId('bell-icon')).toBeInTheDocument();
 		expect(screen.getByTestId('check-icon')).toBeInTheDocument();
-		expect(screen.queryByText('Get Notified')).not.toBeInTheDocument();
-		expect(button).toHaveStyle({
-			backgroundColor: 'var(--cinemata-strait-blue-700)',
-			color: 'var(--cinemata-neutral-50)',
-		});
+		expect(screen.queryByText('GET NOTIFIED')).not.toBeInTheDocument();
+		expect(button.className).toContain('bg-cinemata-strait-blue-600p');
 	});
 
-	it('uses hover color when inactive', async () => {
-		const user = userEvent.setup();
+	it('has hover class when inactive', () => {
 		render(<GetNotifiedButton />);
 
 		const button = screen.getByRole('button', { name: 'Get Notified' });
 
-		await user.hover(button);
-		expect(button).toHaveStyle({
-			backgroundColor: 'var(--cinemata-strait-blue-800)',
-		});
-
-		await user.unhover(button);
-		expect(button).toHaveStyle({
-			backgroundColor: 'var(--cinemata-strait-blue-700)',
-		});
+		expect(button.className).toContain('hover:bg-cinemata-strait-blue-800');
 	});
 
 	it('shakes when switching from inactive to active', () => {

--- a/frontend/src/features/shared/components/MediaDropzone/MediaDropzone.jsx
+++ b/frontend/src/features/shared/components/MediaDropzone/MediaDropzone.jsx
@@ -146,7 +146,9 @@ export function MediaDropzone({
 					</div>
 				) : null}
 
-				<p className="body-body-16-regular m-0 p-0 text-cinemata-neutral-900 dark:text-cinemata-strait-blue-50">{label}</p>
+				<p className="body-body-16-regular m-0 p-0 text-cinemata-neutral-900 dark:text-cinemata-strait-blue-50">
+					{label}
+				</p>
 
 				<Button
 					type="button"

--- a/frontend/src/features/shared/components/MediaDropzone/MediaDropzone.jsx
+++ b/frontend/src/features/shared/components/MediaDropzone/MediaDropzone.jsx
@@ -90,7 +90,7 @@ export function MediaDropzone({
 	return (
 		<div
 			className={joinClasses(
-				'relative w-full rounded-[16px] bg-cinemata-pacific-deep-800 px-6 py-[60px] transition-transform duration-200',
+				'relative w-full rounded-[16px] bg-cinemata-neutral-100 dark:bg-cinemata-pacific-deep-800 px-6 py-[60px] transition-transform duration-200',
 				isDragging ? 'scale-[1.01]' : '',
 				isDropAnimating ? 'scale-[0.995]' : '',
 				disabled ? 'opacity-60' : '',
@@ -127,7 +127,7 @@ export function MediaDropzone({
 					rx="16"
 					ry="16"
 					fill="none"
-					className="stroke-cinemata-strait-blue-300"
+					className="stroke-cinemata-neutral-400 dark:stroke-cinemata-strait-blue-300"
 					strokeWidth="1"
 					strokeDasharray="8 8"
 				/>
@@ -137,7 +137,7 @@ export function MediaDropzone({
 				{iconName ? (
 					<div
 						className={joinClasses(
-							'text-cinemata-strait-blue-50 transition-transform duration-200',
+							'text-cinemata-neutral-900 dark:text-cinemata-strait-blue-50 transition-transform duration-200',
 							isDragging ? '-translate-y-1 scale-105' : '',
 							isDropAnimating ? 'translate-y-0 scale-95' : ''
 						)}
@@ -146,7 +146,7 @@ export function MediaDropzone({
 					</div>
 				) : null}
 
-				<p className="body-body-16-regular m-0 p-0 text-cinemata-strait-blue-50">{label}</p>
+				<p className="body-body-16-regular m-0 p-0 text-cinemata-neutral-900 dark:text-cinemata-strait-blue-50">{label}</p>
 
 				<Button
 					type="button"

--- a/frontend/src/features/shared/components/MediaDropzone/MediaDropzone.stories.jsx
+++ b/frontend/src/features/shared/components/MediaDropzone/MediaDropzone.stories.jsx
@@ -92,7 +92,7 @@ const meta = {
 		},
 	},
 	render: (args) => (
-		<div className="w-[600px] bg-cinemata-pacific-deep-950">
+		<div className="w-[600px] bg-cinemata-neutral-100 dark:bg-cinemata-pacific-deep-950">
 			<MediaDropzone {...args} />
 		</div>
 	),
@@ -121,7 +121,7 @@ export const WithSelectionState = {
 		const [selectedNames, setSelectedNames] = useState([]);
 
 		return (
-			<div className="w-full min-w-[320px] max-w-[1060px] bg-cinemata-pacific-deep-950 p-4 sm:p-8">
+			<div className="w-full min-w-[320px] max-w-[1060px] bg-cinemata-neutral-100 p-4 dark:bg-cinemata-pacific-deep-950 sm:p-8">
 				<MediaDropzone
 					{...args}
 					onFilesSelected={(files) => {

--- a/frontend/src/features/shared/components/MovieItem/MovieItem.jsx
+++ b/frontend/src/features/shared/components/MovieItem/MovieItem.jsx
@@ -56,10 +56,14 @@ function MovieCopy({ title, subtitle, metadata, orientation = 'vertical' }) {
 			className={joinClasses('flex min-w-0 flex-col', orientation === 'horizontal' ? 'gap-3' : 'gap-2')}
 			data-movie-copy
 		>
-			<p className="body-body-16-medium m-0 p-0 text-cinemata-neutral-900 dark:text-cinemata-strait-blue-50 line-clamp-3">{title}</p>
+			<p className="body-body-16-medium m-0 p-0 text-cinemata-neutral-900 dark:text-cinemata-strait-blue-50 line-clamp-3">
+				{title}
+			</p>
 
 			{subtitle ? (
-				<p className="body-body-14-regular m-0 p-0 text-cinemata-sunset-horizon-600 dark:text-cinemata-sunset-horizon-200">{subtitle}</p>
+				<p className="body-body-14-regular m-0 p-0 text-cinemata-sunset-horizon-600 dark:text-cinemata-sunset-horizon-200">
+					{subtitle}
+				</p>
 			) : null}
 
 			<MovieMetadata items={metadata} />
@@ -79,7 +83,12 @@ function MoviePoster({
 	showTopRightIcon = false,
 }) {
 	return (
-		<div className={joinClasses('relative overflow-hidden rounded-[6px] bg-cinemata-neutral-200 dark:bg-cinemata-pacific-deep-800', className)}>
+		<div
+			className={joinClasses(
+				'relative overflow-hidden rounded-[6px] bg-cinemata-neutral-200 dark:bg-cinemata-pacific-deep-800',
+				className
+			)}
+		>
 			<img src={imageSrc} alt={imageAlt} className="h-full w-full object-cover" />
 
 			{badge ? (

--- a/frontend/src/features/shared/components/MovieItem/MovieItem.jsx
+++ b/frontend/src/features/shared/components/MovieItem/MovieItem.jsx
@@ -12,7 +12,7 @@ function MovieItemContainer({ children, contentClassName = '', shellClassName = 
 				<a
 					href={link}
 					className={joinClasses(
-						'h-full w-full cursor-pointer text-inherit no-underline focus:outline-none focus-visible:ring-2 focus-visible:ring-cinemata-strait-blue-200',
+						'h-full w-full cursor-pointer text-inherit no-underline focus:outline-none focus-visible:ring-2 focus-visible:ring-cinemata-strait-blue-600p dark:focus-visible:ring-cinemata-strait-blue-200',
 						contentClassName
 					)}
 					aria-label={title ? `Open ${title}` : 'Open movie details'}
@@ -34,13 +34,13 @@ function MovieMetadata({ items = [] }) {
 	}
 
 	return (
-		<div className="body-body-12-regular flex flex-wrap items-center text-cinemata-pacific-deep-400">
+		<div className="body-body-12-regular flex flex-wrap items-center text-cinemata-neutral-500 dark:text-cinemata-pacific-deep-400">
 			{validItems.map((item, index) => (
 				<span key={`${item}-${index}`} className="inline-flex items-center">
 					{index > 0 ? (
 						<span
 							aria-hidden="true"
-							className="mx-2 h-[4px] w-[4px] rounded-full bg-cinemata-pacific-deep-400"
+							className="mx-2 h-[4px] w-[4px] rounded-full bg-cinemata-neutral-500 dark:bg-cinemata-pacific-deep-400"
 						/>
 					) : null}
 					<span>{item}</span>
@@ -56,10 +56,10 @@ function MovieCopy({ title, subtitle, metadata, orientation = 'vertical' }) {
 			className={joinClasses('flex min-w-0 flex-col', orientation === 'horizontal' ? 'gap-3' : 'gap-2')}
 			data-movie-copy
 		>
-			<p className="body-body-16-medium m-0 p-0 text-cinemata-strait-blue-50 line-clamp-3">{title}</p>
+			<p className="body-body-16-medium m-0 p-0 text-cinemata-neutral-900 dark:text-cinemata-strait-blue-50 line-clamp-3">{title}</p>
 
 			{subtitle ? (
-				<p className="body-body-14-regular m-0 p-0 text-cinemata-sunset-horizon-200">{subtitle}</p>
+				<p className="body-body-14-regular m-0 p-0 text-cinemata-sunset-horizon-600 dark:text-cinemata-sunset-horizon-200">{subtitle}</p>
 			) : null}
 
 			<MovieMetadata items={metadata} />
@@ -79,7 +79,7 @@ function MoviePoster({
 	showTopRightIcon = false,
 }) {
 	return (
-		<div className={joinClasses('relative overflow-hidden rounded-[6px] bg-cinemata-pacific-deep-800', className)}>
+		<div className={joinClasses('relative overflow-hidden rounded-[6px] bg-cinemata-neutral-200 dark:bg-cinemata-pacific-deep-800', className)}>
 			<img src={imageSrc} alt={imageAlt} className="h-full w-full object-cover" />
 
 			{badge ? (
@@ -90,7 +90,7 @@ function MoviePoster({
 
 			{duration ? (
 				<span
-					className="caption-caption-10-regular absolute right-3 bottom-3 inline-flex rounded-[2px] bg-[#111111]/90 p-1 text-cinemata-strait-blue-50"
+					className="caption-caption-10-regular absolute right-3 bottom-3 inline-flex rounded-[2px] bg-[#111111]/90 p-1 text-cinemata-white dark:text-cinemata-strait-blue-50"
 					data-movie-item-duration
 				>
 					{duration}
@@ -99,7 +99,7 @@ function MoviePoster({
 
 			{showTopRightIcon && iconName ? (
 				<span
-					className="absolute top-3 right-3 inline-flex rounded-[2px] bg-cinemata-sunset-horizon-400p px-2 py-1 text-cinemata-pacific-deep-900"
+					className="absolute top-3 right-3 inline-flex rounded-[2px] bg-cinemata-sunset-horizon-400p px-2 py-1 text-cinemata-white dark:text-cinemata-pacific-deep-900"
 					data-movie-item-icon-chip
 				>
 					<Icon name={iconName} size={16} decorative={iconLabel ? false : true} label={iconLabel} />

--- a/frontend/src/features/shared/components/ProgressBar/ProgressBar.jsx
+++ b/frontend/src/features/shared/components/ProgressBar/ProgressBar.jsx
@@ -43,7 +43,7 @@ export function ProgressBar({
 		>
 			<div
 				className={joinClasses(
-					'h-2 w-full overflow-hidden rounded-full bg-cinemata-coral-reef-900',
+					'h-2 w-full overflow-hidden rounded-full bg-cinemata-coral-reef-100 dark:bg-cinemata-coral-reef-900',
 					trackClassName
 				)}
 			>

--- a/frontend/src/features/shared/components/RadioButton/RadioButton.jsx
+++ b/frontend/src/features/shared/components/RadioButton/RadioButton.jsx
@@ -41,18 +41,18 @@ export function RadioButton({
 
 			<span
 				className={joinClasses(
-					'inline-flex shrink-0 items-center justify-center rounded-full bg-cinemata-pacific-deep-900 transition-colors duration-200 peer-checked:bg-cinemata-sunset-horizon-400p'
+					'inline-flex shrink-0 items-center justify-center rounded-full bg-cinemata-neutral-300 dark:bg-cinemata-pacific-deep-900 transition-colors duration-200 peer-checked:bg-cinemata-sunset-horizon-400p'
 				)}
 				style={{ width: 18, height: 18, padding: 3 }}
 				aria-hidden="true"
 			>
 				<span
-					className="block rounded-full bg-cinemata-pacific-deep-900 transition-transform duration-200"
+					className="block rounded-full bg-cinemata-neutral-300 dark:bg-cinemata-pacific-deep-900 transition-transform duration-200"
 					style={{ width: 8, height: 8 }}
 				/>
 			</span>
 
-			{children && <span className="body-body-16-regular text-cinemata-strait-blue-50">{children}</span>}
+			{children && <span className="body-body-16-regular text-cinemata-neutral-900 dark:text-cinemata-strait-blue-50">{children}</span>}
 		</label>
 	);
 }

--- a/frontend/src/features/shared/components/RadioButton/RadioButton.jsx
+++ b/frontend/src/features/shared/components/RadioButton/RadioButton.jsx
@@ -52,7 +52,11 @@ export function RadioButton({
 				/>
 			</span>
 
-			{children && <span className="body-body-16-regular text-cinemata-neutral-900 dark:text-cinemata-strait-blue-50">{children}</span>}
+			{children && (
+				<span className="body-body-16-regular text-cinemata-neutral-900 dark:text-cinemata-strait-blue-50">
+					{children}
+				</span>
+			)}
 		</label>
 	);
 }

--- a/frontend/src/features/shared/components/SearchBar/SearchBar.jsx
+++ b/frontend/src/features/shared/components/SearchBar/SearchBar.jsx
@@ -29,7 +29,7 @@ export function SearchBar({
 				placeholder={placeholder}
 				aria-label={ariaLabel}
 				className={joinClasses(
-					'body-body-14-regular block w-full rounded-[8px] border border-transparent bg-cinemata-pacific-deep-800 px-[22px] py-[15px] pr-[58px] text-cinemata-strait-blue-50 outline-none transition-colors duration-200 placeholder:text-cinemata-pacific-deep-300 focus:border-cinemata-sunset-horizon-400p focus:ring-0 disabled:cursor-not-allowed disabled:opacity-70',
+					'body-body-14-regular block w-full rounded-[8px] border border-cinemata-neutral-300 bg-cinemata-white px-[22px] py-[15px] pr-[58px] text-cinemata-neutral-900 outline-none transition-colors duration-200 placeholder:text-cinemata-neutral-400 focus:border-cinemata-sunset-horizon-400p focus:ring-0 disabled:cursor-not-allowed disabled:opacity-70 dark:border-transparent dark:bg-cinemata-pacific-deep-800 dark:text-cinemata-strait-blue-50 dark:placeholder:text-cinemata-pacific-deep-300',
 					'[&::-webkit-search-cancel-button]:appearance-none'
 				)}
 			/>

--- a/frontend/src/features/shared/components/SearchBar/SearchBar.jsx
+++ b/frontend/src/features/shared/components/SearchBar/SearchBar.jsx
@@ -29,7 +29,7 @@ export function SearchBar({
 				placeholder={placeholder}
 				aria-label={ariaLabel}
 				className={joinClasses(
-					'body-body-14-regular block w-full rounded-[8px] border border-cinemata-neutral-300 bg-cinemata-white px-[22px] py-[15px] pr-[58px] text-cinemata-neutral-900 outline-none transition-colors duration-200 placeholder:text-cinemata-neutral-400 focus:border-cinemata-sunset-horizon-400p focus:ring-0 disabled:cursor-not-allowed disabled:opacity-70 dark:border-transparent dark:bg-cinemata-pacific-deep-800 dark:text-cinemata-strait-blue-50 dark:placeholder:text-cinemata-pacific-deep-300',
+					'body-body-14-regular block w-full rounded-[8px] border border-transparent bg-cinemata-pacific-deep-800 px-[22px] py-[15px] pr-[58px] text-cinemata-strait-blue-50 outline-none transition-colors duration-200 placeholder:text-cinemata-pacific-deep-300 focus:border-cinemata-sunset-horizon-400p focus:ring-0 disabled:cursor-not-allowed disabled:opacity-70',
 					'[&::-webkit-search-cancel-button]:appearance-none'
 				)}
 			/>

--- a/frontend/src/features/shared/components/SegmentButton/SegmentButton.jsx
+++ b/frontend/src/features/shared/components/SegmentButton/SegmentButton.jsx
@@ -82,11 +82,9 @@ export function SegmentButton({
 						aria-pressed={selected}
 						onClick={() => handleToggle(option.value)}
 						className={joinClasses(
-						'body-body-12-medium inline-flex min-w-0 items-center cursor-pointer justify-center gap-1 border-0 px-4 py-2 text-cinemata-neutral-50 transition-colors duration-200 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 first:rounded-l-(--radius-8) last:rounded-r-(--radius-8) only:rounded-(--radius-8)',
-						isFillLayout ? 'flex-1' : 'shrink-0',
-						selected
-							? 'bg-cinemata-sunset-horizon-500'
-							: 'bg-cinemata-pacific-deep-800'
+							'body-body-12-medium inline-flex min-w-0 items-center cursor-pointer justify-center gap-1 border-0 px-4 py-2 text-cinemata-neutral-50 transition-colors duration-200 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 first:rounded-l-(--radius-8) last:rounded-r-(--radius-8) only:rounded-(--radius-8)',
+							isFillLayout ? 'flex-1' : 'shrink-0',
+							selected ? 'bg-cinemata-sunset-horizon-500' : 'bg-cinemata-pacific-deep-800'
 						)}
 					>
 						{option.iconName ? <Icon name={option.iconName} size={20} decorative /> : null}

--- a/frontend/src/features/shared/components/SegmentButton/SegmentButton.jsx
+++ b/frontend/src/features/shared/components/SegmentButton/SegmentButton.jsx
@@ -82,9 +82,11 @@ export function SegmentButton({
 						aria-pressed={selected}
 						onClick={() => handleToggle(option.value)}
 						className={joinClasses(
-							'body-body-12-medium inline-flex min-w-0 items-center cursor-pointer justify-center gap-1 border-0 px-4 py-2 text-cinemata-neutral-50 transition-colors duration-200 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 first:rounded-l-(--radius-8) last:rounded-r-(--radius-8) only:rounded-(--radius-8)',
-							isFillLayout ? 'flex-1' : 'shrink-0',
-							selected ? 'bg-cinemata-sunset-horizon-500' : 'bg-cinemata-pacific-deep-800'
+						'body-body-12-medium inline-flex min-w-0 items-center cursor-pointer justify-center gap-1 border-0 px-4 py-2 text-cinemata-neutral-900 dark:text-cinemata-neutral-50 transition-colors duration-200 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 first:rounded-l-(--radius-8) last:rounded-r-(--radius-8) only:rounded-(--radius-8)',
+						isFillLayout ? 'flex-1' : 'shrink-0',
+						selected
+							? 'bg-cinemata-sunset-horizon-500 dark:bg-cinemata-sunset-horizon-500'
+							: 'bg-cinemata-neutral-200 dark:bg-cinemata-pacific-deep-800'
 						)}
 					>
 						{option.iconName ? <Icon name={option.iconName} size={20} decorative /> : null}

--- a/frontend/src/features/shared/components/SegmentButton/SegmentButton.jsx
+++ b/frontend/src/features/shared/components/SegmentButton/SegmentButton.jsx
@@ -82,11 +82,11 @@ export function SegmentButton({
 						aria-pressed={selected}
 						onClick={() => handleToggle(option.value)}
 						className={joinClasses(
-						'body-body-12-medium inline-flex min-w-0 items-center cursor-pointer justify-center gap-1 border-0 px-4 py-2 text-cinemata-neutral-900 dark:text-cinemata-neutral-50 transition-colors duration-200 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 first:rounded-l-(--radius-8) last:rounded-r-(--radius-8) only:rounded-(--radius-8)',
+						'body-body-12-medium inline-flex min-w-0 items-center cursor-pointer justify-center gap-1 border-0 px-4 py-2 text-cinemata-neutral-50 transition-colors duration-200 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 first:rounded-l-(--radius-8) last:rounded-r-(--radius-8) only:rounded-(--radius-8)',
 						isFillLayout ? 'flex-1' : 'shrink-0',
 						selected
-							? 'bg-cinemata-sunset-horizon-500 dark:bg-cinemata-sunset-horizon-500'
-							: 'bg-cinemata-neutral-200 dark:bg-cinemata-pacific-deep-800'
+							? 'bg-cinemata-sunset-horizon-500'
+							: 'bg-cinemata-pacific-deep-800'
 						)}
 					>
 						{option.iconName ? <Icon name={option.iconName} size={20} decorative /> : null}

--- a/frontend/src/features/shared/components/SegmentButton/SegmentButton.stories.jsx
+++ b/frontend/src/features/shared/components/SegmentButton/SegmentButton.stories.jsx
@@ -99,7 +99,7 @@ const meta = {
 		},
 	},
 	render: (args) => (
-		<div className="bg-cinemata-pacific-deep-950 p-8">
+		<div className="bg-cinemata-neutral-100 p-8 dark:bg-cinemata-pacific-deep-950">
 			<SegmentButton {...args} />
 		</div>
 	),
@@ -121,7 +121,7 @@ export const Controlled = {
 		const [value, setValue] = useState('dark');
 
 		return (
-			<div className="w-full min-w-[320px] max-w-[820px] bg-cinemata-pacific-deep-950 p-8">
+			<div className="w-full min-w-[320px] max-w-[820px] bg-cinemata-neutral-100 p-8 dark:bg-cinemata-pacific-deep-950">
 				<SegmentButton
 					{...args}
 					value={value}
@@ -155,7 +155,7 @@ export const FillWidth = {
 		layout: 'fill',
 	},
 	render: (args) => (
-		<div className="w-full max-w-[720px] bg-cinemata-pacific-deep-950 p-8">
+		<div className="w-full max-w-[720px] bg-cinemata-neutral-100 p-8 dark:bg-cinemata-pacific-deep-950">
 			<SegmentButton {...args} />
 		</div>
 	),

--- a/frontend/src/features/shared/components/SquareImage/SquareImage.jsx
+++ b/frontend/src/features/shared/components/SquareImage/SquareImage.jsx
@@ -30,7 +30,7 @@ export function SquareImage({
 		<span
 			{...props}
 			className={joinClasses(
-				'relative inline-flex shrink-0 items-center justify-center overflow-hidden bg-cinemata-pacific-deep-800',
+				'relative inline-flex shrink-0 items-center justify-center overflow-hidden bg-cinemata-neutral-200 dark:bg-cinemata-pacific-deep-800',
 				className
 			)}
 			style={{
@@ -56,7 +56,7 @@ export function SquareImage({
 			) : null}
 
 			{loading ? (
-				<span aria-hidden="true" className="absolute inset-0 bg-cinemata-pacific-deep-800 opacity-80" />
+				<span aria-hidden="true" className="absolute inset-0 bg-cinemata-neutral-200 dark:bg-cinemata-pacific-deep-800 opacity-80" />
 			) : null}
 
 			{showCenteredIcon ? (
@@ -65,7 +65,7 @@ export function SquareImage({
 						name={centeredIconName}
 						decorative
 						size={21}
-						className={joinClasses('text-cinemata-neutral-50', loading ? 'animate-spin' : '')}
+						className={joinClasses('text-cinemata-neutral-600 dark:text-cinemata-neutral-50', loading ? 'animate-spin' : '')}
 					/>
 				</span>
 			) : null}

--- a/frontend/src/features/shared/components/SquareImage/SquareImage.jsx
+++ b/frontend/src/features/shared/components/SquareImage/SquareImage.jsx
@@ -56,7 +56,10 @@ export function SquareImage({
 			) : null}
 
 			{loading ? (
-				<span aria-hidden="true" className="absolute inset-0 bg-cinemata-neutral-200 dark:bg-cinemata-pacific-deep-800 opacity-80" />
+				<span
+					aria-hidden="true"
+					className="absolute inset-0 bg-cinemata-neutral-200 dark:bg-cinemata-pacific-deep-800 opacity-80"
+				/>
 			) : null}
 
 			{showCenteredIcon ? (
@@ -65,7 +68,10 @@ export function SquareImage({
 						name={centeredIconName}
 						decorative
 						size={21}
-						className={joinClasses('text-cinemata-neutral-600 dark:text-cinemata-neutral-50', loading ? 'animate-spin' : '')}
+						className={joinClasses(
+							'text-cinemata-neutral-600 dark:text-cinemata-neutral-50',
+							loading ? 'animate-spin' : ''
+						)}
 					/>
 				</span>
 			) : null}

--- a/frontend/src/features/shared/components/SquareImage/SquareImage.stories.jsx
+++ b/frontend/src/features/shared/components/SquareImage/SquareImage.stories.jsx
@@ -139,7 +139,7 @@ export const Loading = {
 
 export const Gallery = {
 	render: () => (
-		<div className="inline-flex gap-6 bg-cinemata-pacific-deep-950 p-8">
+		<div className="inline-flex gap-6 bg-cinemata-neutral-100 p-8 dark:bg-cinemata-pacific-deep-950">
 			<SquareImage alt="URL poster" src={sampleUrlImage} />
 			<SquareImage alt="Static poster" src={sampleStaticImage} />
 			<SquareImage alt="Placeholder artwork" src="" iconName="example" />

--- a/frontend/src/features/shared/components/Stepper/Stepper.jsx
+++ b/frontend/src/features/shared/components/Stepper/Stepper.jsx
@@ -17,7 +17,9 @@ export function Stepper({
 				<div className="inline-flex p-2 shrink-0 items-center justify-center rounded-full bg-cinemata-neutral-200 text-cinemata-strait-blue-600p dark:bg-cinemata-pacific-deep-800 dark:text-cinemata-strait-blue-200">
 					<Icon name={iconName} decorative data-stepper-icon />
 				</div>
-				<p className="body-body-14-regular m-0 p-0 text-cinemata-neutral-500 dark:text-cinemata-pacific-deep-300 mt-1">{label}</p>
+				<p className="body-body-14-regular m-0 p-0 text-cinemata-neutral-500 dark:text-cinemata-pacific-deep-300 mt-1">
+					{label}
+				</p>
 			</div>
 
 			<div>
@@ -39,15 +41,23 @@ export function Stepper({
 								/>
 							) : (
 								<div className="w-[6px]">
-								<span className="w-px flex-1 bg-cinemata-neutral-300 dark:bg-cinemata-pacific-deep-600p" data-stepper-dot />
-							</div>
+									<span
+										className="w-px flex-1 bg-cinemata-neutral-300 dark:bg-cinemata-pacific-deep-600p"
+										data-stepper-dot
+									/>
+								</div>
 							)}
 
-							<span className="w-px flex-1 bg-cinemata-neutral-300 dark:bg-cinemata-pacific-deep-600p" data-stepper-line />
+							<span
+								className="w-px flex-1 bg-cinemata-neutral-300 dark:bg-cinemata-pacific-deep-600p"
+								data-stepper-line
+							/>
 						</div>
 
 						<div className="min-w-0 flex-1 flex flex-col mb-6 gap-2">
-							<p className="body-body-16-regular p-0 m-0 text-cinemata-neutral-900 dark:text-cinemata-pacific-deep-50">{item.title}</p>
+							<p className="body-body-16-regular p-0 m-0 text-cinemata-neutral-900 dark:text-cinemata-pacific-deep-50">
+								{item.title}
+							</p>
 
 							<div className="flex flex-wrap items-center gap-3">
 								{item.date ? (

--- a/frontend/src/features/shared/components/Stepper/Stepper.jsx
+++ b/frontend/src/features/shared/components/Stepper/Stepper.jsx
@@ -14,10 +14,10 @@ export function Stepper({
 	return (
 		<div className={joinClasses('w-full', className)} data-stepper>
 			<div className="flex gap-6">
-				<div className="inline-flex p-2 shrink-0 items-center justify-center rounded-full bg-cinemata-pacific-deep-800 text-cinemata-strait-blue-200">
+				<div className="inline-flex p-2 shrink-0 items-center justify-center rounded-full bg-cinemata-neutral-200 text-cinemata-strait-blue-600p dark:bg-cinemata-pacific-deep-800 dark:text-cinemata-strait-blue-200">
 					<Icon name={iconName} decorative data-stepper-icon />
 				</div>
-				<p className="body-body-14-regular m-0 p-0 text-cinemata-pacific-deep-300 mt-1">{label}</p>
+				<p className="body-body-14-regular m-0 p-0 text-cinemata-neutral-500 dark:text-cinemata-pacific-deep-300 mt-1">{label}</p>
 			</div>
 
 			<div>
@@ -26,7 +26,7 @@ export function Stepper({
 						<div className="flex shrink-0 flex-col items-center" aria-hidden="true">
 							<span
 								className={joinClasses(
-									'w-px h-4 bg-cinemata-pacific-deep-600p',
+									'w-px h-4 bg-cinemata-neutral-300 dark:bg-cinemata-pacific-deep-600p',
 									index == 0 ? 'mt-2' : ''
 								)}
 								data-stepper-line
@@ -34,24 +34,24 @@ export function Stepper({
 
 							{index > 0 ? (
 								<span
-									className="my-[10px] h-[6px] w-[6px] rounded-full bg-cinemata-strait-blue-200"
+									className="my-[10px] h-[6px] w-[6px] rounded-full bg-cinemata-neutral-400 dark:bg-cinemata-strait-blue-200"
 									data-stepper-dot
 								/>
 							) : (
 								<div className="w-[6px]">
-									<span className="w-px flex-1 bg-cinemata-pacific-deep-600p" data-stepper-dot />
-								</div>
+								<span className="w-px flex-1 bg-cinemata-neutral-300 dark:bg-cinemata-pacific-deep-600p" data-stepper-dot />
+							</div>
 							)}
 
-							<span className="w-px flex-1 bg-cinemata-pacific-deep-600p" data-stepper-line />
+							<span className="w-px flex-1 bg-cinemata-neutral-300 dark:bg-cinemata-pacific-deep-600p" data-stepper-line />
 						</div>
 
 						<div className="min-w-0 flex-1 flex flex-col mb-6 gap-2">
-							<p className="body-body-16-regular p-0 m-0 text-cinemata-pacific-deep-50">{item.title}</p>
+							<p className="body-body-16-regular p-0 m-0 text-cinemata-neutral-900 dark:text-cinemata-pacific-deep-50">{item.title}</p>
 
 							<div className="flex flex-wrap items-center gap-3">
 								{item.date ? (
-									<span className="body-body-14-regular text-cinemata-pacific-deep-300">
+									<span className="body-body-14-regular text-cinemata-neutral-500 dark:text-cinemata-pacific-deep-300">
 										{item.date}
 									</span>
 								) : null}
@@ -59,7 +59,7 @@ export function Stepper({
 								{item.date && item.href ? (
 									<span
 										aria-hidden="true"
-										className="h-[6px] w-[6px] rounded-full bg-cinemata-pacific-deep-300"
+										className="h-[6px] w-[6px] rounded-full bg-cinemata-neutral-400 dark:bg-cinemata-pacific-deep-300"
 									/>
 								) : null}
 
@@ -68,7 +68,7 @@ export function Stepper({
 										href={item.href}
 										target="_blank"
 										rel="noreferrer"
-										className="body-body-14-bold text-cinemata-sunset-horizon-400p no-underline"
+										className="body-body-14-bold text-cinemata-sunset-horizon-600 dark:text-cinemata-sunset-horizon-400p no-underline"
 									>
 										{item.linkLabel ?? linkLabel}
 									</a>

--- a/frontend/src/features/shared/components/Stepper/Stepper.stories.jsx
+++ b/frontend/src/features/shared/components/Stepper/Stepper.stories.jsx
@@ -74,7 +74,7 @@ const meta = {
 		},
 	},
 	render: (args) => (
-		<div className="w-full min-w-[320px] max-w-[820px] bg-cinemata-pacific-deep-950 p-8">
+		<div className="w-full min-w-[320px] max-w-[820px] bg-cinemata-neutral-50 dark:bg-cinemata-pacific-deep-950 p-8">
 			<Stepper {...args} />
 		</div>
 	),
@@ -107,7 +107,7 @@ export const ThreeItems = {
 
 export const MobileWidth = {
 	render: (args) => (
-		<div className="w-full max-w-[360px] bg-cinemata-pacific-deep-950 p-5">
+		<div className="w-full max-w-[360px] bg-cinemata-neutral-50 p-5 dark:bg-cinemata-pacific-deep-950">
 			<Stepper {...args} />
 		</div>
 	),

--- a/frontend/src/features/shared/components/Switch/Switch.jsx
+++ b/frontend/src/features/shared/components/Switch/Switch.jsx
@@ -37,7 +37,11 @@ export function Switch({
 				className
 			)}
 		>
-			{children && <span className="body-body-16-regular text-cinemata-neutral-700 dark:text-cinemata-neutral-500">{children}</span>}
+			{children && (
+				<span className="body-body-16-regular text-cinemata-neutral-700 dark:text-cinemata-neutral-500">
+					{children}
+				</span>
+			)}
 
 			<input
 				type="checkbox"

--- a/frontend/src/features/shared/components/Switch/Switch.jsx
+++ b/frontend/src/features/shared/components/Switch/Switch.jsx
@@ -37,7 +37,7 @@ export function Switch({
 				className
 			)}
 		>
-			{children && <span className="body-body-16-regular text-cinemata-neutral-500">{children}</span>}
+			{children && <span className="body-body-16-regular text-cinemata-neutral-700 dark:text-cinemata-neutral-500">{children}</span>}
 
 			<input
 				type="checkbox"

--- a/frontend/src/features/shared/components/Switch/Switch.stories.jsx
+++ b/frontend/src/features/shared/components/Switch/Switch.stories.jsx
@@ -55,7 +55,7 @@ const meta = {
 	},
 	decorators: [
 		(Story) => (
-			<div className="inline-flex bg-[#1F1F1F] p-8">
+			<div className="inline-flex bg-cinemata-neutral-100 p-8 dark:bg-[#1F1F1F]">
 				<Story />
 			</div>
 		),

--- a/frontend/src/features/shared/components/TabView/TabView.jsx
+++ b/frontend/src/features/shared/components/TabView/TabView.jsx
@@ -101,7 +101,7 @@ function TabViewList({ items, className = '', triggerClassName = '' }) {
 				role="tablist"
 				aria-label={ariaLabel}
 				className={joinClasses(
-					'flex overflow-hidden rounded-sm bg-cinemata-pacific-deep-800 p-0',
+					'flex overflow-hidden rounded-sm bg-cinemata-neutral-200 dark:bg-cinemata-pacific-deep-800 p-0',
 					tabMode === 'wrap' ? 'w-max min-w-0' : 'min-w-full',
 					className
 				)}
@@ -168,9 +168,9 @@ function TabViewTrigger({ children, value, disabled = false, className = '' }) {
 				}
 			}}
 			className={joinClasses(
-				'body-body-14-bold cursor-pointer whitespace-nowrap border-0 px-4 py-4 text-cinemata-white uppercase tracking-[0.02em] transition-colors duration-200 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50',
-				tabMode === 'wrap' ? 'min-w-0 flex-none' : 'min-w-[160px] flex-1',
-				isSelected ? 'bg-cinemata-strait-blue-800' : 'bg-transparent',
+			'body-body-14-bold cursor-pointer whitespace-nowrap border-0 px-4 py-4 text-cinemata-neutral-900 dark:text-cinemata-white uppercase tracking-[0.02em] transition-colors duration-200 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50',
+			tabMode === 'wrap' ? 'min-w-0 flex-none' : 'min-w-[160px] flex-1',
+			isSelected ? 'bg-cinemata-strait-blue-200 dark:bg-cinemata-strait-blue-800' : 'bg-transparent',
 				className
 			)}
 		>

--- a/frontend/src/features/shared/components/TabView/TabView.jsx
+++ b/frontend/src/features/shared/components/TabView/TabView.jsx
@@ -168,9 +168,9 @@ function TabViewTrigger({ children, value, disabled = false, className = '' }) {
 				}
 			}}
 			className={joinClasses(
-			'body-body-14-bold cursor-pointer whitespace-nowrap border-0 px-4 py-4 text-cinemata-white uppercase tracking-[0.02em] transition-colors duration-200 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50',
-			tabMode === 'wrap' ? 'min-w-0 flex-none' : 'min-w-[160px] flex-1',
-			isSelected ? 'bg-cinemata-strait-blue-800' : 'bg-transparent',
+				'body-body-14-bold cursor-pointer whitespace-nowrap border-0 px-4 py-4 text-cinemata-white uppercase tracking-[0.02em] transition-colors duration-200 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50',
+				tabMode === 'wrap' ? 'min-w-0 flex-none' : 'min-w-[160px] flex-1',
+				isSelected ? 'bg-cinemata-strait-blue-800' : 'bg-transparent',
 				className
 			)}
 		>

--- a/frontend/src/features/shared/components/TabView/TabView.jsx
+++ b/frontend/src/features/shared/components/TabView/TabView.jsx
@@ -101,7 +101,7 @@ function TabViewList({ items, className = '', triggerClassName = '' }) {
 				role="tablist"
 				aria-label={ariaLabel}
 				className={joinClasses(
-					'flex overflow-hidden rounded-sm bg-cinemata-neutral-200 dark:bg-cinemata-pacific-deep-800 p-0',
+					'flex overflow-hidden rounded-sm bg-cinemata-pacific-deep-800 p-0',
 					tabMode === 'wrap' ? 'w-max min-w-0' : 'min-w-full',
 					className
 				)}
@@ -168,9 +168,9 @@ function TabViewTrigger({ children, value, disabled = false, className = '' }) {
 				}
 			}}
 			className={joinClasses(
-			'body-body-14-bold cursor-pointer whitespace-nowrap border-0 px-4 py-4 text-cinemata-neutral-900 dark:text-cinemata-white uppercase tracking-[0.02em] transition-colors duration-200 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50',
+			'body-body-14-bold cursor-pointer whitespace-nowrap border-0 px-4 py-4 text-cinemata-white uppercase tracking-[0.02em] transition-colors duration-200 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50',
 			tabMode === 'wrap' ? 'min-w-0 flex-none' : 'min-w-[160px] flex-1',
-			isSelected ? 'bg-cinemata-strait-blue-200 dark:bg-cinemata-strait-blue-800' : 'bg-transparent',
+			isSelected ? 'bg-cinemata-strait-blue-800' : 'bg-transparent',
 				className
 			)}
 		>

--- a/frontend/src/features/shared/components/TabView/TabView.stories.jsx
+++ b/frontend/src/features/shared/components/TabView/TabView.stories.jsx
@@ -3,7 +3,11 @@ import { expect, userEvent, within } from 'storybook/test';
 import { TabContent, TabView } from './TabView';
 
 function TabViewFrame({ children }) {
-	return <div className="w-full min-w-[320px] max-w-[720px] bg-cinemata-neutral-100 p-6 dark:bg-cinemata-pacific-deep-950">{children}</div>;
+	return (
+		<div className="w-full min-w-[320px] max-w-[720px] bg-cinemata-neutral-100 p-6 dark:bg-cinemata-pacific-deep-950">
+			{children}
+		</div>
+	);
 }
 
 const meta = {

--- a/frontend/src/features/shared/components/TabView/TabView.stories.jsx
+++ b/frontend/src/features/shared/components/TabView/TabView.stories.jsx
@@ -3,7 +3,7 @@ import { expect, userEvent, within } from 'storybook/test';
 import { TabContent, TabView } from './TabView';
 
 function TabViewFrame({ children }) {
-	return <div className="w-full min-w-[320px] max-w-[720px] bg-cinemata-pacific-deep-950 p-6">{children}</div>;
+	return <div className="w-full min-w-[320px] max-w-[720px] bg-cinemata-neutral-100 p-6 dark:bg-cinemata-pacific-deep-950">{children}</div>;
 }
 
 const meta = {

--- a/frontend/src/features/shared/components/TextAlert/TextAlert.jsx
+++ b/frontend/src/features/shared/components/TextAlert/TextAlert.jsx
@@ -16,13 +16,13 @@ export function TextAlert({
 			{...props}
 			role={role}
 			className={joinClasses(
-				'body-body-16-regular flex w-full items-center gap-3 text-cinemata-sunset-horizon-400p',
+				'body-body-16-regular flex w-full items-center gap-3 text-cinemata-sunset-horizon-600 dark:text-cinemata-sunset-horizon-400p',
 				className
 			)}
 		>
 			<span
 				aria-hidden="true"
-				className="inline-flex h-6 w-6 shrink-0 items-center justify-center text-cinemata-sunset-horizon-400p"
+				className="inline-flex h-6 w-6 shrink-0 items-center justify-center text-cinemata-sunset-horizon-600 dark:text-cinemata-sunset-horizon-400p"
 			>
 				<Icon name={iconName} size={24} decorative />
 			</span>

--- a/frontend/src/features/shared/components/Tooltip/Tooltip.jsx
+++ b/frontend/src/features/shared/components/Tooltip/Tooltip.jsx
@@ -102,7 +102,7 @@ export function Tooltip({
 					id={tooltipId}
 					role="tooltip"
 					className={joinClasses(
-						'body-body-14-regular absolute z-20 w-[250px] rounded-[8px] border border-cinemata-pacific-deep-800 bg-cinemata-pacific-deep-900 px-3 py-1.5 leading-[1.2] text-cinemata-strait-blue-50',
+						'body-body-14-regular absolute z-20 w-[250px] rounded-[8px] border border-cinemata-neutral-300 bg-cinemata-white px-3 py-1.5 leading-[1.2] text-cinemata-neutral-900 dark:border-cinemata-pacific-deep-800 dark:bg-cinemata-pacific-deep-900 dark:text-cinemata-strait-blue-50',
 						PLACEMENT_CLASSES[resolvedPlacement],
 						contentClassName
 					)}

--- a/frontend/src/features/shared/components/Tooltip/Tooltip.stories.jsx
+++ b/frontend/src/features/shared/components/Tooltip/Tooltip.stories.jsx
@@ -144,8 +144,10 @@ export const RichContent = {
 		trigger: 'click',
 		content: (
 			<div className="flex max-w-[220px] flex-col gap-1">
-			<p className="body-body-14-bold text-cinemata-neutral-900 dark:text-cinemata-strait-blue-50">Tooltip Title</p>
-			<p className="body-body-14-regular text-cinemata-neutral-500 dark:text-cinemata-pacific-deep-300">
+				<p className="body-body-14-bold text-cinemata-neutral-900 dark:text-cinemata-strait-blue-50">
+					Tooltip Title
+				</p>
+				<p className="body-body-14-regular text-cinemata-neutral-500 dark:text-cinemata-pacific-deep-300">
 					Add any custom content here while keeping the same shared tooltip surface.
 				</p>
 			</div>

--- a/frontend/src/features/shared/components/Tooltip/Tooltip.stories.jsx
+++ b/frontend/src/features/shared/components/Tooltip/Tooltip.stories.jsx
@@ -105,7 +105,7 @@ const meta = {
 		},
 	},
 	render: (args) => (
-		<div className="flex w-[300px] h-[400px] items-center justify-center bg-cinemata-pacific-deep-950 p-10">
+		<div className="flex w-[300px] h-[400px] items-center justify-center bg-cinemata-neutral-100 dark:bg-cinemata-pacific-deep-950 p-10">
 			<Tooltip {...args}>
 				<TooltipIconButton />
 			</Tooltip>
@@ -144,8 +144,8 @@ export const RichContent = {
 		trigger: 'click',
 		content: (
 			<div className="flex max-w-[220px] flex-col gap-1">
-				<p className="body-body-14-bold text-cinemata-strait-blue-50">Tooltip Title</p>
-				<p className="body-body-14-regular text-cinemata-pacific-deep-300">
+			<p className="body-body-14-bold text-cinemata-neutral-900 dark:text-cinemata-strait-blue-50">Tooltip Title</p>
+			<p className="body-body-14-regular text-cinemata-neutral-500 dark:text-cinemata-pacific-deep-300">
 					Add any custom content here while keeping the same shared tooltip surface.
 				</p>
 			</div>
@@ -158,7 +158,7 @@ export const Controlled = {
 		const [open, setOpen] = useState(true);
 
 		return (
-			<div className="flex min-h-[240px] items-center justify-center bg-cinemata-pacific-deep-950 p-10">
+			<div className="flex min-h-[240px] items-center justify-center bg-cinemata-neutral-100 dark:bg-cinemata-pacific-deep-950 p-10">
 				<Tooltip {...args} trigger="click" open={open} onOpenChange={setOpen}>
 					<TooltipIconButton />
 				</Tooltip>

--- a/frontend/src/storybook/Colors.mdx
+++ b/frontend/src/storybook/Colors.mdx
@@ -1,0 +1,104 @@
+import { Meta, Title, Subtitle, Heading } from '@storybook/addon-docs/blocks';
+
+<Meta title="Introduction/Colors" />
+
+<Title>Color Mapping</Title>
+<Subtitle>Light and dark mode color assignments for cinemata-* tokens</Subtitle>
+
+This document maps which `cinemata-*` color to use for each UI role in light and dark mode, based on actual component usage across the design system.
+
+<Heading>Text</Heading>
+
+- **Primary text** — light: `text-cinemata-neutral-900` / dark: `dark:text-cinemata-white` or `dark:text-cinemata-strait-blue-50`
+- **Secondary / muted text** — light: `text-cinemata-neutral-500` or `text-cinemata-neutral-600` / dark: `dark:text-cinemata-pacific-deep-300` or `dark:text-cinemata-neutral-500`
+- **Placeholder text** — light: `text-cinemata-neutral-400` / dark: `dark:text-cinemata-pacific-deep-300`
+- **Text on colored bg** — `text-cinemata-white` (same in both)
+- **Badge text** — `text-cinemata-neutral-50` (same in both)
+- **Text on dark surface** — `text-cinemata-neutral-950 dark:text-cinemata-neutral-50`
+- **Subtitle / accent text** — light: `text-cinemata-sunset-horizon-600` / dark: `dark:text-cinemata-sunset-horizon-200`
+- **Helper text** — light: `text-cinemata-sunset-horizon-600` / dark: `dark:text-cinemata-sunset-horizon-400p`
+- **Error text** — `text-cinemata-red-500` (same in both)
+- **Link / emphasis text** — `text-cinemata-strait-blue-600p` (same in both)
+- **Label text** — light: `text-cinemata-neutral-900` / dark: `dark:text-cinemata-strait-blue-50`
+- **Label (active / filled)** — light: `text-cinemata-pacific-deep-400` / dark: `dark:text-cinemata-pacific-deep-300`
+- **Label (disabled)** — `text-cinemata-pacific-deep-400` (same in both)
+
+<Heading>Backgrounds</Heading>
+
+- **Input / form field surface** — light: `bg-cinemata-neutral-50` / dark: `dark:bg-cinemata-pacific-deep-900`
+- **Input hover** — light: `bg-cinemata-pacific-deep-50` / dark: `dark:bg-cinemata-pacific-deep-800`
+- **Disabled input** — light: `bg-cinemata-pacific-deep-50` / dark: `dark:bg-cinemata-pacific-deep-900`
+- **Card / container** — light: `bg-cinemata-neutral-200` / dark: `dark:bg-cinemata-pacific-deep-800`
+- **Page / story wrapper** — light: `bg-cinemata-neutral-100` / dark: `dark:bg-cinemata-pacific-deep-950`
+- **Tooltip** — light: `bg-cinemata-white` / dark: `dark:bg-cinemata-pacific-deep-900`
+- **Dropzone** — light: `bg-cinemata-neutral-100` / dark: `dark:bg-cinemata-pacific-deep-800`
+- **Dialog overlay** — light: `bg-cinemata-black/40` / dark: `dark:bg-cinemata-pacific-deep-950 dark:opacity-80`
+- **Dialog content** — light: `bg-cinemata-white` / dark: `dark:bg-cinemata-pacific-deep-800`
+- **Primary button** — `bg-cinemata-strait-blue-600p`, hover: `bg-cinemata-strait-blue-800` (same in both)
+- **Secondary button** — `bg-cinemata-sunset-horizon-500`, hover: `bg-cinemata-sunset-horizon-700` (same in both)
+- **Special button** — light: `bg-cinemata-pacific-deep-600p` / dark: `dark:bg-cinemata-pacific-deep-950`
+- **Segment selected** — `bg-cinemata-sunset-horizon-500` (same in both)
+- **Segment default** — light: `bg-cinemata-neutral-200` / dark: `dark:bg-cinemata-pacific-deep-800`
+- **Tab bar** — light: `bg-cinemata-neutral-200` / dark: `dark:bg-cinemata-pacific-deep-800`
+- **Tab selected** — light: `bg-cinemata-strait-blue-200` / dark: `dark:bg-cinemata-strait-blue-800`
+- **Badge** — inline `backgroundColor` from the `color` prop (same in both)
+- **Dot separator** — light: `bg-cinemata-neutral-500` / dark: `dark:bg-cinemata-pacific-deep-400`
+- **Progress track** — light: `bg-cinemata-coral-reef-100` / dark: `dark:bg-cinemata-coral-reef-900`
+- **Progress indicator** — `bg-cinemata-coral-reef-400p` (same in both)
+- **Checkbox / radio unchecked** — light: `bg-cinemata-neutral-300` / dark: `dark:bg-cinemata-pacific-deep-900`
+- **Checkbox / radio checked** — `bg-cinemata-sunset-horizon-400p` (same in both)
+- **Avatar fallback** — light: `bg-cinemata-neutral-200` / dark: `dark:bg-cinemata-neutral-50`
+- **Avatar badge (comment)** — `bg-cinemata-strait-blue-900` (same in both)
+- **Avatar badge (favorite)** — `bg-cinemata-sunset-horizon-800` (same in both)
+- **Avatar badge (like)** — `bg-cinemata-red-950` (same in both)
+- **Search input** — light: `bg-cinemata-white` / dark: `dark:bg-cinemata-pacific-deep-800`
+- **Image placeholder** — light: `bg-cinemata-neutral-200` / dark: `dark:bg-cinemata-pacific-deep-800`
+
+<Heading>Borders</Heading>
+
+- **Default input border** — `border-cinemata-pacific-deep-500` (same in both)
+- **Active / focused border** — light: `border-cinemata-coral-reef-400p` / dark: `dark:border-cinemata-sunset-horizon-400p`
+- **Error border** — `border-cinemata-red-500` (same in both)
+- **Disabled border** — light: `border-cinemata-coral-reef-400p` / dark: `dark:border-cinemata-red-500`
+- **Tooltip border** — light: `border-cinemata-neutral-300` / dark: `dark:border-cinemata-pacific-deep-800`
+- **Search input border** — light: `border-cinemata-neutral-300` / dark: `dark:border-transparent`
+- **Outline button border** — `border-cinemata-strait-blue-600p` (same in both)
+- **Focus ring** — light: `ring-cinemata-strait-blue-600p` / dark: `dark:ring-cinemata-strait-blue-200`
+- **Avatar badge border** — light: `border-cinemata-white` / dark: `dark:border-cinemata-pacific-deep-900`
+- **Confirmation dialog border** — light: `border-cinemata-neutral-300` / dark: `dark:border-cinemata-strait-blue-300`
+
+<Heading>Decorative elements</Heading>
+
+- **Stepper line** — light: `bg-cinemata-neutral-300` / dark: `dark:bg-cinemata-pacific-deep-600p`
+- **Stepper dot** — light: `bg-cinemata-neutral-400` / dark: `dark:bg-cinemata-strait-blue-200`
+- **Stepper icon bg** — light: `bg-cinemata-neutral-200` / dark: `dark:bg-cinemata-pacific-deep-800`
+- **Stepper icon color** — light: `text-cinemata-strait-blue-600p` / dark: `dark:text-cinemata-strait-blue-200`
+- **Dropzone dashed border** — light: `stroke-cinemata-neutral-400` / dark: `dark:stroke-cinemata-strait-blue-300`
+- **Confirmation dialog gradient** — light: `from-cinemata-white to-cinemata-neutral-50` / dark: `dark:from-cinemata-pacific-deep-900 dark:to-cinemata-pacific-deep-950`
+
+<Heading>Which scale is for what</Heading>
+
+- **neutral** — Primary surfaces and text in light mode (50–200 for backgrounds, 500–900 for text)
+- **pacific-deep** — Primary surfaces and text in dark mode (800–950 for backgrounds, 50–300 for text)
+- **strait-blue** — Links, emphasis, primary buttons, focus rings, light text in dark mode (50 for text, 600p for actions)
+- **sunset-horizon** — Secondary actions, accents, alert text, active borders (400p–600 for light text, 200–400p for dark text)
+- **coral-reef** — Active/focused borders in light mode, progress bars
+- **red** — Errors and destructive actions
+- **green** — Success states
+- **amber** — Warnings
+- **white / black** — Absolute values for text on colored backgrounds, dialog overlays
+
+<Heading>Pattern summary</Heading>
+
+- All components now define **light mode as default** with `dark:` overrides for dark mode
+- Light mode uses `neutral` and `white` scales for surfaces, `neutral-900` for text
+- Dark mode uses `pacific-deep` scale for surfaces, `strait-blue-50` or `white` for text
+- Buttons keep the same brand colors in both themes — only text/icon variants adapt
+- Badge and avatar badge icons use dark-surface colors in both themes to keep icon/text visible against their colored backgrounds
+- `DialogContent` is unstyled — consumers pass background, padding, and sizing via `className`
+
+<Heading>Source files</Heading>
+
+- `src/static/css/config/_light_theme.scss` — All `--cinemata-*` values on `body` (light mode)
+- `src/static/css/config/_dark_theme.scss` — Overrides on `body.dark_theme` (dark mode)
+- `src/static/css/tailwind.css` — `@theme inline` bridge that makes `bg-cinemata-*` / `text-cinemata-*` utilities available


### PR DESCRIPTION
## Description

Add light mode support to shared components and create a color mapping documentation page for Storybook.

**Components updated (20):** Avatar, Button, CheckboxButton, ConfirmationDialogContent, Dialog, Dropdown, FollowButton, GetNotifiedButton, MediaDropzone, MovieItem, ProgressBar, RadioButton, SegmentButton, SquareImage, Stepper, Switch, TabView, TextAlert, Tooltip, SearchBar

**Key changes:**
- Components that appear on page surfaces (TextField, Dialog, Tooltip, Stepper, MediaDropzone, etc.) now define light mode as the default with `dark:` overrides for dark mode
- Components designed for dark surfaces only (Badge, SegmentButton, TabView, Button) keep a single set of dark-surface colors — no `dark:` variants
- `DialogContent` was refactored to be unstyled — consumers pass background, padding, and sizing via `className`
- `FollowButton` and `GetNotifiedButton` migrated from inline `style` attributes to Tailwind classes
- Storybook preview containers in all story files updated to use light/dark background pairs (`bg-cinemata-neutral-100 dark:bg-cinemata-pacific-deep-950`)
- Created `Colors.mdx` Storybook documentation page mapping each UI role (text, backgrounds, borders, decorative elements) to its light and dark mode `cinemata-*` token

## Related Issue

Fixes #551 

## Motivation and Context

The shared component library was originally built for dark mode only. This change introduces light mode defaults across page-surface components so the design system works correctly when toggling between themes in Storybook and in production. Components that always sit on dark surfaces (badges, tabs, segment buttons) intentionally keep their dark-surface colors in both themes to maintain icon and text visibility.

The `Colors.mdx` documentation gives contributors a single reference for which color token to use in each UI role across both themes.

## How Has This Been Tested?

- Verified all 20 updated components render correctly in Storybook in both light and dark mode using the Color Mode toolbar toggle
- Confirmed badge and avatar badge icons remain visible against their colored backgrounds in both themes
- Checked that `DialogContent` consumers (`Dialog.stories.jsx`, `ConfirmationDialogContent.stories.jsx`) render correctly after the unstyled refactor
- Reviewed `Colors.mdx` renders properly in Storybook's Introduction section

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):

- [x] I have not imported `flux` in a new component
- [x] If adding a new feature, I used Modern Track patterns
- [x] New features do not create new SCSS files (use Tailwind instead)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive light mode theme support across all UI components
  * Introduced design token-based color system documentation

* **Style**
  * Updated component styling to properly render in both light and dark modes
  * Applied new design tokens for improved visual consistency across the interface

* **Refactor**
  * Simplified component logic for follow and notification interactions

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EngageMedia-video/cinematacms/pull/667)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->