### PR TITLE
feat: add user role badges to media page and comments

### DIFF
--- a/files/models.py
+++ b/files/models.py
@@ -1055,6 +1055,14 @@ class Media(models.Model):
         # Use .name to get relative path from MEDIA_ROOT
         return helpers.url_from_path(self.user.logo.name)
 
+    @property
+    def author_is_trusted(self):
+        return self.user.advancedUser
+
+    @property
+    def author_is_manager(self):
+        return self.user.is_superuser or self.user.is_manager
+
     def get_absolute_url(self, api=False, edit=False):
         if edit:
             return reverse("edit_media") + f"?m={self.friendly_token}"

--- a/files/serializers.py
+++ b/files/serializers.py
@@ -88,6 +88,8 @@ class MediaSerializer(serializers.ModelSerializer):
             "author_name",
             "author_profile",
             "author_thumbnail",
+            "author_is_trusted",
+            "author_is_manager",
             "encoding_status",
             "views",
             "likes",
@@ -256,6 +258,8 @@ class SingleMediaSerializer(serializers.ModelSerializer):
             "author_name",
             "author_profile",
             "author_thumbnail",
+            "author_is_trusted",
+            "author_is_manager",
             "encodings_info",
             "encoding_status",
             "views",
@@ -400,6 +404,11 @@ class CommentSerializer(serializers.ModelSerializer):
     author_profile = serializers.ReadOnlyField(source="user.get_absolute_url")
     author_name = serializers.ReadOnlyField(source="user.name")
     author_thumbnail_url = serializers.ReadOnlyField(source="user.thumbnail_url")
+    author_is_trusted = serializers.ReadOnlyField(source="user.advancedUser")
+    author_is_manager = serializers.SerializerMethodField()
+
+    def get_author_is_manager(self, obj):
+        return obj.user.is_superuser or obj.user.is_manager
 
     class Meta:
         model = Comment
@@ -411,6 +420,8 @@ class CommentSerializer(serializers.ModelSerializer):
             "author_thumbnail_url",
             "author_profile",
             "author_name",
+            "author_is_trusted",
+            "author_is_manager",
             "media_url",
             "uid",
         )

--- a/frontend/src/features/shared/components/UserRoleBadge/UserRoleBadge.jsx
+++ b/frontend/src/features/shared/components/UserRoleBadge/UserRoleBadge.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import './UserRoleBadge.scss';
+
+// "manager" role is displayed as "Moderator" to end users per issue #546
+function getRoleBadge(isManager, isTrusted) {
+	if (isManager) return { label: 'Moderator', className: 'moderator' };
+	if (isTrusted) return { label: 'Trusted', className: 'trusted' };
+	return null;
+}
+
+export function UserRoleBadge({ isManager, isTrusted }) {
+	const badge = getRoleBadge(isManager, isTrusted);
+	if (!badge) return null;
+	return (
+		<span className={`user-role-badge user-role-badge--${badge.className}`} aria-label={`Role: ${badge.label}`}>
+			{badge.label}
+		</span>
+	);
+}
+
+UserRoleBadge.propTypes = {
+	isManager: PropTypes.bool,
+	isTrusted: PropTypes.bool,
+};

--- a/frontend/src/features/shared/components/UserRoleBadge/UserRoleBadge.scss
+++ b/frontend/src/features/shared/components/UserRoleBadge/UserRoleBadge.scss
@@ -1,0 +1,23 @@
+.user-role-badge {
+	display: inline-block;
+	padding: 1px 6px;
+	margin-left: 6px;
+	font-size: 11px;
+	font-weight: 600;
+	line-height: 16px;
+	letter-spacing: 0.03em;
+	border-radius: 3px;
+	vertical-align: middle;
+	white-space: nowrap;
+	text-transform: uppercase;
+
+	&--trusted {
+		color: var(--badge-trusted-text-color, #fff);
+		background-color: var(--badge-trusted-bg-color, #4caf50);
+	}
+
+	&--moderator {
+		color: var(--badge-moderator-text-color, #fff);
+		background-color: var(--badge-moderator-bg-color, #ed7c30);
+	}
+}

--- a/frontend/src/features/shared/components/UserRoleBadge/index.js
+++ b/frontend/src/features/shared/components/UserRoleBadge/index.js
@@ -1,0 +1,1 @@
+export { UserRoleBadge } from './UserRoleBadge';

--- a/frontend/src/features/shared/components/index.js
+++ b/frontend/src/features/shared/components/index.js
@@ -24,3 +24,4 @@ export { TextAlert } from './TextAlert';
 export { TabView, TabContent } from './TabView';
 export { Tooltip } from './Tooltip';
 export { Text } from './Text';
+export { UserRoleBadge } from './UserRoleBadge';

--- a/frontend/src/static/css/config/_dark_theme.scss
+++ b/frontend/src/static/css/config/_dark_theme.scss
@@ -493,4 +493,10 @@ body.dark_theme {
 	--cinemata-amber-800: #92400e;
 	--cinemata-amber-900: #78350f;
 	--cinemata-amber-950: #451a03;
+
+	/* ── Role Badge Colors ────────────────────────────── */
+	--badge-trusted-bg-color: #66bb6a;
+	--badge-trusted-text-color: #000;
+	--badge-moderator-bg-color: #ffa726;
+	--badge-moderator-text-color: #000;
 }

--- a/frontend/src/static/css/config/_light_theme.scss
+++ b/frontend/src/static/css/config/_light_theme.scss
@@ -492,4 +492,10 @@ body {
 	--cinemata-amber-800: #92400e;
 	--cinemata-amber-900: #78350f;
 	--cinemata-amber-950: #451a03;
+
+	/* ── Role Badge Colors ────────────────────────────── */
+	--badge-trusted-bg-color: #4caf50;
+	--badge-trusted-text-color: #fff;
+	--badge-moderator-bg-color: #ed7c30;
+	--badge-moderator-text-color: #fff;
 }

--- a/frontend/src/static/js/components/-NEW-/Comments.js
+++ b/frontend/src/static/js/components/-NEW-/Comments.js
@@ -26,6 +26,7 @@ import { MaterialIcon } from './MaterialIcon';
 import { UserThumbnail } from './UserThumbnail';
 
 import { PopupMain } from './Popup';
+import { UserRoleBadge } from '../../../../features/shared/components/UserRoleBadge';
 
 import '../styles/Comments.scss';
 import { replaceString } from '../../utils/string-replacement.js';
@@ -283,6 +284,7 @@ function Comment(props) {
 							<a href={props.author_link} title={props.author_name}>
 								{props.author_name}
 							</a>
+							<UserRoleBadge isManager={props.author_is_manager} isTrusted={props.author_is_trusted} />
 						</div>
 						<div className="comment-date">
 							{props.publish_date != null ? replaceString(format(new Date(props.publish_date))) : ''}
@@ -314,6 +316,8 @@ Comment.propTypes = {
 	author_name: PropTypes.string,
 	author_link: PropTypes.string,
 	author_thumb: PropTypes.string,
+	author_is_trusted: PropTypes.bool,
+	author_is_manager: PropTypes.bool,
 	publish_date: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 	likes: PropTypes.number,
 	dislikes: PropTypes.number,
@@ -531,6 +535,8 @@ export default function CommentsList(props) {
 										'/' +
 										c.author_thumbnail_url.replace(/^\//g, '')
 									}
+									author_is_trusted={c.author_is_trusted}
+									author_is_manager={c.author_is_manager}
 									publish_date={c.add_date}
 									likes={0}
 									dislikes={0}

--- a/frontend/src/static/js/components/-NEW-/UserItem.js
+++ b/frontend/src/static/js/components/-NEW-/UserItem.js
@@ -125,7 +125,7 @@ export function UserItem(props) {
 				)}
 				{isManager && (
 					<div className="badge orange-badge" style={{ top: `${1 + orangeBadgeIndex++ * 1.7}rem` }}>
-						Manager
+						Moderator
 					</div>
 				)}
 			</React.Fragment>

--- a/frontend/src/static/js/pages/MediaPage/includes/ViewerInfo.js
+++ b/frontend/src/static/js/pages/MediaPage/includes/ViewerInfo.js
@@ -46,6 +46,8 @@ export default class ViewerInfo extends React.PureComponent {
 				name: MediaPageStore.get('media-data').author_name,
 				url: MediaPageStore.get('media-data').author_profile,
 				thumb: MediaPageStore.get('media-author-thumbnail-url'),
+				isTrusted: MediaPageStore.get('media-data').author_is_trusted,
+				isManager: MediaPageStore.get('media-data').author_is_manager,
 			};
 
 			published = MediaPageStore.get('media-data').add_date;

--- a/frontend/src/static/js/pages/MediaPage/includes/ViewerInfoContent.js
+++ b/frontend/src/static/js/pages/MediaPage/includes/ViewerInfoContent.js
@@ -19,6 +19,8 @@ import { RatingSystem } from '../../../components/RatingSystem/RatingSystem';
 
 import { PopupMain } from '../../../components/-NEW-/Popup';
 
+import { UserRoleBadge } from '../../../../../features/shared/components/UserRoleBadge';
+
 import { publishedOnDate } from '../../../functions/';
 
 import { formatInnerLink } from '../../../functions/formatInnerLink';
@@ -66,6 +68,7 @@ function MediaAuthorBanner(props) {
 					<a href={props.link} className="author-banner-name" title={props.name}>
 						<span>{props.name}</span>
 					</a>
+					<UserRoleBadge isManager={props.isManager} isTrusted={props.isTrusted} />
 				</span>
 			</div>
 		</div>
@@ -263,6 +266,8 @@ export default function ViewerInfoContent(props) {
 									thumb={authorThumb}
 									name={props.author.name}
 									published={props.published}
+									isManager={props.author.isManager}
+									isTrusted={props.author.isTrusted}
 								/>
 							);
 						}

--- a/frontend/src/static/js/pages/MediaPage/includes/ViewerInfoVideo.js
+++ b/frontend/src/static/js/pages/MediaPage/includes/ViewerInfoVideo.js
@@ -30,6 +30,8 @@ export default class ViewerInfoVideo extends ViewerInfo {
 				name: MediaPageStore.get('media-data').author_name,
 				url: MediaPageStore.get('media-data').author_profile,
 				thumb: MediaPageStore.get('media-author-thumbnail-url'),
+				isTrusted: MediaPageStore.get('media-data').author_is_trusted,
+				isManager: MediaPageStore.get('media-data').author_is_manager,
 			};
 
 			published = MediaPageStore.get('media-data').add_date;


### PR DESCRIPTION
## Description
Add a reusable `UserRoleBadge` component that displays user roles (TRUSTED, MODERATOR) as colored badges next to author names. Expose author role booleans in media and comment API serializers so the frontend can render badges in the media page author banner and comment threads.

## Related Issue
Fixes #546

## Motivation and Context
Users have roles (Trusted User, Manager) stored on the User model, but these are not exposed in media or comment API responses. The frontend has no way to indicate who is a trusted community member or moderator. This change bridges that gap by adding role fields to the API and rendering them visually.

## How Has This Been Tested?
- Frontend webpack build compiles successfully with no errors
- Verified serializer field declarations follow the existing `ReadOnlyField(source="user.*")` pattern used by `author_name` and `author_thumbnail_url`
- Verified model properties follow the existing `author_name` `@property` pattern
- Tested locally: TRUSTED (green) badge renders on media page for trusted users, MODERATOR (orange) badge renders for managers
- No migrations needed — all changes are computed properties and serializer fields

## Screenshots (if appropriate):
<img width="1200" height="946" alt="screenshot-trusted-badge" src="https://github.com/user-attachments/assets/980db322-02ac-4daf-8b20-3e32cd7083f4" />
<img width="1200" height="946" alt="screenshot-moderator-badge" src="https://github.com/user-attachments/assets/b9dc059b-4132-41a5-b1b2-55e9a68b823c" />
<img width="1200" height="946" alt="screenshot-comments-badges" src="https://github.com/user-attachments/assets/a1d0cadd-f4b2-4d04-b8cf-f2e1b2f1be39" />



## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added role badges to display author credentials (Moderator and Trusted status) throughout the app, including comments and media pages for improved user credibility visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EngageMedia-video/cinematacms/pull/676?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->