### PR TITLE
fix: restore homepage author and synopsis behavior

### DIFF
--- a/files/tests/test_index_revamp_initial_data.py
+++ b/files/tests/test_index_revamp_initial_data.py
@@ -183,6 +183,18 @@ class IndexRevampInitialDataTest(TestCase):
         self.assertEqual(second_payload["results"][0]["friendly_token"], hero.friendly_token)
         self.assertIn("hero_playback", second_payload["results"][0])
 
+    def test_summary_update_invalidates_home_initial_data_cache(self):
+        first_payload = self._featured_payload()
+        self.assertEqual(first_payload["results"][0]["summary"], self.media.summary)
+
+        self.media.summary = "Updated homepage synopsis"
+        self.media.save(update_fields=["summary"])
+
+        updated_payload = self._featured_payload()
+
+        self.assertEqual(updated_payload["results"][0]["friendly_token"], self.media.friendly_token)
+        self.assertEqual(updated_payload["results"][0]["summary"], "Updated homepage synopsis")
+
     def test_recommended_payload_is_valid_json(self):
         response = self._get_revamp_response()
         content = response.content.decode()

--- a/frontend/src/features/home/components/HeroMediaCard.jsx
+++ b/frontend/src/features/home/components/HeroMediaCard.jsx
@@ -11,7 +11,7 @@ function getCountry(media) {
 }
 
 function getDescription(media) {
-	return media.description || media.summary || '';
+	return media.summary || media.description || '';
 }
 
 function formatViews(value) {
@@ -38,7 +38,7 @@ function AuthorName({ href, name }) {
 	}
 
 	const className =
-		'm-0 w-fit no-underline hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring-focus';
+		'm-0 inline-flex min-h-8 w-fit max-w-full touch-manipulation items-center no-underline hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring-focus';
 
 	if (href) {
 		return (

--- a/frontend/src/features/home/components/HeroMediaCard.test.jsx
+++ b/frontend/src/features/home/components/HeroMediaCard.test.jsx
@@ -5,8 +5,8 @@ import { HeroMediaCard, HeroMediaCardSkeleton } from './HeroMediaCard';
 const MEDIA = {
 	title: 'A Long Featured Film Title That Still Needs To Wrap Cleanly',
 	url: '/media/featured-film/',
-	description: 'A synopsis loaded from the media description.',
-	summary: 'A fallback synopsis.',
+	description: 'More information and credits from the media form.',
+	summary: 'A synopsis loaded from the media summary.',
 	author_name: 'Featured Author',
 	author_profile: '/profiles/featured-author/',
 	media_country: 'Philippines',
@@ -37,27 +37,30 @@ describe('HeroMediaCard', () => {
 		expect(titleLink).toHaveClass('text-inherit');
 		expect(titleLink).toHaveClass('hover:underline');
 
-		const description = screen.getByText('A synopsis loaded from the media description.');
+		const description = screen.getByText('A synopsis loaded from the media summary.');
 		expect(description).toHaveClass('body-body-14-regular');
 		expect(description).toHaveClass('text-text-description');
 		expect(description.className).not.toMatch(/dark:text-\[/);
 		expect(description).not.toHaveClass('dark:text-cinemata-pacific-deep-50');
+		expect(screen.queryByText('More information and credits from the media form.')).not.toBeInTheDocument();
 
 		const author = screen.getByRole('link', { name: 'Featured Author' });
 		expect(author).toHaveClass('body-body-12-regular');
 		expect(author).toHaveClass('text-text-link');
+		expect(author).toHaveClass('min-h-8');
+		expect(author).toHaveClass('touch-manipulation');
 
 		const views = screen.getByText('12,345 views');
 		expect(views).toHaveClass('text-text-muted');
 	});
 
-	it('falls back to summary and object-shaped country info from the API', () => {
+	it('falls back to description and object-shaped country info from the API', () => {
 		render(
 			<HeroMediaCard
 				media={{
 					...MEDIA,
-					description: '',
-					summary: 'Summary from the API list payload.',
+					description: 'Description from the API list payload.',
+					summary: '',
 					media_country: '',
 					media_country_info: { title: 'Singapore' },
 					views: '1 view',
@@ -65,7 +68,7 @@ describe('HeroMediaCard', () => {
 			/>
 		);
 
-		expect(screen.getByText('Summary from the API list payload.')).toBeInTheDocument();
+		expect(screen.getByText('Description from the API list payload.')).toBeInTheDocument();
 		expect(screen.getByText('Singapore')).toBeInTheDocument();
 		expect(screen.getByText('1 view')).toBeInTheDocument();
 	});
@@ -80,8 +83,8 @@ describe('HeroMediaCard', () => {
 		expect(screen.queryByRole('link', { name: MEDIA.title })).not.toBeInTheDocument();
 	});
 
-	it('renders description as plain text', () => {
-		render(<HeroMediaCard media={{ ...MEDIA, description: '<img src=x onerror=alert(1)>' }} />);
+	it('renders synopsis as plain text', () => {
+		render(<HeroMediaCard media={{ ...MEDIA, description: '', summary: '<img src=x onerror=alert(1)>' }} />);
 
 		expect(screen.queryByRole('img')).not.toBeInTheDocument();
 		expect(screen.getByText('<img src=x onerror=alert(1)>')).toBeInTheDocument();

--- a/frontend/src/features/home/components/HeroSection.test.jsx
+++ b/frontend/src/features/home/components/HeroSection.test.jsx
@@ -419,10 +419,11 @@ describe('HeroSection', () => {
 		expect(screen.getByText('Summary from the list API.')).toBeInTheDocument();
 	});
 
-	it('renders description as plain text, not HTML', () => {
+	it('renders synopsis as plain text, not HTML', () => {
 		const mediaWithHtml = {
 			...SAMPLE_MEDIA,
-			description: '<img src=x onerror=alert(1)>',
+			description: '',
+			summary: '<img src=x onerror=alert(1)>',
 		};
 		renderHero([mediaWithHtml]);
 		expect(screen.queryByRole('img', { name: '' })).toBeNull();

--- a/frontend/src/features/home/components/MediaTile.jsx
+++ b/frontend/src/features/home/components/MediaTile.jsx
@@ -36,6 +36,7 @@ export function MediaTile({ item }) {
 			link={item.url}
 			duration={getMediaDurationLabel(item)}
 			subtitle={getAuthorName(item)}
+			subtitleHref={item.author_profile || ''}
 			metadata={metadata}
 			badge={firstCategory?.title || ''}
 			badgeColor={firstCategory?.color || DEFAULT_CATEGORY_COLOR}

--- a/frontend/src/features/home/components/MediaTile.test.jsx
+++ b/frontend/src/features/home/components/MediaTile.test.jsx
@@ -7,6 +7,7 @@ const BASE_ITEM = {
 	thumbnail_url: 'https://example.com/thumb.jpg',
 	url: '/media/duration-film/',
 	author_name: 'Duration Author',
+	author_profile: '/profiles/duration-author/',
 	media_country: 'Indonesia',
 	views: 42,
 	state: 'private',
@@ -25,5 +26,13 @@ describe('MediaTile', () => {
 		render(<MediaTile item={{ ...BASE_ITEM, duration: '03:21' }} />);
 
 		expect(screen.getByText('03:21')).toHaveAttribute('data-movie-item-duration');
+	});
+
+	it('links the author name to the author profile', () => {
+		render(<MediaTile item={BASE_ITEM} />);
+
+		const author = screen.getByRole('link', { name: 'Duration Author' });
+
+		expect(author).toHaveAttribute('href', '/profiles/duration-author/');
 	});
 });

--- a/frontend/src/features/shared/components/MovieItem/MovieItem.jsx
+++ b/frontend/src/features/shared/components/MovieItem/MovieItem.jsx
@@ -5,17 +5,13 @@ import { Icon } from '../Icon';
 function MovieItemContainer({ children, contentClassName = '', shellClassName = '', link = '', title = '' }) {
 	if (link) {
 		return (
-			<article className={shellClassName}>
+			<article className={cn(shellClassName, 'relative')}>
 				<a
 					href={link}
-					className={cn(
-						'h-full w-full cursor-pointer text-inherit no-underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring-focus',
-						contentClassName
-					)}
+					className="absolute inset-0 z-10 cursor-pointer rounded-[6px] text-inherit no-underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring-focus"
 					aria-label={title ? `Open ${title}` : 'Open movie details'}
-				>
-					{children}
-				</a>
+				/>
+				<div className={contentClassName}>{children}</div>
 			</article>
 		);
 	}
@@ -49,8 +45,9 @@ function MovieMetadata({ items = [] }) {
 	);
 }
 
-function MovieCopy({ title, subtitle, metadata, orientation = 'vertical' }) {
+function MovieCopy({ title, subtitle, subtitleHref = '', metadata, orientation = 'vertical' }) {
 	const isHorizontal = orientation === 'horizontal';
+	const subtitleClassName = 'body-body-12-regular m-0 p-0 text-text-link';
 
 	return (
 		<div className={cn('flex min-w-0 flex-col', isHorizontal ? 'gap-3' : 'gap-2')} data-movie-copy>
@@ -63,7 +60,19 @@ function MovieCopy({ title, subtitle, metadata, orientation = 'vertical' }) {
 				{title}
 			</p>
 
-			{subtitle ? <p className="body-body-12-regular m-0 p-0 text-text-link">{subtitle}</p> : null}
+			{subtitle && subtitleHref ? (
+				<a
+					href={subtitleHref}
+					className={cn(
+						subtitleClassName,
+						'relative z-20 inline-flex min-h-8 w-fit max-w-full touch-manipulation items-center no-underline hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring-focus'
+					)}
+				>
+					{subtitle}
+				</a>
+			) : subtitle ? (
+				<p className={subtitleClassName}>{subtitle}</p>
+			) : null}
 
 			<MovieMetadata items={metadata} />
 		</div>
@@ -122,6 +131,7 @@ export function HorizontalMovieItem({
 	link = '',
 	metadata = [],
 	subtitle = '',
+	subtitleHref = '',
 	title = 'Movie Title',
 }) {
 	return (
@@ -141,7 +151,13 @@ export function HorizontalMovieItem({
 			/>
 
 			<div className="flex min-w-0 flex-1 flex-col gap-3">
-				<MovieCopy title={title} subtitle={subtitle} metadata={metadata} orientation="horizontal" />
+				<MovieCopy
+					title={title}
+					subtitle={subtitle}
+					subtitleHref={subtitleHref}
+					metadata={metadata}
+					orientation="horizontal"
+				/>
 			</div>
 		</MovieItemContainer>
 	);
@@ -159,6 +175,7 @@ export function VerticalMovieItem({
 	link = '',
 	metadata = [],
 	subtitle = '',
+	subtitleHref = '',
 	title = 'Movie Title',
 }) {
 	return (
@@ -180,7 +197,13 @@ export function VerticalMovieItem({
 				className="aspect-video w-full"
 			/>
 
-			<MovieCopy title={title} subtitle={subtitle} metadata={metadata} orientation="vertical" />
+			<MovieCopy
+				title={title}
+				subtitle={subtitle}
+				subtitleHref={subtitleHref}
+				metadata={metadata}
+				orientation="vertical"
+			/>
 		</MovieItemContainer>
 	);
 }
@@ -198,6 +221,7 @@ export function MovieItem({
 	metadata = [],
 	orientation = 'vertical',
 	subtitle = '',
+	subtitleHref = '',
 	title = 'Movie Title',
 }) {
 	if (orientation === 'horizontal') {
@@ -212,6 +236,7 @@ export function MovieItem({
 				link={link}
 				metadata={metadata}
 				subtitle={subtitle}
+				subtitleHref={subtitleHref}
 				title={title}
 			/>
 		);
@@ -230,6 +255,7 @@ export function MovieItem({
 			link={link}
 			metadata={metadata}
 			subtitle={subtitle}
+			subtitleHref={subtitleHref}
 			title={title}
 		/>
 	);

--- a/frontend/src/features/shared/components/MovieItem/MovieItem.test.jsx
+++ b/frontend/src/features/shared/components/MovieItem/MovieItem.test.jsx
@@ -115,4 +115,31 @@ describe('MovieItem', () => {
 
 		expect(movieLink).toHaveAttribute('href', '/media/cinema-paradiso/');
 	});
+
+	it('keeps the subtitle profile link clickable inside a linked movie card', () => {
+		render(
+			<VerticalMovieItem
+				imageSrc={samplePoster}
+				imageAlt="Clickable poster"
+				title="Cinema Paradiso"
+				subtitle="Giuseppe Tornatore"
+				subtitleHref="/profiles/giuseppe-tornatore/"
+				metadata={['1988']}
+				link="/media/cinema-paradiso/"
+			/>
+		);
+
+		expect(screen.getByRole('link', { name: 'Open Cinema Paradiso' })).toHaveAttribute(
+			'href',
+			'/media/cinema-paradiso/'
+		);
+		expect(screen.getByRole('link', { name: 'Giuseppe Tornatore' })).toHaveAttribute(
+			'href',
+			'/profiles/giuseppe-tornatore/'
+		);
+		expect(screen.getByRole('link', { name: 'Giuseppe Tornatore' })).toHaveClass('z-20');
+		expect(screen.getByRole('link', { name: 'Giuseppe Tornatore' })).toHaveClass('min-h-8');
+		expect(screen.getByRole('link', { name: 'Giuseppe Tornatore' })).toHaveClass('touch-manipulation');
+		expect(screen.getByRole('link', { name: 'Giuseppe Tornatore' }).closest('a[aria-label]')).toBeNull();
+	});
 });


### PR DESCRIPTION
## Description
Homepage visitors now see the edited Synopsis in the featured hero, and lower homepage video-card author names now navigate to the author profile instead of being swallowed by the card overlay.

The fix keeps the video card itself clickable while rendering the author as a separate, touch-friendly profile link above the overlay. The hero copy now follows the media detail page behavior by preferring `summary` before falling back to `description`.

## Related Issue
Fixes #(issue)

## Motivation and Context
The featured-video Synopsis field could be edited in the CMS but the homepage hero continued to show the older description copy whenever both fields were present. The lower homepage video cards also displayed author names as plain text inside a linked card, so clicking or tapping them opened nothing useful for the author profile flow.

## How Has This Been Tested?
- `npm run test:run -- src/features/home/components/HeroMediaCard.test.jsx src/features/home/components/HeroSection.test.jsx src/features/home/components/MediaTile.test.jsx src/features/shared/components/MovieItem/MovieItem.test.jsx`
- `uv run python manage.py test files.tests.test_index_revamp_initial_data.IndexRevampInitialDataTest.test_summary_update_invalidates_home_initial_data_cache`
- `npm run lint:modern`
- `git diff --check`
- Chrome verification on `http://localhost:8000/` confirmed the lower-card author link has a 32px touch target and is the top hit-tested anchor.

## Screenshots (if appropriate):
https://github.com/user-attachments/assets/a5b51470-e548-45e3-b274-be4c2f44088e

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):
- [x] I have not imported `flux` in a new component
- [ ] If adding a new feature, I used Modern Track patterns
- [x] New features do not create new SCSS files (use Tailwind instead)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Author names and profile subtitles are now interactive links.
  * Media summary is prioritized for featured media descriptions.

* **Bug Fixes**
  * Improved media display to prefer summary content and render author link styling consistently.
  * Subtitle/profile links remain independently clickable even when the whole card is a link.

* **Tests**
  * Added XSS-safety checks for media synopsis rendering.
  * Added cache invalidation test to ensure updated summaries appear.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EngageMedia-video/cinematacms/pull/701?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->