### PR TITLE
fix: stack content sensitivity checkboxes vertically (#528)

### DIFF
--- a/templates/cms/edit_media.html
+++ b/templates/cms/edit_media.html
@@ -277,6 +277,17 @@
 
         <style>
 
+			#div_id_content_sensitivity .controls {
+				display: flex;
+				flex-direction: column;
+				gap: 4px;
+			}
+
+			#div_id_content_sensitivity .controls .checkbox {
+				font-size: 100% !important;
+				font-weight: normal !important;
+			}
+
 			.license_controls{}
 
 			.license_controls_header{


### PR DESCRIPTION
## Description
Fix the content sensitivity checkbox layout in the edit media form. Django's `CheckboxSelectMultiple` renders items inline by default, causing a messy wrapping layout with 15 items. Added CSS to display the list as a single vertical column.

## Related Issue
Follow-up to #528

## Motivation and Context
With the updated list of 15 content sensitivity values (from King's review), the inline checkbox layout wraps unpredictably. The Figma design shows a clean single-column list.

## How Has This Been Tested?
- Verified locally on the edit media page — checkboxes now stack vertically in a single column
- No other form fields affected (CSS targets `#id_content_sensitivity` specifically)

## Screenshots (if appropriate):
<img width="1341" height="987" alt="image" src="https://github.com/user-attachments/assets/052e8747-8211-49b6-bd5e-f1f51e2a16b6" />


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):
- [x] I have not imported `flux` in a new component
- [x] If adding a new feature, I used Modern Track patterns
- [x] New features do not create new SCSS files (use Tailwind instead)