### PR TITLE
fix: tighten movie item author spacing

### DIFF
--- a/frontend/src/features/shared/components/MovieItem/MovieItem.jsx
+++ b/frontend/src/features/shared/components/MovieItem/MovieItem.jsx
@@ -81,7 +81,7 @@ function MovieCopy({ title, titleLink = '', subtitle, subtitleLink = '', metadat
 					href={subtitleLink}
 					className={cn(
 						subtitleClassName,
-						'relative z-20 inline-flex min-h-8 w-fit max-w-full touch-manipulation items-center no-underline hover:text-text-link-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-ring-focus'
+						'relative z-20 inline-flex w-fit max-w-full touch-manipulation no-underline hover:text-text-link-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-ring-focus'
 					)}
 				>
 					{subtitle}

--- a/frontend/src/features/shared/components/MovieItem/MovieItem.test.jsx
+++ b/frontend/src/features/shared/components/MovieItem/MovieItem.test.jsx
@@ -142,7 +142,7 @@ describe('MovieItem', () => {
 			'/profiles/giuseppe-tornatore/'
 		);
 		expect(screen.getByRole('link', { name: 'Giuseppe Tornatore' })).toHaveClass('z-20');
-		expect(screen.getByRole('link', { name: 'Giuseppe Tornatore' })).toHaveClass('min-h-8');
+		expect(screen.getByRole('link', { name: 'Giuseppe Tornatore' })).not.toHaveClass('min-h-8');
 		expect(screen.getByRole('link', { name: 'Giuseppe Tornatore' })).toHaveClass('touch-manipulation');
 		expect(screen.getByRole('link', { name: 'Giuseppe Tornatore' }).closest('a[aria-label]')).toBeNull();
 	});


### PR DESCRIPTION
## Summary
Movie cards no longer reserve an oversized author row when the author is a profile link. The author remains clickable inside linked cards, but the title, author, and metadata stack returns to compact spacing.

## Validation
- `npm run test:run -- MovieItem.test.jsx`
- `npm run lint:modern`
- Storybook visual check for linked author spacing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated subtitle link styling in movie items for improved layout and positioning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EngageMedia-video/cinematacms/pull/709?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->