### PR TITLE
fix(topbar): top message no longer overlaps topbar on desktop

### DIFF
--- a/frontend/src/features/layout/topbar/Topbar.jsx
+++ b/frontend/src/features/layout/topbar/Topbar.jsx
@@ -30,7 +30,7 @@ export function Topbar() {
 			<header
 				data-modern-track
 				data-topbar
-				className="fixed top-0 left-0 right-0 z-[60] w-full border-b-2 border-white/10 bg-cinemata-pacific-deep-900 text-cinemata-white"
+				className="fixed inset-x-0 z-[60] w-full border-b-2 border-white/10 bg-cinemata-pacific-deep-900 text-cinemata-white"
 			>
 				<div className="flex items-center gap-3 px-4 h-[60px] sm:h-[90px]">
 					<TopbarSidebarToggle />

--- a/frontend/src/static/css/tailwind.css
+++ b/frontend/src/static/css/tailwind.css
@@ -557,6 +557,16 @@
 	}
 }
 
+/* `top` is set here rather than via Tailwind's `top-0` utility because
+ * Tailwind's utilities layer is imported with `!important` above. In a
+ * cascade with `!important`, layer ordering reverses and the layered
+ * `.top-0 { top: 0 !important }` would beat any unlayered `!important`
+ * offset rule. Setting top in plain unlayered CSS without `!important`
+ * lets the .top-message-body offset rule win normally on specificity. */
+header[data-topbar] {
+	top: 0;
+}
+
 .top-message-body header[data-topbar] {
 	top: var(--top-message-height, 43px);
 }


### PR DESCRIPTION
## Description

Follow-up to #669. After the new topbar shipped, an active top message
banner (e.g. "Hello Milestone 2 Team!") visually overlaps the first row
of the topbar at every breakpoint: the banner sits at `top: 0` with
`z-index: 1000`, the topbar also sits at `top: 0` with `z-index: 60`,
and there's no rule pushing the topbar down.

The topbar's intended offset rule was already in place
(`.top-message-body header[data-topbar] { top: var(--top-message-height) }`),
but it was losing the cascade against the topbar's own `top-0` Tailwind
utility. Both end up as `!important` because `tailwindcss/utilities.css`
is imported with the `important` keyword in `tailwind.css`, and
CSS `@layer` cascade **reverses layer order when `!important` is
present** — so the layered `.top-0` rule in `@layer utilities` beats
any unlayered `!important` rule regardless of specificity.

## Motivation

Reported on the post-merge build of #669. Topbar shows the banner clipping the top of the topbar's logo, search field, and upload button on desktop.

## Fix

<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/fde393a2-47fc-408a-b154-705df144fcc8" />

Two-line change:

1. Drop `top-0` from the topbar's `className` in `Topbar.jsx` (replaced by
   `inset-x-0` to keep the horizontal pinning) — removes the conflicting
   layered `!important` rule.
2. Set `top` via plain unlayered CSS in `tailwind.css`. Two rules cover
   the default and offset cases, neither needs `!important`:

   ```css
   header[data-topbar]                     { top: 0; }
   .top-message-body header[data-topbar]   { top: var(--top-message-height, 43px); }
   ```

   Standard specificity cascade applies — the second rule (specificity
   0,2,1) wins over the first (0,1,1) when `body.top-message-body` is
   present.

## Testing

Verified in a real browser via Playwright after `make quick-build`:

- **Desktop (1280×800):**
  `top-message.bottom = 44px`, `header.top = 44px` → no overlap.
- **Mobile (390×844):**
  Same — `header.top = 44px` immediately below the banner. The mobile
  second row (back button / page title / compact upload) stays inside
  the topbar, not pushed under content.

Reproduction steps for reviewers:

```js
// In DevTools console on a page using AppLayout / LegacyTopbarMount:
localStorage.setItem('MediaCMS["top-message-text"]', 'Test banner');
localStorage.setItem('MediaCMS["top-message-has-been-displayed"]', 'false');
location.reload();
```

The orange banner should sit at the very top with the topbar (logo +
search + buttons) flush below it, not under it.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Code style matches existing patterns
- [x] No new tests required — visual regression covered by Playwright run on the build output
- [x] Lint, build, and existing unit tests pass locally (306/306)

## Modern Track Checklist

- [x] No `flux` imports added
- [x] No new SCSS files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Optimized topbar header positioning and styling for improved layout consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EngageMedia-video/cinematacms/pull/682?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->