### PR TITLE
fix: topbar mobile row2 search

### DIFF
--- a/frontend/src/features/global-search/GlobalSearchMobileOverlay.jsx
+++ b/frontend/src/features/global-search/GlobalSearchMobileOverlay.jsx
@@ -60,7 +60,7 @@ function GlobalSearchMobileOverlayInner({ isOpen, onClose }) {
 			role="dialog"
 			aria-modal="true"
 			aria-label="Search"
-			className="fixed inset-0 z-[100] flex flex-col bg-cinemata-pacific-deep-950"
+			className="fixed inset-0 z-[1100] flex flex-col bg-cinemata-pacific-deep-950"
 		>
 			<div className="flex items-center gap-2 border-b border-cinemata-pacific-deep-700/60 bg-cinemata-pacific-deep-900 px-3 py-3">
 				<button

--- a/frontend/src/features/layout/topbar/Topbar.jsx
+++ b/frontend/src/features/layout/topbar/Topbar.jsx
@@ -14,14 +14,17 @@ import { TopbarUploadButton } from './TopbarUploadButton';
 import { TopbarUserMenu } from './TopbarUserMenu';
 import useTopbarStore from './useTopbarStore';
 import { useIsHomeRoute } from './useIsHomeRoute';
+import { useSidebarVisible } from './useSidebarVisible';
 
 export function Topbar() {
 	const openMobileSearch = useTopbarStore((state) => state.openMobileSearch);
 	const user = useContext(UserContext);
 	const isHome = useIsHomeRoute();
-	// Anonymous home gets a full-width search bar in row 2 instead, so the
-	// top-row icon is redundant in that case. Every other case keeps it.
-	const showMobileSearchIcon = !(user?.is?.anonymous && isHome);
+	const sidebarVisible = useSidebarVisible();
+	// Anonymous users get a full-width search bar in row 2 whenever row 2 has
+	// no UPLOAD action to show (home, or sidebar drawer open). In those cases
+	// the top-row search icon would be redundant.
+	const showMobileSearchIcon = !(user?.is?.anonymous && (isHome || sidebarVisible));
 
 	// Marker for the mobile --header-height override in tailwind.css so it
 	// only applies on pages that actually mount this topbar.

--- a/frontend/src/features/layout/topbar/Topbar.jsx
+++ b/frontend/src/features/layout/topbar/Topbar.jsx
@@ -1,7 +1,8 @@
-import React, { useEffect } from 'react';
+import React, { useContext, useEffect } from 'react';
 
 import '../../../static/css/tailwind.css';
 
+import UserContext from '../../../static/js/contexts/UserContext';
 import { Icon } from '../../shared/components/Icon';
 import { TopbarLogo } from './TopbarLogo';
 import { TopbarMobileBar } from './TopbarMobileBar';
@@ -12,9 +13,15 @@ import { TopbarSidebarToggle } from './TopbarSidebarToggle';
 import { TopbarUploadButton } from './TopbarUploadButton';
 import { TopbarUserMenu } from './TopbarUserMenu';
 import useTopbarStore from './useTopbarStore';
+import { useIsHomeRoute } from './useIsHomeRoute';
 
 export function Topbar() {
 	const openMobileSearch = useTopbarStore((state) => state.openMobileSearch);
+	const user = useContext(UserContext);
+	const isHome = useIsHomeRoute();
+	// Anonymous home gets a full-width search bar in row 2 instead, so the
+	// top-row icon is redundant in that case. Every other case keeps it.
+	const showMobileSearchIcon = !(user?.is?.anonymous && isHome);
 
 	// Marker for the mobile --header-height override in tailwind.css so it
 	// only applies on pages that actually mount this topbar.
@@ -36,14 +43,18 @@ export function Topbar() {
 					<TopbarSidebarToggle />
 					<TopbarLogo />
 					<TopbarSearchDesktop />
-					<button
-						type="button"
-						onClick={openMobileSearch}
-						aria-label="Open search"
-						className="sm:hidden inline-flex items-center justify-center w-10 h-10 rounded-full bg-cinemata-pacific-deep-800 text-cinemata-white hover:bg-cinemata-pacific-deep-700 transition-colors shrink-0 ml-auto"
-					>
-						<Icon name="magnifyingGlass" size={20} decorative />
-					</button>
+					{showMobileSearchIcon ? (
+						<button
+							type="button"
+							onClick={openMobileSearch}
+							aria-label="Open search"
+							className="sm:hidden inline-flex items-center justify-center w-10 h-10 rounded-full bg-cinemata-pacific-deep-800 text-cinemata-white hover:bg-cinemata-pacific-deep-700 transition-colors shrink-0 ml-auto"
+						>
+							<Icon name="magnifyingGlass" size={20} decorative />
+						</button>
+					) : (
+						<span aria-hidden="true" className="sm:hidden ml-auto" />
+					)}
 					<div className="hidden sm:inline-flex shrink-0">
 						<TopbarUploadButton />
 					</div>

--- a/frontend/src/features/layout/topbar/Topbar.jsx
+++ b/frontend/src/features/layout/topbar/Topbar.jsx
@@ -4,6 +4,7 @@ import '../../../static/css/tailwind.css';
 
 import UserContext from '../../../static/js/contexts/UserContext';
 import { Icon } from '../../shared/components/Icon';
+import { TopbarIconButton } from './TopbarIconButton';
 import { TopbarLogo } from './TopbarLogo';
 import { TopbarMobileBar } from './TopbarMobileBar';
 import { TopbarNotificationButton } from './TopbarNotificationButton';
@@ -47,14 +48,13 @@ export function Topbar() {
 					<TopbarLogo />
 					<TopbarSearchDesktop />
 					{showMobileSearchIcon ? (
-						<button
-							type="button"
+						<TopbarIconButton
 							onClick={openMobileSearch}
 							aria-label="Open search"
-							className="sm:hidden inline-flex items-center justify-center w-10 h-10 rounded-full bg-cinemata-pacific-deep-800 text-cinemata-white hover:bg-cinemata-pacific-deep-700 transition-colors shrink-0 ml-auto"
+							className="sm:hidden ml-auto"
 						>
 							<Icon name="magnifyingGlass" size={20} decorative />
-						</button>
+						</TopbarIconButton>
 					) : (
 						<span aria-hidden="true" className="sm:hidden ml-auto" />
 					)}

--- a/frontend/src/features/layout/topbar/TopbarIconButton.jsx
+++ b/frontend/src/features/layout/topbar/TopbarIconButton.jsx
@@ -4,7 +4,7 @@ import { cn } from '../../shared/utils/classNames';
 
 export const TopbarIconButton = forwardRef(function TopbarIconButton(
 	{ className, children, type = 'button', ...rest },
-	ref,
+	ref
 ) {
 	return (
 		<button
@@ -12,7 +12,7 @@ export const TopbarIconButton = forwardRef(function TopbarIconButton(
 			type={type}
 			className={cn(
 				'inline-flex items-center justify-center w-10 h-10 rounded-full bg-cinemata-pacific-deep-800 hover:bg-cinemata-pacific-deep-700 transition-colors shrink-0 text-cinemata-white',
-				className,
+				className
 			)}
 			{...rest}
 		>

--- a/frontend/src/features/layout/topbar/TopbarIconButton.jsx
+++ b/frontend/src/features/layout/topbar/TopbarIconButton.jsx
@@ -1,0 +1,22 @@
+import React, { forwardRef } from 'react';
+
+import { cn } from '../../shared/utils/classNames';
+
+export const TopbarIconButton = forwardRef(function TopbarIconButton(
+	{ className, children, type = 'button', ...rest },
+	ref,
+) {
+	return (
+		<button
+			ref={ref}
+			type={type}
+			className={cn(
+				'inline-flex items-center justify-center w-10 h-10 rounded-full bg-cinemata-pacific-deep-800 hover:bg-cinemata-pacific-deep-700 transition-colors shrink-0 text-cinemata-white',
+				className,
+			)}
+			{...rest}
+		>
+			{children}
+		</button>
+	);
+});

--- a/frontend/src/features/layout/topbar/TopbarMobileBar.jsx
+++ b/frontend/src/features/layout/topbar/TopbarMobileBar.jsx
@@ -50,9 +50,14 @@ function derivePageTitle() {
 	for (const [pattern, label] of ROUTE_TITLES) {
 		if (pattern.test(path)) return label;
 	}
+	// document.title may start with a separator (e.g. "| Sign In" on django-allauth
+	// pages), so filter empty segments before picking the first label.
 	const raw = (typeof document !== 'undefined' && document.title) || '';
-	const first = raw.split(/[-|–—]/)[0].trim();
-	return first || 'Home';
+	const segments = raw
+		.split(/[-|–—]/)
+		.map((segment) => segment.trim())
+		.filter(Boolean);
+	return segments[0] || 'Home';
 }
 
 export function TopbarMobileBar() {
@@ -85,37 +90,30 @@ export function TopbarMobileBar() {
 		else window.location.assign('/');
 	}
 
-	// Sidebar drawer open → row 2 collapses to a single full-width UPLOAD action.
-	if (sidebarVisible) {
-		return (
-			<div className="flex sm:hidden items-center px-4 h-16 bg-cinemata-pacific-deep-900">
-				<TopbarUploadButton className="flex w-full" />
-			</div>
-		);
-	}
+	const isAnonymous = Boolean(user?.is?.anonymous);
 
-	// Home + anonymous → full-width search-bar affordance that opens the
-	// fullscreen overlay on tap (replaces the redundant top-row search icon).
-	if (home && user?.is?.anonymous) {
-		return (
-			<div className="flex sm:hidden items-center px-4 h-16 bg-cinemata-pacific-deep-900">
-				<button
-					type="button"
-					onClick={openMobileSearch}
-					aria-label="Open search"
-					className="flex w-full items-center gap-2 h-10 px-3 rounded-full bg-cinemata-pacific-deep-800 hover:bg-cinemata-pacific-deep-700 transition-colors text-left text-cinemata-strait-blue-100"
-				>
-					<Icon name="magnifyingGlass" size={18} decorative />
-					<Text as="span" variant="body-14" className="m-0 truncate text-cinemata-strait-blue-100">
-						Search for Films, Members, Events, etc
-					</Text>
-				</button>
-			</div>
-		);
-	}
-
-	// Home + logged-in → just the UPLOAD action (or nothing if the user can't upload).
-	if (home) {
+	// Sidebar drawer open OR home → row 2 collapses to a single full-width
+	// primary action. Anonymous users see a search-bar affordance (search is
+	// their only useful action surface, so the row never goes blank); logged-in
+	// users see the UPLOAD MEDIA action they care about.
+	if (sidebarVisible || home) {
+		if (isAnonymous) {
+			return (
+				<div className="flex sm:hidden items-center px-4 h-16 bg-cinemata-pacific-deep-900">
+					<button
+						type="button"
+						onClick={openMobileSearch}
+						aria-label="Open search"
+						className="flex w-full items-center gap-2 h-10 px-3 rounded-full bg-cinemata-pacific-deep-800 hover:bg-cinemata-pacific-deep-700 transition-colors text-left text-cinemata-strait-blue-100"
+					>
+						<Icon name="magnifyingGlass" size={18} decorative />
+						<Text as="span" variant="body-14" className="m-0 truncate text-cinemata-strait-blue-100">
+							Search for Films, Members, Events, etc
+						</Text>
+					</button>
+				</div>
+			);
+		}
 		return (
 			<div className="flex sm:hidden items-center px-4 h-16 bg-cinemata-pacific-deep-900">
 				<TopbarUploadButton className="flex w-full" />

--- a/frontend/src/features/layout/topbar/TopbarMobileBar.jsx
+++ b/frontend/src/features/layout/topbar/TopbarMobileBar.jsx
@@ -1,14 +1,12 @@
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 
+import UserContext from '../../../static/js/contexts/UserContext';
 import { Icon } from '../../shared/components/Icon';
 import { Text } from '../../shared/components/Text';
 import { TopbarUploadButton } from './TopbarUploadButton';
+import { useIsHomeRoute } from './useIsHomeRoute';
 import { useSidebarVisible } from './useSidebarVisible';
-
-function isHome() {
-	if (typeof window === 'undefined') return false;
-	return window.location.pathname === '/' || window.location.pathname === '';
-}
+import useTopbarStore from './useTopbarStore';
 
 // Pathname → title map (first match wins). Profile sub-routes use the section name, not the username.
 const ROUTE_TITLES = [
@@ -59,13 +57,14 @@ function derivePageTitle() {
 
 export function TopbarMobileBar() {
 	const [title, setTitle] = useState(derivePageTitle);
-	const [home, setHome] = useState(isHome);
 	const sidebarVisible = useSidebarVisible();
+	const home = useIsHomeRoute();
+	const user = useContext(UserContext);
+	const openMobileSearch = useTopbarStore((state) => state.openMobileSearch);
 
 	useEffect(() => {
 		function sync() {
 			setTitle(derivePageTitle());
-			setHome(isHome());
 		}
 		const observer = new MutationObserver(sync);
 		const titleEl = document.querySelector('title');
@@ -86,6 +85,7 @@ export function TopbarMobileBar() {
 		else window.location.assign('/');
 	}
 
+	// Sidebar drawer open → row 2 collapses to a single full-width UPLOAD action.
 	if (sidebarVisible) {
 		return (
 			<div className="flex sm:hidden items-center px-4 h-16 bg-cinemata-pacific-deep-900">
@@ -94,20 +94,46 @@ export function TopbarMobileBar() {
 		);
 	}
 
-	return (
-		<div className="flex sm:hidden items-center justify-between gap-3 px-4 h-16 bg-cinemata-pacific-deep-900">
-			{home ? (
-				<span aria-hidden="true" className="w-8 h-8 shrink-0" />
-			) : (
+	// Home + anonymous → full-width search-bar affordance that opens the
+	// fullscreen overlay on tap (replaces the redundant top-row search icon).
+	if (home && user?.is?.anonymous) {
+		return (
+			<div className="flex sm:hidden items-center px-4 h-16 bg-cinemata-pacific-deep-900">
 				<button
 					type="button"
-					onClick={onBack}
-					aria-label="Go back"
-					className="inline-flex items-center justify-center w-8 h-8 rounded-full bg-cinemata-pacific-deep-800 hover:bg-cinemata-pacific-deep-700 transition-colors shrink-0 text-cinemata-strait-blue-100"
+					onClick={openMobileSearch}
+					aria-label="Open search"
+					className="flex w-full items-center gap-2 h-10 px-3 rounded-full bg-cinemata-pacific-deep-800 hover:bg-cinemata-pacific-deep-700 transition-colors text-left text-cinemata-strait-blue-100"
 				>
-					<Icon name="chevronLeft" size={18} decorative />
+					<Icon name="magnifyingGlass" size={18} decorative />
+					<Text as="span" variant="body-14" className="m-0 truncate text-cinemata-strait-blue-100">
+						Search for Films, Members, Events, etc
+					</Text>
 				</button>
-			)}
+			</div>
+		);
+	}
+
+	// Home + logged-in → just the UPLOAD action (or nothing if the user can't upload).
+	if (home) {
+		return (
+			<div className="flex sm:hidden items-center px-4 h-16 bg-cinemata-pacific-deep-900">
+				<TopbarUploadButton className="flex w-full" />
+			</div>
+		);
+	}
+
+	// Non-home → back + page title + (UPLOAD if user can upload).
+	return (
+		<div className="flex sm:hidden items-center justify-between gap-3 px-4 h-16 bg-cinemata-pacific-deep-900">
+			<button
+				type="button"
+				onClick={onBack}
+				aria-label="Go back"
+				className="inline-flex items-center justify-center w-8 h-8 rounded-full bg-cinemata-pacific-deep-800 hover:bg-cinemata-pacific-deep-700 transition-colors shrink-0 text-cinemata-strait-blue-100"
+			>
+				<Icon name="chevronLeft" size={18} decorative />
+			</button>
 			<Text as="h1" variant="body-16-bold" className="m-0 flex-1 truncate text-cinemata-strait-blue-50">
 				{title}
 			</Text>

--- a/frontend/src/features/layout/topbar/TopbarNotificationButton.jsx
+++ b/frontend/src/features/layout/topbar/TopbarNotificationButton.jsx
@@ -7,6 +7,7 @@ import { useUnreadCount } from '../../notifications/hooks/useUnreadCount';
 import { NotificationDropdown } from '../../notifications/components/NotificationDropdown';
 import useNotificationStore from '../../notifications/useNotificationStore';
 import notificationQueryClient from '../../notifications/queryClient';
+import { TopbarIconButton } from './TopbarIconButton';
 
 function BellButton() {
 	const { data } = useUnreadCount();
@@ -15,13 +16,12 @@ function BellButton() {
 
 	return (
 		<div className="relative inline-flex items-center">
-			<button
-				type="button"
+			<TopbarIconButton
 				onClick={toggleDropdown}
 				aria-label={`Notifications${count > 0 ? `, ${count} unread` : ''}`}
 				aria-haspopup="true"
 				aria-expanded={isDropdownOpen}
-				className="relative inline-flex items-center justify-center w-10 h-10 rounded-full bg-cinemata-pacific-deep-800 hover:bg-cinemata-pacific-deep-700 transition-colors shrink-0 text-cinemata-strait-blue-50"
+				className="relative text-cinemata-strait-blue-50"
 			>
 				<Icon name="notificationBell" size={20} decorative />
 				{count > 0 ? (
@@ -30,7 +30,7 @@ function BellButton() {
 						className="absolute top-1.5 right-1.5 w-2.5 h-2.5 bg-red-500 rounded-full pointer-events-none ring-2 ring-cinemata-pacific-deep-900"
 					/>
 				) : null}
-			</button>
+			</TopbarIconButton>
 			{isDropdownOpen ? <NotificationDropdown /> : null}
 		</div>
 	);

--- a/frontend/src/features/layout/topbar/TopbarNotificationButton.jsx
+++ b/frontend/src/features/layout/topbar/TopbarNotificationButton.jsx
@@ -21,13 +21,13 @@ function BellButton() {
 				aria-label={`Notifications${count > 0 ? `, ${count} unread` : ''}`}
 				aria-haspopup="true"
 				aria-expanded={isDropdownOpen}
-				className="relative inline-flex items-center justify-center w-8 h-8 rounded-full bg-cinemata-pacific-deep-800 hover:bg-cinemata-pacific-deep-700 transition-colors shrink-0 text-cinemata-strait-blue-50"
+				className="relative inline-flex items-center justify-center w-10 h-10 rounded-full bg-cinemata-pacific-deep-800 hover:bg-cinemata-pacific-deep-700 transition-colors shrink-0 text-cinemata-strait-blue-50"
 			>
-				<Icon name="notificationBell" size={24} decorative />
+				<Icon name="notificationBell" size={20} decorative />
 				{count > 0 ? (
 					<span
 						aria-hidden="true"
-						className="absolute -top-0.5 -right-0.5 w-2.5 h-2.5 bg-red-500 rounded-full pointer-events-none ring-2 ring-cinemata-pacific-deep-900"
+						className="absolute top-1.5 right-1.5 w-2.5 h-2.5 bg-red-500 rounded-full pointer-events-none ring-2 ring-cinemata-pacific-deep-900"
 					/>
 				) : null}
 			</button>

--- a/frontend/src/features/layout/topbar/useIsHomeRoute.js
+++ b/frontend/src/features/layout/topbar/useIsHomeRoute.js
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+
+function isHomePath() {
+	if (typeof window === 'undefined') return false;
+	const path = window.location.pathname;
+	return path === '/' || path === '';
+}
+
+export function useIsHomeRoute() {
+	const [home, setHome] = useState(isHomePath);
+
+	useEffect(() => {
+		function sync() {
+			setHome(isHomePath());
+		}
+		window.addEventListener('popstate', sync);
+		return () => window.removeEventListener('popstate', sync);
+	}, []);
+
+	return home;
+}


### PR DESCRIPTION
## Description

Post-merge follow-ups on the mobile topbar after #669 shipped. Five
small visual / UX bugs reported during QA:

1. **Anonymous + home (mobile) felt empty.** Row 2 only showed the
   page-title label "Home" with no actionable element, because
   anonymous users don't have an UPLOAD button.
2. **Logged-in + home (mobile) showed a redundant "Home" label**
   next to the UPLOAD button.
3. **Bell icon visibly smaller than the search icon.** Bell was a
   `32x32` button with a `24px` glyph (which overflowed it) next to a
   `40x40` search button with a `20px` glyph in the same row.
4. **Fullscreen mobile search overlay was clipped by the top message
   banner.** Search input row sat under the orange "Hello Milestone…"
   strip because the dialog was at `z-index: 100` while the banner is
   `z-index: 1000`.
5. **Anonymous + sidebar drawer open → row 2 was completely empty.**
   The sidebar-open branch always rendered UPLOAD, which is null for
   anonymous users.
6. **`/accounts/login/` and `/accounts/logout/` showed "Home"** as the
   mobile page title because `document.title` there is `"| Sign In"` /
   `"| Sign Out"`, and the parser's first split segment was an empty
   string that fell back to "Home".

Desktop is unchanged across all six.

## Behaviour after this PR

Mobile row 2 reshapes by route + auth state + sidebar state. Logic
collapsed into a single condition: when row 2 has no contextual
content to show (home, or sidebar drawer open), it becomes one
full-width primary action — search for anonymous, UPLOAD for
logged-in.

| State                                          | Row 1 (top)                                            | Row 2 (bottom)                                            |
| ---------------------------------------------- | ------------------------------------------------------ | --------------------------------------------------------- |
| Home + anonymous                               | hamburger · logo · Sign in pill                        | **full-width search bar** (tap opens overlay)             |
| Home + logged-in                               | hamburger · logo · search icon · bell · avatar         | **full-width UPLOAD MEDIA**                               |
| Non-home + anonymous                           | hamburger · logo · search icon · Sign in pill          | back · page title                                         |
| Non-home + logged-in                           | hamburger · logo · search icon · bell · avatar         | back · page title · UPLOAD (compact)                      |
| Sidebar drawer open + anonymous                | X · logo · Sign in pill                                | **full-width search bar**                                 |
| Sidebar drawer open + logged-in                | X · logo · search icon · bell · avatar                 | **full-width UPLOAD MEDIA**                               |

The row-2 search affordance is a styled button (not a real input). On
tap it opens the existing fullscreen search overlay, the same one the
top-row search icon already drives. The top-row mobile search icon is
hidden whenever row 2 already surfaces a search bar (anonymous +
home, or anonymous + sidebar open) so the same action isn't offered
twice.

### Bell vs search icon

Bell button is now `40x40` with a `20px` glyph, matching the search
button. The red unread dot is repositioned so it sits inside the new
button bounds.

### Search overlay z-index

Fullscreen mobile search dialog raised from `z-index: 100` to
`z-index: 1100` so it renders above the legacy top-message banner
(`z-index: 1000`, declared in `styles.scss`) as a true fullscreen
modal.

### Auth-page titles

`derivePageTitle` now filters empty segments before picking the first
label. `document.title` of `"| Sign In"` → segments `["Sign In"]` →
`"Sign In"`. Normal titles like `"Featured - CinemataCMS"` remain
unchanged (segments `["Featured", "CinemataCMS"]` → `"Featured"`).

## Implementation notes

- New small hook
  `frontend/src/features/layout/topbar/useIsHomeRoute.js` shared by
  `Topbar.jsx` (for top-row search-icon visibility) and
  `TopbarMobileBar.jsx` (for row-2 branching). Both watch `popstate`
  so the layout stays correct after browser navigation.
- `TopbarMobileBar.jsx` collapsed the home and sidebar-open branches
  into a single "no contextual content" early-return that picks the
  right action by `isAnonymous`. Easier to reason about than nested
  ternaries.

## Screenshot

### Non-Login View
<img width="812" height="1298" alt="image" src="https://github.com/user-attachments/assets/69c902ea-1ce9-429e-9faa-ea0f2b2811d9" />

### Non-Login and Side View
<img width="808" height="1298" alt="image" src="https://github.com/user-attachments/assets/8e0294d3-64bf-4899-bc44-3e9d70076a6b" />

### Non-Login and Non-Home View
<img width="816" height="1296" alt="image" src="https://github.com/user-attachments/assets/c0066e38-4043-43ed-a836-c9013fb2c83e" />

### Login and Home View
<img width="804" height="1290" alt="image" src="https://github.com/user-attachments/assets/c73f24b4-8ad0-43e7-ad43-dda8d8e0b7fa" />


## Testing

Verified with Playwright at 390x844 mobile and 1280x800 desktop, with
the top-message banner active throughout:

- **Anonymous + home (mobile):** row 2 = full-width search bar; top
  search icon hidden; tap drives the fullscreen overlay.
- **Anonymous + sidebar open (home or non-home, mobile):** row 2 =
  full-width search bar; top search icon hidden.
- **Anonymous + /featured (mobile):** row 1 search icon visible; row
  2 = back + "Featured".
- **Logged-in + home (mobile):** row 2 = full-width UPLOAD MEDIA; row
  1 search icon and bell now visibly the same size.
- **Logged-in + /featured (mobile):** row 2 = back + "Featured" +
  UPLOA... (compact); row 1 icons same-sized.
- **Logged-in + sidebar open (mobile):** row 2 = full-width UPLOAD.
- **Fullscreen search overlay (mobile):** no banner overlap; input
  row fully visible.
- **/accounts/login/ and /accounts/logout/ (mobile):** row 2 heading
  reads "Sign In" / "Sign Out" instead of "Home".
- **Desktop (1280x800):** unchanged — inline search bar, UPLOAD
  MEDIA, bell, avatar all visible; bell sized to match the other
  controls.

Local validation: `npm run lint:modern`, `npx vitest run` (305/305
pass), `npm run build`, `npx prettier --check` — all clean.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Code style matches existing patterns
- [x] No new tests required — visual regression covered by Playwright run on the build output
- [x] Lint, build, and existing unit tests pass locally (305/305)

## Modern Track Checklist

- [x] No `flux` imports added
- [x] No new SCSS files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a compact topbar icon button component and refined mobile search control to show only when appropriate.
  * Added home-route detection to improve mobile bar behavior.

* **Bug Fixes**
  * Fixed mobile topbar rendering across home vs. non-home routes and when the sidebar is visible.
  * Ensured mobile search overlay appears above other content.

* **Style**
  * Tweaked notification bell sizing, button layout, and unread-badge positioning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EngageMedia-video/cinematacms/pull/691?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->