### PR TITLE
feat: add storage usage indicator to sidebar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ pyvenv.cfg
 .claude/*
 .serena/
 CLAUDE.md
+AGENTS.md
+.agents/
 
 Bento4-SDK-1-6-0-632.x86_64-unknown-linux/
 DB_DUMPS/

--- a/cms/dev_settings.py
+++ b/cms/dev_settings.py
@@ -22,7 +22,6 @@ INSTALLED_APPS = [
     "allauth",
     "allauth.account",
     "allauth.socialaccount",
-    "allauth.mfa",
     "django.contrib.contenttypes",
     "django.contrib.sessions",
     "django.contrib.messages",
@@ -34,7 +33,6 @@ INSTALLED_APPS = [
     "files.apps.FilesConfig",
     "users.apps.UsersConfig",
     "actions.apps.ActionsConfig",
-    "notifications.apps.NotificationsConfig",
     "debug_toolbar",
     "mptt",
     "crispy_forms",
@@ -42,7 +40,6 @@ INSTALLED_APPS = [
     "djcelery_email",
     "ckeditor",
     "django_recaptcha",
-    "waffle",
 ]
 
 MIDDLEWARE = [

--- a/cms/dev_settings.py
+++ b/cms/dev_settings.py
@@ -22,6 +22,7 @@ INSTALLED_APPS = [
     "allauth",
     "allauth.account",
     "allauth.socialaccount",
+    "allauth.mfa",
     "django.contrib.contenttypes",
     "django.contrib.sessions",
     "django.contrib.messages",
@@ -33,6 +34,7 @@ INSTALLED_APPS = [
     "files.apps.FilesConfig",
     "users.apps.UsersConfig",
     "actions.apps.ActionsConfig",
+    "notifications.apps.NotificationsConfig",
     "debug_toolbar",
     "mptt",
     "crispy_forms",
@@ -40,6 +42,7 @@ INSTALLED_APPS = [
     "djcelery_email",
     "ckeditor",
     "django_recaptcha",
+    "waffle",
 ]
 
 MIDDLEWARE = [

--- a/cms/permissions.py
+++ b/cms/permissions.py
@@ -1,3 +1,4 @@
+from django.apps import apps
 from django.conf import settings
 from rest_framework import permissions
 
@@ -71,6 +72,15 @@ def user_requires_mfa(user):
     }
 
     return any(role in role_checks and role_checks[role] for role in required_roles)
+
+
+def is_mfa_enabled_for_user(user):
+    if not apps.is_installed("allauth.mfa"):
+        return False
+
+    from allauth.mfa.utils import is_mfa_enabled
+
+    return is_mfa_enabled(user)
 
 
 def should_enforce_mfa_on_path(path):

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -1,5 +1,6 @@
 import os
 
+from django.apps import apps
 from django.conf import settings
 from django.contrib import admin
 from django.http import HttpResponse
@@ -40,13 +41,15 @@ urlpatterns = [
     path("health/live", health_live),
     path("health/ready", health_ready),
     path(settings.DJANGO_ADMIN_URL, admin.site.urls),
-    path("", include("notifications.urls")),
     path("", include("files.urls")),
     path("", include("users.urls")),
     path("accounts/", include("allauth.urls")),
     path("api-auth/", include("rest_framework.urls")),
     path("tinymce/", include("tinymce.urls")),
 ]
+
+if apps.is_installed("notifications"):
+    urlpatterns.insert(4, path("", include("notifications.urls")))
 
 # Only add debug toolbar URLs when DEBUG is True
 if settings.DEBUG:

--- a/docs/modern-track-color-system.md
+++ b/docs/modern-track-color-system.md
@@ -239,7 +239,7 @@ Component-scoped legacy semantic groups also exist (search, comments, playlists,
 | `bg/overlay-dark`, `bg/chrome`, `bg/chrome-hover` | 3 | Always-dark UI chrome — topbar, search overlays, mobile dialogs. Do not invert. |
 | `bg/skeleton`, `bg/control` | 2 | Loading skeletons and standard small control surfaces, including radio backgrounds. |
 | `bg/primary`, `bg/primary-hover`, `bg/secondary`, `bg/secondary-hover` | 4 | Action surfaces. `primary` is strait-blue; `secondary` is sunset-horizon (the brand action color) and is what `bg-brand-primary` now routes through. |
-| `bg/danger`, `bg/danger-strong`, `bg/danger-strong-hover`, `bg/success`, `bg/warning` | 5 | Semantic feedback. Strong danger tokens cover active destructive/toggled-danger surfaces. |
+| `bg/danger`, `bg/danger-strong`, `bg/danger-strong-hover`, `bg/success`, `bg/success-strong`, `bg/warning` | 6 | Semantic feedback. Strong danger tokens cover active destructive/toggled-danger surfaces; `success-strong` pairs with `success` for striped progress fills. |
 | `text/strong`, `text/primary`, `text/secondary`, `text/muted`, `text/description`, `text/subtle`, `text/disabled` | 7 | Themed content text. |
 | `text/inverse`, `text/on-primary`, `text/on-chrome`, `text/on-chrome-muted` | 4 | Text on inverse/action/chrome surfaces. |
 | `text/link`, `text/link-hover`, `text/accent`, `text/danger`, `text/success`, `text/warning` | 6 | Inline-link and semantic text. |

--- a/files/context_processors.py
+++ b/files/context_processors.py
@@ -1,6 +1,7 @@
 import json
 
 import waffle
+from django.apps import apps
 from django.conf import settings
 from django.db import DatabaseError
 
@@ -17,6 +18,9 @@ from .storage_usage import get_storage_usage_for_request
 
 
 def _switch(name, fallback_setting):
+    if not apps.is_installed("waffle"):
+        return getattr(settings, fallback_setting, False)
+
     try:
         return waffle.switch_is_active(name)
     except DatabaseError:

--- a/files/context_processors.py
+++ b/files/context_processors.py
@@ -7,6 +7,7 @@ from django.db import DatabaseError
 from .lists import UNUSUAL_COUNTRIES
 from .methods import can_manage_uploads, can_upload_media, is_curator, is_mediacms_editor, is_mediacms_manager
 from .models import HomepagePopup, TopMessage
+from .storage_usage import get_storage_usage_for_request
 
 # NOTE: context_processors.py can be considered as a dumping ground of sorts for
 # multiple variables that, as declared, are then instantiated to be referenced
@@ -38,6 +39,13 @@ def stuff(request):
     ret["CAN_REPORT_MEDIA"] = _switch("can_report_media", "CAN_REPORT_MEDIA")
     ret["CAN_SHARE_MEDIA"] = _switch("can_share_media", "CAN_SHARE_MEDIA")
     ret["UPLOAD_MAX_SIZE"] = settings.UPLOAD_MAX_SIZE
+    try:
+        storage_scope, storage_used_bytes = get_storage_usage_for_request(request)
+    except DatabaseError:
+        storage_scope = "site"
+        storage_used_bytes = None
+    ret["STORAGE_SCOPE"] = storage_scope
+    ret["STORAGE_USED_BYTES"] = storage_used_bytes
 
     if request.user.is_authenticated and request.user.advancedUser:
         ret["UPLOAD_MAX_FILES_NUMBER"] = 10

--- a/files/management/commands/backfill_media_storage_usage.py
+++ b/files/management/commands/backfill_media_storage_usage.py
@@ -1,0 +1,72 @@
+from django.core.management.base import BaseCommand
+
+from files.models import Media
+from files.storage_usage import calculate_media_storage_usage, invalidate_storage_usage_cache
+
+
+class Command(BaseCommand):
+    help = "Backfill aggregate storage usage bytes for Media objects"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--batch-size",
+            type=int,
+            default=100,
+            help="Number of media rows to process in each batch (default: 100)",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Calculate usage without writing updates",
+        )
+        parser.add_argument(
+            "--user-id",
+            type=int,
+            help="Only backfill media owned by this user ID",
+        )
+
+    def handle(self, *args, **options):
+        batch_size = options["batch_size"]
+        dry_run = options["dry_run"]
+        user_id = options.get("user_id")
+
+        queryset = Media.objects.prefetch_related("encodings", "subtitles").all().order_by("id")
+        if user_id:
+            queryset = queryset.filter(user_id=user_id)
+
+        total = queryset.count()
+        processed = 0
+        changed = 0
+        pending_updates = []
+
+        if dry_run:
+            self.stdout.write(self.style.WARNING("DRY RUN: no storage usage values will be written"))
+
+        for media in queryset.iterator(chunk_size=batch_size):
+            used_bytes = calculate_media_storage_usage(media)
+            processed += 1
+
+            if media.storage_usage_bytes != used_bytes:
+                changed += 1
+                if not dry_run:
+                    media.storage_usage_bytes = used_bytes
+                    pending_updates.append(media)
+
+            if len(pending_updates) >= batch_size:
+                Media.objects.bulk_update(pending_updates, ["storage_usage_bytes"], batch_size=batch_size)
+                pending_updates = []
+
+            if processed % batch_size == 0:
+                self.stdout.write(f"Processed {processed}/{total} media rows")
+
+        if pending_updates:
+            Media.objects.bulk_update(pending_updates, ["storage_usage_bytes"], batch_size=batch_size)
+
+        if not dry_run:
+            invalidate_storage_usage_cache(user_id=user_id)
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Storage usage backfill complete: processed={processed}, changed={changed}, dry_run={dry_run}"
+            )
+        )

--- a/files/management/commands/backfill_media_storage_usage.py
+++ b/files/management/commands/backfill_media_storage_usage.py
@@ -1,4 +1,4 @@
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 
 from files.models import Media
 from files.storage_usage import calculate_media_storage_usage, invalidate_storage_usage_cache
@@ -27,6 +27,9 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         batch_size = options["batch_size"]
+        if batch_size <= 0:
+            raise CommandError("Invalid --batch-size: must be a positive integer")
+
         dry_run = options["dry_run"]
         user_id = options.get("user_id")
 

--- a/files/migrations/0024_media_storage_usage_bytes.py
+++ b/files/migrations/0024_media_storage_usage_bytes.py
@@ -10,6 +10,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="media",
             name="storage_usage_bytes",
-            field=models.BigIntegerField(default=0),
+            field=models.PositiveBigIntegerField(default=0),
         ),
     ]

--- a/files/migrations/0024_media_storage_usage_bytes.py
+++ b/files/migrations/0024_media_storage_usage_bytes.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("files", "0023_category_color"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="media",
+            name="storage_usage_bytes",
+            field=models.BigIntegerField(default=0),
+        ),
+    ]

--- a/files/models.py
+++ b/files/models.py
@@ -288,6 +288,7 @@ class Media(models.Model):
     video_height = models.IntegerField(default=1)
     md5sum = models.CharField(max_length=50, blank=True, null=True)
     size = models.CharField(max_length=20, blank=True, null=True)
+    storage_usage_bytes = models.BigIntegerField(default=0)
     # set this here, so we don't perform extra query for it on media listing
     preview_file_path = models.CharField(max_length=501, blank=True)
     password = models.CharField(max_length=256, blank=True, help_text="when video is in restricted state")
@@ -1981,6 +1982,40 @@ def media_save(sender, instance, created, **kwargs):
     instance.transcribe_function()
 
 
+def _schedule_storage_usage_refresh_for_media(media_id):
+    try:
+        from .storage_usage import schedule_refresh_media_storage_usage
+
+        schedule_refresh_media_storage_usage(media_id)
+    except Exception as e:
+        logger.warning(f"Failed to schedule storage usage refresh for media {media_id}: {e}")
+
+
+def _invalidate_storage_usage_for_user(user_id):
+    try:
+        from .storage_usage import invalidate_storage_usage_cache
+
+        invalidate_storage_usage_cache(user_id=user_id)
+    except Exception as e:
+        logger.warning(f"Failed to invalidate storage usage cache for user {user_id}: {e}")
+
+
+@receiver(post_save, sender=Media)
+def media_storage_usage_save(sender, instance, created, update_fields=None, **kwargs):
+    file_fields = {
+        "media_file",
+        "thumbnail",
+        "poster",
+        "uploaded_thumbnail",
+        "uploaded_poster",
+        "sprites",
+        "hls_file",
+    }
+    if update_fields is not None and not file_fields.intersection(set(update_fields)):
+        return
+    _schedule_storage_usage_refresh_for_media(instance.id)
+
+
 def _revoke_encoding_tasks(media_instance):
     """Revoke all pending/running Celery encoding tasks for a media instance.
 
@@ -2022,6 +2057,7 @@ def media_file_pre_delete(sender, instance, **kwargs):
     # Invalidate cache before deletion
     invalidate_media_cache(instance.friendly_token)
     invalidate_media_list_cache()
+    _invalidate_storage_usage_for_user(instance.user_id)
 
     # Invalidate media path cache (for secure file serving)
     invalidate_func = get_invalidate_media_path_cache()
@@ -2290,6 +2326,31 @@ def encoding_file_delete(sender, instance, **kwargs):
             instance.media.post_encode_actions(encoding=instance, action="delete")
     # delete local chunks, and remote chunks + media file. Only when the
     # last encoding of a media is complete
+
+
+@receiver(post_save, sender=Encoding)
+def encoding_storage_usage_save(sender, instance, update_fields=None, **kwargs):
+    file_fields = {"media_file", "chunk_file_path", "status"}
+    if update_fields is not None and not file_fields.intersection(set(update_fields)):
+        return
+    _schedule_storage_usage_refresh_for_media(instance.media_id)
+
+
+@receiver(post_delete, sender=Encoding)
+def encoding_storage_usage_delete(sender, instance, **kwargs):
+    _schedule_storage_usage_refresh_for_media(instance.media_id)
+
+
+@receiver(post_save, sender=Subtitle)
+def subtitle_storage_usage_save(sender, instance, update_fields=None, **kwargs):
+    if update_fields is not None and "subtitle_file" not in set(update_fields):
+        return
+    _schedule_storage_usage_refresh_for_media(instance.media_id)
+
+
+@receiver(post_delete, sender=Subtitle)
+def subtitle_storage_usage_delete(sender, instance, **kwargs):
+    _schedule_storage_usage_refresh_for_media(instance.media_id)
 
 
 @receiver(post_delete, sender=Comment)

--- a/files/models.py
+++ b/files/models.py
@@ -10,6 +10,7 @@ import uuid
 
 import m3u8
 import waffle
+from django.apps import apps
 from django.conf import settings
 from django.contrib.postgres.indexes import GinIndex
 from django.contrib.postgres.search import SearchVectorField
@@ -1089,9 +1090,12 @@ class Media(models.Model):
     def ratings_info(self):
         # to be used if user ratings are allowed
         ret = []
-        try:
-            ratings_enabled = waffle.switch_is_active("allow_ratings")
-        except DatabaseError:
+        if apps.is_installed("waffle"):
+            try:
+                ratings_enabled = waffle.switch_is_active("allow_ratings")
+            except DatabaseError:
+                ratings_enabled = getattr(settings, "ALLOW_RATINGS", False)
+        else:
             ratings_enabled = getattr(settings, "ALLOW_RATINGS", False)
         if not ratings_enabled:
             return []

--- a/files/models.py
+++ b/files/models.py
@@ -288,7 +288,7 @@ class Media(models.Model):
     video_height = models.IntegerField(default=1)
     md5sum = models.CharField(max_length=50, blank=True, null=True)
     size = models.CharField(max_length=20, blank=True, null=True)
-    storage_usage_bytes = models.BigIntegerField(default=0)
+    storage_usage_bytes = models.PositiveBigIntegerField(default=0)
     # set this here, so we don't perform extra query for it on media listing
     preview_file_path = models.CharField(max_length=501, blank=True)
     password = models.CharField(max_length=256, blank=True, help_text="when video is in restricted state")
@@ -1985,19 +1985,25 @@ def media_save(sender, instance, created, **kwargs):
 def _schedule_storage_usage_refresh_for_media(media_id):
     try:
         from .storage_usage import schedule_refresh_media_storage_usage
-
+    except ImportError:
+        logger.warning("storage_usage module not available; skipping refresh for media %s", media_id)
+        return
+    try:
         schedule_refresh_media_storage_usage(media_id)
-    except Exception as e:
-        logger.warning(f"Failed to schedule storage usage refresh for media {media_id}: {e}")
+    except Exception:
+        logger.warning("Failed to schedule storage usage refresh for media %s", media_id, exc_info=True)
 
 
 def _invalidate_storage_usage_for_user(user_id):
     try:
         from .storage_usage import invalidate_storage_usage_cache
-
+    except ImportError:
+        logger.warning("storage_usage module not available; skipping cache invalidation for user %s", user_id)
+        return
+    try:
         invalidate_storage_usage_cache(user_id=user_id)
-    except Exception as e:
-        logger.warning(f"Failed to invalidate storage usage cache for user {user_id}: {e}")
+    except Exception:
+        logger.warning("Failed to invalidate storage usage cache for user %s", user_id, exc_info=True)
 
 
 @receiver(post_save, sender=Media)

--- a/files/storage_usage.py
+++ b/files/storage_usage.py
@@ -3,13 +3,12 @@ import os
 
 from django.conf import settings
 from django.core.cache import cache
-from django.db import OperationalError, transaction
+from django.db import transaction
 from django.db.models import Sum
-from django.db.utils import DatabaseError
 
 logger = logging.getLogger(__name__)
 
-STORAGE_USAGE_CACHE_TIMEOUT = 60
+STORAGE_USAGE_CACHE_TIMEOUT = 21600
 SITE_STORAGE_USAGE_CACHE_KEY = "storage_usage:site"
 USER_STORAGE_USAGE_CACHE_KEY = "storage_usage:user:{user_id}"
 
@@ -164,13 +163,15 @@ def refresh_media_storage_usage(media_or_id):
 def schedule_refresh_media_storage_usage(media_or_id):
     media_id = getattr(media_or_id, "id", media_or_id)
 
-    def refresh():
-        try:
-            refresh_media_storage_usage(media_id)
-        except (DatabaseError, OperationalError, OSError):
-            logger.warning("Failed to refresh storage usage for media %s", media_id, exc_info=True)
+    def enqueue():
+        from .tasks import refresh_media_storage_usage_task
 
-    transaction.on_commit(refresh)
+        try:
+            refresh_media_storage_usage_task.apply_async(args=[media_id], queue="short_tasks")
+        except Exception:
+            logger.warning("Failed to enqueue storage usage refresh for media %s", media_id, exc_info=True)
+
+    transaction.on_commit(enqueue)
 
 
 def get_user_storage_usage(user):

--- a/files/storage_usage.py
+++ b/files/storage_usage.py
@@ -3,8 +3,9 @@ import os
 
 from django.conf import settings
 from django.core.cache import cache
-from django.db import transaction
+from django.db import OperationalError, transaction
 from django.db.models import Sum
+from django.db.utils import DatabaseError
 
 logger = logging.getLogger(__name__)
 
@@ -166,7 +167,7 @@ def schedule_refresh_media_storage_usage(media_or_id):
     def refresh():
         try:
             refresh_media_storage_usage(media_id)
-        except Exception:
+        except (DatabaseError, OperationalError, OSError):
             logger.warning("Failed to refresh storage usage for media %s", media_id, exc_info=True)
 
     transaction.on_commit(refresh)

--- a/files/storage_usage.py
+++ b/files/storage_usage.py
@@ -1,0 +1,206 @@
+import logging
+import os
+
+from django.conf import settings
+from django.core.cache import cache
+from django.db import transaction
+from django.db.models import Sum
+
+logger = logging.getLogger(__name__)
+
+STORAGE_USAGE_CACHE_TIMEOUT = 60
+SITE_STORAGE_USAGE_CACHE_KEY = "storage_usage:site"
+USER_STORAGE_USAGE_CACHE_KEY = "storage_usage:user:{user_id}"
+
+
+def user_storage_usage_cache_key(user_id):
+    return USER_STORAGE_USAGE_CACHE_KEY.format(user_id=user_id)
+
+
+def invalidate_storage_usage_cache(user_id=None):
+    cache.delete(SITE_STORAGE_USAGE_CACHE_KEY)
+    if user_id:
+        cache.delete(user_storage_usage_cache_key(user_id))
+
+
+def _normalize_local_path(path):
+    if not path:
+        return ""
+    if os.path.isabs(path):
+        return os.path.realpath(path)
+    media_root = getattr(settings, "MEDIA_ROOT", "")
+    if media_root:
+        return os.path.realpath(os.path.join(media_root, path))
+    return os.path.realpath(path)
+
+
+def _safe_filefield_size(field_file, seen_paths):
+    if not field_file:
+        return 0
+
+    name = getattr(field_file, "name", "")
+    if not name:
+        return 0
+
+    local_path = ""
+    try:
+        local_path = field_file.path
+    except (NotImplementedError, OSError, ValueError):
+        local_path = ""
+
+    if local_path:
+        key = f"file:{_normalize_local_path(local_path)}"
+    else:
+        storage = getattr(field_file, "storage", None)
+        storage_name = storage.__class__.__name__ if storage else "storage"
+        key = f"storage:{storage_name}:{name}"
+
+    if key in seen_paths:
+        return 0
+
+    try:
+        if local_path and os.path.exists(local_path):
+            size = os.path.getsize(local_path)
+        else:
+            storage = getattr(field_file, "storage", None)
+            size = storage.size(name) if storage else field_file.size
+    except (FileNotFoundError, OSError, ValueError) as e:
+        logger.warning("Skipping missing media storage file %s: %s", name, e)
+        return 0
+
+    if not isinstance(size, int) or size < 0:
+        return 0
+
+    seen_paths.add(key)
+    return size
+
+
+def _safe_local_file_size(path, seen_paths):
+    if not path:
+        return 0
+
+    local_path = _normalize_local_path(path)
+    key = f"file:{local_path}"
+    if key in seen_paths:
+        return 0
+
+    try:
+        if not os.path.isfile(local_path):
+            return 0
+        size = os.path.getsize(local_path)
+    except OSError as e:
+        logger.warning("Skipping missing media storage file %s: %s", path, e)
+        return 0
+
+    if size < 0:
+        return 0
+
+    seen_paths.add(key)
+    return size
+
+
+def _safe_local_directory_size(path, seen_paths):
+    if not path:
+        return 0
+
+    directory = path if os.path.isdir(path) else os.path.dirname(path)
+    local_directory = _normalize_local_path(directory)
+    if not os.path.isdir(local_directory):
+        return 0
+
+    total = 0
+    for root, _, files in os.walk(local_directory):
+        for filename in files:
+            total += _safe_local_file_size(os.path.join(root, filename), seen_paths)
+    return total
+
+
+def calculate_media_storage_usage(media):
+    seen_paths = set()
+    total = 0
+
+    for field_name in (
+        "media_file",
+        "thumbnail",
+        "poster",
+        "uploaded_thumbnail",
+        "uploaded_poster",
+        "sprites",
+    ):
+        total += _safe_filefield_size(getattr(media, field_name, None), seen_paths)
+
+    for encoding in media.encodings.all():
+        total += _safe_filefield_size(encoding.media_file, seen_paths)
+        total += _safe_local_file_size(encoding.chunk_file_path, seen_paths)
+
+    for subtitle in media.subtitles.all():
+        total += _safe_filefield_size(subtitle.subtitle_file, seen_paths)
+
+    total += _safe_local_directory_size(media.hls_file, seen_paths)
+
+    return total
+
+
+def refresh_media_storage_usage(media_or_id):
+    from .models import Media
+
+    media = (
+        media_or_id
+        if isinstance(media_or_id, Media)
+        else Media.objects.prefetch_related("encodings", "subtitles").filter(pk=media_or_id).first()
+    )
+
+    if not media:
+        invalidate_storage_usage_cache()
+        return 0
+
+    used_bytes = calculate_media_storage_usage(media)
+    Media.objects.filter(pk=media.pk).update(storage_usage_bytes=used_bytes)
+    invalidate_storage_usage_cache(user_id=media.user_id)
+    return used_bytes
+
+
+def schedule_refresh_media_storage_usage(media_or_id):
+    media_id = getattr(media_or_id, "id", media_or_id)
+
+    def refresh():
+        try:
+            refresh_media_storage_usage(media_id)
+        except Exception:
+            logger.warning("Failed to refresh storage usage for media %s", media_id, exc_info=True)
+
+    transaction.on_commit(refresh)
+
+
+def get_user_storage_usage(user):
+    if not getattr(user, "is_authenticated", False):
+        return get_site_storage_usage()
+
+    key = user_storage_usage_cache_key(user.id)
+    cached = cache.get(key)
+    if cached is not None:
+        return cached
+
+    from .models import Media
+
+    used_bytes = Media.objects.filter(user=user).aggregate(total=Sum("storage_usage_bytes"))["total"] or 0
+    cache.set(key, used_bytes, STORAGE_USAGE_CACHE_TIMEOUT)
+    return used_bytes
+
+
+def get_site_storage_usage():
+    cached = cache.get(SITE_STORAGE_USAGE_CACHE_KEY)
+    if cached is not None:
+        return cached
+
+    from .models import Media
+
+    used_bytes = Media.objects.aggregate(total=Sum("storage_usage_bytes"))["total"] or 0
+    cache.set(SITE_STORAGE_USAGE_CACHE_KEY, used_bytes, STORAGE_USAGE_CACHE_TIMEOUT)
+    return used_bytes
+
+
+def get_storage_usage_for_request(request):
+    if request.user.is_authenticated:
+        return "user", get_user_storage_usage(request.user)
+    return "site", get_site_storage_usage()

--- a/files/tasks.py
+++ b/files/tasks.py
@@ -844,6 +844,17 @@ def media_init(friendly_token):
     return True
 
 
+@task(name="refresh_media_storage_usage", queue="short_tasks")
+def refresh_media_storage_usage_task(media_id):
+    from .storage_usage import refresh_media_storage_usage
+
+    try:
+        refresh_media_storage_usage(media_id)
+    except Exception:
+        logger.warning("Failed to refresh storage usage for media %s", media_id, exc_info=True)
+    return True
+
+
 @task(name="check_running_states", queue="short_tasks")
 def check_running_states():
     encodings = Encoding.objects.filter(status="running")

--- a/files/tasks.py
+++ b/files/tasks.py
@@ -52,6 +52,7 @@ from .models import (
     TranscriptionRequest,
 )
 from .query_cache import invalidate_media_cache
+from .storage_usage import schedule_refresh_media_storage_usage
 
 logger = get_task_logger(__name__)
 
@@ -825,6 +826,8 @@ def create_hls(friendly_token):
             if media.hls_file != pp:
                 media.hls_file = pp
                 media.save(update_fields=["hls_file"])
+            else:
+                schedule_refresh_media_storage_usage(media.id)
     return True
 
 

--- a/files/tests/test_storage_usage.py
+++ b/files/tests/test_storage_usage.py
@@ -12,7 +12,11 @@ from django.test import RequestFactory, TestCase, override_settings
 from files import tasks
 from files.context_processors import stuff
 from files.models import EncodeProfile, Encoding, Language, Media, Subtitle
-from files.storage_usage import calculate_media_storage_usage, refresh_media_storage_usage
+from files.storage_usage import (
+    calculate_media_storage_usage,
+    refresh_media_storage_usage,
+    schedule_refresh_media_storage_usage,
+)
 from files.tests.helpers import create_test_media, create_test_user
 
 
@@ -107,6 +111,19 @@ class StorageUsageTests(TestCase):
         self.assertEqual(self.media.storage_usage_bytes, 6)
         self.assertIsNone(cache.get(f"storage_usage:user:{self.user.id}"))
         self.assertIsNone(cache.get("storage_usage:site"))
+
+    def test_schedule_refresh_media_storage_usage_enqueues_after_commit(self):
+        with patch("files.tasks.refresh_media_storage_usage_task.apply_async") as apply_async:
+            with self.captureOnCommitCallbacks(execute=True):
+                schedule_refresh_media_storage_usage(self.media)
+
+        apply_async.assert_called_once_with(args=[self.media.pk], queue="short_tasks")
+
+    def test_refresh_media_storage_usage_task_calls_refresh_helper(self):
+        with patch("files.storage_usage.refresh_media_storage_usage") as refresh:
+            self.assertTrue(tasks.refresh_media_storage_usage_task(self.media.pk))
+
+        refresh.assert_called_once_with(self.media.pk)
 
     def test_context_processor_exposes_user_and_site_storage_usage(self):
         other_user = create_test_user(username="storage_other")

--- a/files/tests/test_storage_usage.py
+++ b/files/tests/test_storage_usage.py
@@ -154,8 +154,11 @@ class StorageUsageTests(TestCase):
 
         def fake_run(command, capture_output):
             output_dir = next(
-                part.removeprefix("--output-dir=") for part in command if part.startswith("--output-dir=")
+                (part.removeprefix("--output-dir=") for part in command if part.startswith("--output-dir=")),
+                None,
             )
+            if output_dir is None:
+                raise ValueError("Expected mp4hls command to include --output-dir=<path>")
             os.makedirs(output_dir, exist_ok=True)
             with open(os.path.join(output_dir, "master.m3u8"), "wb") as master_file:
                 master_file.write(b"new")

--- a/files/tests/test_storage_usage.py
+++ b/files/tests/test_storage_usage.py
@@ -1,0 +1,173 @@
+import os
+import tempfile
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+from django.contrib.auth.models import AnonymousUser
+from django.core.cache import cache
+from django.core.files.base import ContentFile
+from django.core.management import call_command
+from django.test import RequestFactory, TestCase, override_settings
+
+from files import tasks
+from files.context_processors import stuff
+from files.models import EncodeProfile, Encoding, Language, Media, Subtitle
+from files.storage_usage import calculate_media_storage_usage, refresh_media_storage_usage
+from files.tests.helpers import create_test_media, create_test_user
+
+
+class StorageUsageTests(TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.hls_dir = os.path.join(self.tmpdir.name, "hls")
+        os.makedirs(self.hls_dir, exist_ok=True)
+        self.override = override_settings(
+            ADMINS_NOTIFICATIONS={"NEW_USER": False},
+            MEDIA_ROOT=self.tmpdir.name,
+            HLS_DIR=self.hls_dir,
+            TEMP_DIRECTORY=self.tmpdir.name,
+        )
+        self.override.enable()
+        self.addCleanup(self.override.disable)
+        self.addCleanup(self.tmpdir.cleanup)
+        cache.clear()
+
+        self.user = create_test_user(username="storage_owner")
+        self.media = create_test_media(self.user)
+
+    def _attach_file(self, instance, field_name, name, content):
+        field_file = getattr(instance, field_name)
+        generated_name = field_file.field.generate_filename(instance, name)
+        stored_name = field_file.storage.save(generated_name, ContentFile(content))
+        instance.__class__.objects.filter(pk=instance.pk).update(**{field_name: stored_name})
+        setattr(instance, field_name, stored_name)
+        if isinstance(instance, Media):
+            if field_name == "media_file":
+                instance._Media__original_media_file = instance.media_file
+            elif field_name == "uploaded_poster":
+                instance._Media__original_uploaded_poster = instance.uploaded_poster
+        return stored_name
+
+    def _profile(self):
+        return EncodeProfile.objects.create(
+            name="720p mp4",
+            extension="mp4",
+            resolution=720,
+            codec="h264",
+        )
+
+    def test_calculate_media_storage_usage_counts_all_assets(self):
+        self._attach_file(self.media, "media_file", "original.mp4", b"original12")
+        self._attach_file(self.media, "thumbnail", "thumb.jpg", b"thumb")
+        self._attach_file(self.media, "sprites", "sprites.jpg", b"sprite")
+
+        encoding = Encoding.objects.create(media=self.media, profile=self._profile(), status="success")
+        self._attach_file(self.media, "uploaded_poster", "poster.jpg", b"poster")
+        self._attach_file(encoding, "media_file", "encoded.mp4", b"encoded")
+        chunk_path = os.path.join(self.tmpdir.name, "chunk.mp4")
+        with open(chunk_path, "wb") as chunk_file:
+            chunk_file.write(b"chunked")
+        Encoding.objects.filter(pk=encoding.pk).update(chunk_file_path=chunk_path)
+
+        language = Language.objects.create(code="test-storage", title="Storage Test")
+        subtitle = Subtitle.objects.create(media=self.media, language=language, user=self.user)
+        self._attach_file(subtitle, "subtitle_file", "captions.vtt", b"sub")
+
+        hls_path = os.path.join(self.hls_dir, self.media.uid.hex, "master.m3u8")
+        os.makedirs(os.path.dirname(hls_path), exist_ok=True)
+        with open(hls_path, "wb") as master_file:
+            master_file.write(b"hls")
+        with open(os.path.join(os.path.dirname(hls_path), "segment.ts"), "wb") as segment_file:
+            segment_file.write(b"segment")
+        Media.objects.filter(pk=self.media.pk).update(hls_file=hls_path)
+
+        self.media.refresh_from_db()
+
+        self.assertEqual(
+            calculate_media_storage_usage(self.media),
+            10 + 5 + 6 + 6 + 7 + 7 + 3 + 3 + 7,
+        )
+
+    def test_calculate_media_storage_usage_counts_duplicate_paths_once(self):
+        thumbnail_name = self._attach_file(self.media, "thumbnail", "same.jpg", b"same-file")
+        Media.objects.filter(pk=self.media.pk).update(poster=thumbnail_name)
+        self.media.refresh_from_db()
+
+        self.assertEqual(calculate_media_storage_usage(self.media), 9)
+
+    def test_refresh_media_storage_usage_updates_media_and_clears_cache(self):
+        self._attach_file(self.media, "media_file", "original.mp4", b"stored")
+        Media.objects.filter(pk=self.media.pk).update(storage_usage_bytes=0)
+        cache.set(f"storage_usage:user:{self.user.id}", 1)
+        cache.set("storage_usage:site", 1)
+
+        self.assertEqual(refresh_media_storage_usage(self.media.pk), 6)
+
+        self.media.refresh_from_db()
+        self.assertEqual(self.media.storage_usage_bytes, 6)
+        self.assertIsNone(cache.get(f"storage_usage:user:{self.user.id}"))
+        self.assertIsNone(cache.get("storage_usage:site"))
+
+    def test_context_processor_exposes_user_and_site_storage_usage(self):
+        other_user = create_test_user(username="storage_other")
+        other_media = create_test_media(other_user)
+        Media.objects.filter(pk=self.media.pk).update(storage_usage_bytes=11)
+        Media.objects.filter(pk=other_media.pk).update(storage_usage_bytes=17)
+
+        request = RequestFactory().get("/")
+        request.user = self.user
+        context = stuff(request)
+        self.assertEqual(context["STORAGE_SCOPE"], "user")
+        self.assertEqual(context["STORAGE_USED_BYTES"], 11)
+
+        anonymous_request = RequestFactory().get("/")
+        anonymous_request.user = AnonymousUser()
+        context = stuff(anonymous_request)
+        self.assertEqual(context["STORAGE_SCOPE"], "site")
+        self.assertEqual(context["STORAGE_USED_BYTES"], 28)
+
+    def test_backfill_media_storage_usage_command_updates_media(self):
+        self._attach_file(self.media, "media_file", "original.mp4", b"stored")
+        Media.objects.filter(pk=self.media.pk).update(storage_usage_bytes=0)
+
+        out = StringIO()
+        call_command("backfill_media_storage_usage", batch_size=1, stdout=out)
+
+        self.media.refresh_from_db()
+        self.assertEqual(self.media.storage_usage_bytes, 6)
+        self.assertIn("Storage usage backfill complete", out.getvalue())
+
+    def test_create_hls_refreshes_storage_usage_when_hls_path_is_unchanged(self):
+        fake_mp4hls = os.path.join(self.tmpdir.name, "mp4hls")
+        with open(fake_mp4hls, "w", encoding="utf-8") as command_file:
+            command_file.write("#!/bin/sh\n")
+
+        self._attach_file(self.media, "media_file", "original.mp4", b"original")
+        encoding = Encoding.objects.create(media=self.media, profile=self._profile(), status="success")
+        self._attach_file(encoding, "media_file", "encoded.mp4", b"encoded")
+
+        hls_path = os.path.join(self.hls_dir, self.media.uid.hex, "master.m3u8")
+        os.makedirs(os.path.dirname(hls_path), exist_ok=True)
+        with open(hls_path, "wb") as master_file:
+            master_file.write(b"old")
+        Media.objects.filter(pk=self.media.pk).update(hls_file=hls_path)
+
+        def fake_run(command, capture_output):
+            output_dir = next(
+                part.removeprefix("--output-dir=") for part in command if part.startswith("--output-dir=")
+            )
+            os.makedirs(output_dir, exist_ok=True)
+            with open(os.path.join(output_dir, "master.m3u8"), "wb") as master_file:
+                master_file.write(b"new")
+            return MagicMock(returncode=0)
+
+        with (
+            override_settings(MP4HLS_COMMAND=fake_mp4hls),
+            patch("files.tasks.subprocess.run", side_effect=fake_run),
+            patch("files.tasks.schedule_refresh_media_storage_usage") as schedule_refresh,
+        ):
+            self.assertTrue(tasks.create_hls(self.media.friendly_token))
+
+        self.media.refresh_from_db()
+        self.assertEqual(self.media.hls_file, hls_path)
+        schedule_refresh.assert_called_once_with(self.media.id)

--- a/files/views.py
+++ b/files/views.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 
 import waffle
-from allauth.mfa.utils import is_mfa_enabled
+from django.apps import apps
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
@@ -40,6 +40,7 @@ from cms.custom_pagination import FastPaginationWithoutCount, SmallPreviewPagina
 from cms.permissions import (
     IsAuthorizedToAdd,
     IsUserOrEditor,
+    is_mfa_enabled_for_user,
     user_requires_mfa,
 )
 from cms.request_utils import get_client_ip
@@ -351,7 +352,7 @@ def manage_users(request):
     if request.user.is_anonymous:
         return HttpResponseRedirect("/")
     # MFA check
-    if user_requires_mfa(request.user) and not is_mfa_enabled(request.user):
+    if user_requires_mfa(request.user) and not is_mfa_enabled_for_user(request.user):
         return HttpResponseRedirect("/accounts/2fa/totp/activate")
 
     # Hard config -> ensure superuser / manager only have access
@@ -367,7 +368,7 @@ def manage_media(request):
         return HttpResponseRedirect("/")
 
     # MFA check
-    if user_requires_mfa(request.user) and not is_mfa_enabled(request.user):
+    if user_requires_mfa(request.user) and not is_mfa_enabled_for_user(request.user):
         return HttpResponseRedirect("/accounts/2fa/totp/activate")
 
     # Hard config -> ensure superuser / manager / editor only have access
@@ -382,7 +383,7 @@ def manage_comments(request):
     if request.user.is_anonymous:
         return HttpResponseRedirect("/")
 
-    if user_requires_mfa(request.user) and not is_mfa_enabled(request.user):
+    if user_requires_mfa(request.user) and not is_mfa_enabled_for_user(request.user):
         return HttpResponseRedirect("/accounts/2fa/totp/activate")
 
     if not (request.user.is_superuser or request.user.is_manager or request.user.is_editor):
@@ -396,7 +397,7 @@ def manage_uploads(request):
     if request.user.is_anonymous:
         return HttpResponseRedirect("/")
 
-    if user_requires_mfa(request.user) and not is_mfa_enabled(request.user):
+    if user_requires_mfa(request.user) and not is_mfa_enabled_for_user(request.user):
         return HttpResponseRedirect("/accounts/2fa/totp/activate")
 
     if not can_manage_uploads(request.user):
@@ -561,9 +562,12 @@ def upload_media(request):
     form = LoginForm()
     context = {}
     context["form"] = form
-    try:
-        upload_allowed = waffle.switch_is_active("upload_media_allowed")
-    except DatabaseError:
+    if apps.is_installed("waffle"):
+        try:
+            upload_allowed = waffle.switch_is_active("upload_media_allowed")
+        except DatabaseError:
+            upload_allowed = getattr(settings, "UPLOAD_MEDIA_ALLOWED", True)
+    else:
         upload_allowed = getattr(settings, "UPLOAD_MEDIA_ALLOWED", True)
     context["can_add"] = upload_allowed and can_upload_media(request.user)
     can_upload_exp = settings.CANNOT_ADD_MEDIA_MESSAGE

--- a/files/views.py
+++ b/files/views.py
@@ -124,6 +124,7 @@ from .serializers import (
     TopMessageSerializer,
 )
 from .stop_words import STOP_WORDS
+from .storage_usage import schedule_refresh_media_storage_usage
 from .tasks import save_user_action
 
 VALID_USER_ACTIONS = [action for action, name in USER_MEDIA_ACTIONS]
@@ -1103,6 +1104,7 @@ def edit_subtitle(request):
                 # CRITICAL FIX: Update media edit_date to bust cache
                 subtitle.media.edit_date = timezone.now()
                 subtitle.media.save(update_fields=["edit_date"])
+                schedule_refresh_media_storage_usage(subtitle.media_id)
 
                 messages.add_message(request, messages.INFO, "Subtitle was edited")
                 return HttpResponseRedirect(subtitle.media.get_absolute_url())

--- a/frontend/src/features/layout/Sidebar/shell/Sidebar.jsx
+++ b/frontend/src/features/layout/Sidebar/shell/Sidebar.jsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect } from 'react';
 
 import { SidebarNavigationMenu } from '../navigation/SidebarNavigationMenu';
+import { StorageUsage } from '../storage';
 import { SidebarThemeSwitcher } from '../theme/SidebarThemeSwitcher';
 
 import PageStore from '../../../../static/js/pages/_PageStore.js';
@@ -73,10 +74,7 @@ export function Sidebar({ id = 'app-sidebar' }) {
 
 	const sidebarFooterContent = shouldRenderSidebarContent ? (
 		<div className="relative z-10 flex flex-col gap-4 py-4 px-4">
-			<div>
-				{/* TODO: Place storage component here */}
-				<p>Placeholder for storage</p>
-			</div>
+			<StorageUsage />
 
 			<Link
 				variant="tertiary"

--- a/frontend/src/features/layout/Sidebar/storage/StorageUsage.jsx
+++ b/frontend/src/features/layout/Sidebar/storage/StorageUsage.jsx
@@ -31,7 +31,7 @@ export function StorageUsage({ usedBytes, scope } = {}) {
 					<span className="body-body-12-regular text-text-muted">{label}</span>
 					<span className="h-3 w-14 rounded-full bg-bg-surface-muted" aria-hidden="true" />
 				</div>
-				<div className="h-2 w-full rounded-full bg-cinemata-coral-reef-100 dark:bg-cinemata-coral-reef-900" />
+				<div className="h-2 w-full rounded-full bg-bg-skeleton" />
 			</div>
 		);
 	}
@@ -53,15 +53,12 @@ export function StorageUsage({ usedBytes, scope } = {}) {
 				<span className="body-body-12-regular min-w-0 text-text-muted">{label}</span>
 				<span className="body-body-12-medium shrink-0 text-text-strong">{formatBytes(resolvedUsedBytes)}</span>
 			</div>
-			<div
-				aria-hidden="true"
-				className="h-2 w-full overflow-hidden rounded-full bg-cinemata-coral-reef-100 dark:bg-cinemata-coral-reef-900"
-			>
+			<div aria-hidden="true" className="h-2 w-full overflow-hidden rounded-full bg-bg-skeleton">
 				<div
-					className="h-full w-full rounded-full bg-cinemata-green-700p dark:bg-cinemata-green-800"
+					className="h-full w-full rounded-full bg-bg-success"
 					style={{
 						backgroundImage:
-							'repeating-linear-gradient(135deg, var(--cinemata-green-500) 0, var(--cinemata-green-500) 6px, var(--cinemata-green-800) 6px, var(--cinemata-green-800) 12px)',
+							'repeating-linear-gradient(135deg, var(--bg-success) 0, var(--bg-success) 6px, var(--bg-success-strong) 6px, var(--bg-success-strong) 12px)',
 					}}
 				/>
 			</div>

--- a/frontend/src/features/layout/Sidebar/storage/StorageUsage.jsx
+++ b/frontend/src/features/layout/Sidebar/storage/StorageUsage.jsx
@@ -1,0 +1,70 @@
+import React from 'react';
+
+import PageStore from '../../../../static/js/pages/_PageStore.js';
+import { formatBytes } from '../../../shared/utils/formatBytes.js';
+
+function isValidUsage(value) {
+	return Number.isFinite(value) && value >= 0;
+}
+
+function resolveStorageConfig(usedBytes, scope) {
+	if (usedBytes !== undefined || scope !== undefined) {
+		return {
+			usedBytes,
+			scope: scope || 'site',
+		};
+	}
+
+	return PageStore.get('config-storage') || {};
+}
+
+export function StorageUsage({ usedBytes, scope } = {}) {
+	const storage = resolveStorageConfig(usedBytes, scope);
+	const resolvedScope = storage.scope === 'user' ? 'user' : 'site';
+	const resolvedUsedBytes = Number(storage.usedBytes);
+	const label = resolvedScope === 'user' ? 'Your Usage' : 'Storage Hosted';
+
+	if (storage.usedBytes === undefined) {
+		return (
+			<div className="flex flex-col gap-2" aria-label={`${label} loading`}>
+				<div className="flex items-baseline justify-between gap-3">
+					<span className="body-body-12-regular text-text-muted">{label}</span>
+					<span className="h-3 w-14 rounded-full bg-bg-surface-muted" aria-hidden="true" />
+				</div>
+				<div className="h-2 w-full rounded-full bg-cinemata-coral-reef-100 dark:bg-cinemata-coral-reef-900" />
+			</div>
+		);
+	}
+
+	if (storage.usedBytes === null || storage.usedBytes === '' || !isValidUsage(resolvedUsedBytes)) {
+		return (
+			<div className="flex flex-col gap-2">
+				<div className="flex items-baseline justify-between gap-3">
+					<span className="body-body-12-regular text-text-muted">{label}</span>
+					<span className="body-body-12-medium shrink-0 text-text-muted">Unavailable</span>
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex flex-col gap-2">
+			<div className="flex items-baseline justify-between gap-3">
+				<span className="body-body-12-regular min-w-0 text-text-muted">{label}</span>
+				<span className="body-body-12-medium shrink-0 text-text-strong">{formatBytes(resolvedUsedBytes)}</span>
+			</div>
+			<div
+				aria-hidden="true"
+				className="h-2 w-full overflow-hidden rounded-full bg-cinemata-coral-reef-100 dark:bg-cinemata-coral-reef-900"
+			>
+				<div
+					className="h-full w-full rounded-full bg-cinemata-green-700p dark:bg-cinemata-green-800"
+					style={{
+						backgroundImage:
+							'repeating-linear-gradient(135deg, var(--cinemata-green-500) 0, var(--cinemata-green-500) 6px, var(--cinemata-green-800) 6px, var(--cinemata-green-800) 12px)',
+					}}
+				/>
+			</div>
+		</div>
+	);
+}

--- a/frontend/src/features/layout/Sidebar/storage/StorageUsage.stories.jsx
+++ b/frontend/src/features/layout/Sidebar/storage/StorageUsage.stories.jsx
@@ -1,0 +1,38 @@
+import { StorageUsage } from './StorageUsage';
+import { SidebarPanel } from '../storybook/sidebarStoryHelpers';
+
+const meta = {
+	title: 'Components/Overlays/Sidebar/Storage Usage',
+	component: StorageUsage,
+	tags: ['autodocs'],
+	decorators: [
+		(Story) => (
+			<SidebarPanel>
+				<Story />
+			</SidebarPanel>
+		),
+	],
+};
+
+export default meta;
+
+export const UserUsage = {
+	args: {
+		scope: 'user',
+		usedBytes: 1024 ** 3 * 12.3,
+	},
+};
+
+export const SiteHosted = {
+	args: {
+		scope: 'site',
+		usedBytes: 1024 ** 4 * 4.8,
+	},
+};
+
+export const Unavailable = {
+	args: {
+		scope: 'user',
+		usedBytes: null,
+	},
+};

--- a/frontend/src/features/layout/Sidebar/storage/StorageUsage.test.jsx
+++ b/frontend/src/features/layout/Sidebar/storage/StorageUsage.test.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { StorageUsage } from './StorageUsage';
+
+vi.mock('../../../../static/js/pages/_PageStore.js', () => ({
+	default: {
+		get: vi.fn(() => ({ scope: 'user', usedBytes: 1024 ** 3 })),
+	},
+}));
+
+describe('StorageUsage', () => {
+	it('renders authenticated user usage', () => {
+		render(<StorageUsage scope="user" usedBytes={1024 ** 3 * 1.5} />);
+
+		expect(screen.getByText('Your Usage')).toBeInTheDocument();
+		expect(screen.getByText('1.5 GB')).toBeInTheDocument();
+	});
+
+	it('renders site-wide hosted storage for logged-out visitors', () => {
+		render(<StorageUsage scope="site" usedBytes={1024 ** 4 * 2} />);
+
+		expect(screen.getByText('Storage Hosted')).toBeInTheDocument();
+		expect(screen.getByText('2 TB')).toBeInTheDocument();
+	});
+
+	it('renders an unavailable state for invalid usage values', () => {
+		render(<StorageUsage scope="user" usedBytes={null} />);
+
+		expect(screen.getByText('Your Usage')).toBeInTheDocument();
+		expect(screen.getByText('Unavailable')).toBeInTheDocument();
+	});
+
+	it('does not expose quota or progressbar semantics before quotas exist', () => {
+		render(<StorageUsage scope="user" usedBytes={1024 ** 2 * 250} />);
+
+		expect(screen.queryByText(/quota/i)).not.toBeInTheDocument();
+		expect(screen.queryByText(/%/)).not.toBeInTheDocument();
+		expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+	});
+
+	it('falls back to PageStore storage config when props are omitted', () => {
+		render(<StorageUsage />);
+
+		expect(screen.getByText('Your Usage')).toBeInTheDocument();
+		expect(screen.getByText('1 GB')).toBeInTheDocument();
+	});
+});

--- a/frontend/src/features/layout/Sidebar/storage/index.js
+++ b/frontend/src/features/layout/Sidebar/storage/index.js
@@ -1,0 +1,1 @@
+export { StorageUsage } from './StorageUsage';

--- a/frontend/src/features/shared/utils/formatBytes.js
+++ b/frontend/src/features/shared/utils/formatBytes.js
@@ -1,0 +1,22 @@
+const UNITS = ['B', 'KB', 'MB', 'GB', 'TB'];
+
+function trimTrailingZeroes(value) {
+	return value.replace(/\.0+$/, '').replace(/(\.\d*[1-9])0+$/, '$1');
+}
+
+export function formatBytes(bytes, { decimals = 1 } = {}) {
+	if (bytes === null || bytes === undefined || bytes === '') return null;
+	const value = Number(bytes);
+	if (!Number.isFinite(value) || value < 0) return null;
+	if (value === 0) return '0 B';
+
+	const unitIndex = Math.min(Math.floor(Math.log(value) / Math.log(1024)), UNITS.length - 1);
+	const unitValue = value / 1024 ** unitIndex;
+
+	if (unitIndex === 0) {
+		return `${Math.round(unitValue)} ${UNITS[unitIndex]}`;
+	}
+
+	const precision = Math.max(0, decimals);
+	return `${trimTrailingZeroes(unitValue.toFixed(precision))} ${UNITS[unitIndex]}`;
+}

--- a/frontend/src/features/shared/utils/formatBytes.test.js
+++ b/frontend/src/features/shared/utils/formatBytes.test.js
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { formatBytes } from './formatBytes';
+
+describe('formatBytes', () => {
+	it('formats zero and byte values', () => {
+		expect(formatBytes(0)).toBe('0 B');
+		expect(formatBytes(512)).toBe('512 B');
+	});
+
+	it('formats binary unit boundaries', () => {
+		expect(formatBytes(1024)).toBe('1 KB');
+		expect(formatBytes(1024 ** 2)).toBe('1 MB');
+		expect(formatBytes(1024 ** 3)).toBe('1 GB');
+		expect(formatBytes(1024 ** 4)).toBe('1 TB');
+	});
+
+	it('formats fractional values with configurable decimals', () => {
+		expect(formatBytes(1536)).toBe('1.5 KB');
+		expect(formatBytes(1536, { decimals: 2 })).toBe('1.5 KB');
+		expect(formatBytes(1024 ** 3 * 12.34, { decimals: 2 })).toBe('12.34 GB');
+	});
+
+	it('returns null for missing or invalid values', () => {
+		expect(formatBytes(null)).toBeNull();
+		expect(formatBytes(undefined)).toBeNull();
+		expect(formatBytes('')).toBeNull();
+		expect(formatBytes(Number.NaN)).toBeNull();
+		expect(formatBytes(Number.POSITIVE_INFINITY)).toBeNull();
+		expect(formatBytes(-1)).toBeNull();
+	});
+});

--- a/frontend/src/static/css/tailwind.css
+++ b/frontend/src/static/css/tailwind.css
@@ -580,6 +580,7 @@ body {
 	--bg-danger-strong: var(--cinemata-red-800);
 	--bg-danger-strong-hover: var(--cinemata-red-400);
 	--bg-success: var(--cinemata-green-500);
+	--bg-success-strong: var(--cinemata-green-800);
 	--bg-warning: var(--cinemata-amber-500);
 
 	/* Text */
@@ -672,6 +673,7 @@ body.dark_theme {
 	--color-bg-danger-strong: var(--bg-danger-strong);
 	--color-bg-danger-strong-hover: var(--bg-danger-strong-hover);
 	--color-bg-success: var(--bg-success);
+	--color-bg-success-strong: var(--bg-success-strong);
 	--color-bg-warning: var(--bg-warning);
 
 	/* Text */

--- a/frontend/src/static/js/mediacms/config.js
+++ b/frontend/src/static/js/mediacms/config.js
@@ -12,6 +12,7 @@ import * as optionsPages from './optionsPages.js';
 import * as optionsEmbedded from './optionsEmbedded.js';
 import * as playlists from './playlists.js';
 import * as notifications from './notifications.js';
+import * as storage from './storage.js';
 
 let DATA = null;
 
@@ -91,6 +92,7 @@ export function config(glbl) {
 	optionsEmbedded.init(glbl.features.embeddedVideo);
 	media.init(glbl.features.mediaItem, glbl.features.media.shareOptions);
 	playlists.init(glbl.features.playlists);
+	storage.init(glbl.storage);
 
 	notifications.init(glbl.contents.notifications);
 
@@ -100,6 +102,7 @@ export function config(glbl) {
 		member: member.settings(),
 		media: media.settings(),
 		playlists: playlists.settings(),
+		storage: storage.settings(),
 		url: url.pages(),
 		api: api.endpoints(),
 		sidebar: sidebar.settings(),

--- a/frontend/src/static/js/mediacms/storage.js
+++ b/frontend/src/static/js/mediacms/storage.js
@@ -1,0 +1,29 @@
+let STORAGE = null;
+
+function normalizeScope(scope) {
+	return scope === 'user' ? 'user' : 'site';
+}
+
+function normalizeBytes(value) {
+	if (value === null || value === undefined || value === '') {
+		return null;
+	}
+	const bytes = Number(value);
+	return Number.isFinite(bytes) && bytes >= 0 ? bytes : null;
+}
+
+export function init(settings) {
+	STORAGE = {
+		scope: 'site',
+		usedBytes: null,
+	};
+
+	if (void 0 !== settings && null !== settings) {
+		STORAGE.scope = normalizeScope(settings.scope);
+		STORAGE.usedBytes = normalizeBytes(settings.used_bytes);
+	}
+}
+
+export function settings() {
+	return STORAGE;
+}

--- a/frontend/src/static/js/pages/_PageStore.js
+++ b/frontend/src/static/js/pages/_PageStore.js
@@ -249,6 +249,9 @@ class PageStore extends EventEmitter {
 			case 'config-site':
 				r = mediacms_config.site;
 				break;
+			case 'config-storage':
+				r = mediacms_config.storage;
+				break;
 			case 'api-playlists':
 				r = mediacms_api_endpoint_url(type.split('-')[1]);
 				break;

--- a/install.sh
+++ b/install.sh
@@ -119,6 +119,7 @@ fi
 
 
 python manage.py migrate
+python manage.py backfill_media_storage_usage || echo "Warning: storage usage backfill encountered errors; continuing installation."
 echo "Seeding feature flag switches..."
 if ! python manage.py seed_waffle_switches --force; then
     echo "Error: Feature flag seeding failed. Aborting installation."

--- a/restart_script.sh
+++ b/restart_script.sh
@@ -53,6 +53,7 @@ if ! python manage.py migrate; then
   echo "Database migrations failed. Aborting restart."
   exit 1
 fi
+python manage.py backfill_media_storage_usage || echo "Warning: storage usage backfill encountered errors; continuing restart."
 
 # Update ownership
 echo "Updating ownership..."

--- a/templates/config/core/storage.html
+++ b/templates/config/core/storage.html
@@ -1,0 +1,4 @@
+MediaCMS.storage = {
+	scope: "{{ STORAGE_SCOPE|default:'site'|escapejs }}",
+	used_bytes: {{ STORAGE_USED_BYTES|default_if_none:"null" }}
+};

--- a/templates/config/index.html
+++ b/templates/config/index.html
@@ -10,6 +10,7 @@
 	{% include "config/core/api.html" %}
 	{% include "config/core/url.html" %}
 	{% include "config/core/user.html" %}
+	{% include "config/core/storage.html" %}
 
 	{% include "config/installation/contents.html" %}
 	{% include "config/installation/features.html" %}

--- a/users/adapter.py
+++ b/users/adapter.py
@@ -1,12 +1,11 @@
 from allauth.account.adapter import DefaultAccountAdapter
-from allauth.mfa.utils import is_mfa_enabled
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.shortcuts import resolve_url
 from django.urls import reverse
 from django.utils.http import url_has_allowed_host_and_scheme
 
-from cms.permissions import user_requires_mfa
+from cms.permissions import is_mfa_enabled_for_user, user_requires_mfa
 from utils.security import generate_cipher, generate_key
 
 from .models import BlackListedEmail
@@ -37,7 +36,7 @@ class MyAccountAdapter(DefaultAccountAdapter):
 
     def get_login_redirect_url(self, request):
         if user_requires_mfa(request.user):
-            mfa_enabled = is_mfa_enabled(request.user)
+            mfa_enabled = is_mfa_enabled_for_user(request.user)
             if not mfa_enabled:
                 return resolve_url("/accounts/2fa/totp/activate")
             return self._get_safe_redirect_url(request)

--- a/users/admin.py
+++ b/users/admin.py
@@ -1,8 +1,14 @@
-from allauth.mfa.models import Authenticator
+from django.apps import apps
 from django.contrib import admin
+from django.contrib.admin.sites import NotRegistered
 from django.db.models import OuterRef, Subquery
 
 from .models import BlackListedEmail, User
+
+if apps.is_installed("allauth.mfa"):
+    from allauth.mfa.models import Authenticator
+else:
+    Authenticator = None
 
 
 @admin.register(BlackListedEmail)
@@ -41,9 +47,9 @@ class UserAdmin(admin.ModelAdmin):
         "is_editor",
         "is_manager",
         "is_curator",
-        "has_mfa_enabled",
-        "mfa_created_at",
     ]
+    if Authenticator:
+        list_display += ["has_mfa_enabled", "mfa_created_at"]
     list_filter = ["is_superuser", "is_editor", "is_manager", "is_curator"]
     ordering = ("-date_added",)
 
@@ -56,6 +62,8 @@ class UserAdmin(admin.ModelAdmin):
 
     def get_queryset(self, request):
         queryset = super().get_queryset(request)
+        if not Authenticator:
+            return queryset
         queryset = queryset.annotate(
             mfa_created=Subquery(
                 Authenticator.objects.filter(user=OuterRef("pk")).order_by("created_at").values("created_at")[:1]
@@ -101,67 +109,70 @@ class UserAdmin(admin.ModelAdmin):
             notify_user_on_role_update(obj, upgraded_roles)
 
 
-# unregister regular authenticator model
-admin.site.unregister(Authenticator)
+if Authenticator:
+    # unregister regular authenticator model
+    try:
+        admin.site.unregister(Authenticator)
+    except NotRegistered:
+        pass
 
+    @admin.register(Authenticator)
+    class CustomAuthenticatorAdmin(admin.ModelAdmin):
+        list_display = ("user", "type", "auth_description", "created_at", "last_used_at")
+        list_filter = ("type", "created_at", "last_used_at")
+        readonly_fields = ("type", "user", "data_masked", "created_at", "last_used_at")
+        exclude = ("data",)  # Hide the raw data field
 
-@admin.register(Authenticator)
-class CustomAuthenticatorAdmin(admin.ModelAdmin):
-    list_display = ("user", "type", "auth_description", "created_at", "last_used_at")
-    list_filter = ("type", "created_at", "last_used_at")
-    readonly_fields = ("type", "user", "data_masked", "created_at", "last_used_at")
-    exclude = ("data",)  # Hide the raw data field
+        def get_fields(self, request, obj=None):
+            """Ensure 'data' field is not directly editable"""
+            fields = super().get_fields(request, obj)
+            if "data" in fields:
+                fields.remove("data")
+            return fields
 
-    def get_fields(self, request, obj=None):
-        """Ensure 'data' field is not directly editable"""
-        fields = super().get_fields(request, obj)
-        if "data" in fields:
-            fields.remove("data")
-        return fields
+        @admin.display(description="Authentication Method")
+        def auth_description(self, obj):
+            """Display a meaningful name for the authenticator without revealing secrets"""
+            if obj.type == obj.Type.WEBAUTHN:
+                return f"WebAuthn: {obj.wrap().name}"
+            elif obj.type == obj.Type.TOTP:
+                return "Authenticator App"
+            elif obj.type == obj.Type.RECOVERY_CODES:
+                # Show count of unused codes without revealing the codes themselves
+                unused_count = len(obj.wrap().get_unused_codes())
+                return f"Recovery Codes ({unused_count} remaining)"
+            return obj.get_type_display()
 
-    @admin.display(description="Authentication Method")
-    def auth_description(self, obj):
-        """Display a meaningful name for the authenticator without revealing secrets"""
-        if obj.type == obj.Type.WEBAUTHN:
-            return f"WebAuthn: {obj.wrap().name}"
-        elif obj.type == obj.Type.TOTP:
-            return "Authenticator App"
-        elif obj.type == obj.Type.RECOVERY_CODES:
-            # Show count of unused codes without revealing the codes themselves
-            unused_count = len(obj.wrap().get_unused_codes())
-            return f"Recovery Codes ({unused_count} remaining)"
-        return obj.get_type_display()
+        @admin.display(description="Protected Data")
+        def data_masked(self, obj):
+            """Display a masked version of the data"""
+            if obj.type == obj.Type.WEBAUTHN:
+                # For WebAuthn, only show name and creation data
+                name = obj.wrap().name
+                has_credential = "credential" in obj.data
+                return f"Name: {name}, Has credential data: {'Yes' if has_credential else 'No'}"
 
-    @admin.display(description="Protected Data")
-    def data_masked(self, obj):
-        """Display a masked version of the data"""
-        if obj.type == obj.Type.WEBAUTHN:
-            # For WebAuthn, only show name and creation data
-            name = obj.wrap().name
-            has_credential = "credential" in obj.data
-            return f"Name: {name}, Has credential data: {'Yes' if has_credential else 'No'}"
+            elif obj.type == obj.Type.TOTP:
+                # For TOTP, just indicate secret exists but don't show it
+                has_secret = "secret" in obj.data
+                return f"TOTP secret: {'[ENCRYPTED]' if has_secret else 'None'}"
 
-        elif obj.type == obj.Type.TOTP:
-            # For TOTP, just indicate secret exists but don't show it
-            has_secret = "secret" in obj.data
-            return f"TOTP secret: {'[ENCRYPTED]' if has_secret else 'None'}"
+            elif obj.type == obj.Type.RECOVERY_CODES:
+                # For recovery codes, show count and usage status
+                seed = obj.data.get("seed", None)
+                unused_count = len(obj.wrap().get_unused_codes())
+                total_count = 0
 
-        elif obj.type == obj.Type.RECOVERY_CODES:
-            # For recovery codes, show count and usage status
-            seed = obj.data.get("seed", None)
-            unused_count = len(obj.wrap().get_unused_codes())
-            total_count = 0
+                # Try to determine total recovery code count
+                from allauth.mfa import app_settings as mfa_settings
 
-            # Try to determine total recovery code count
-            from allauth.mfa import app_settings as mfa_settings
+                total_count = mfa_settings.RECOVERY_CODE_COUNT
 
-            total_count = mfa_settings.RECOVERY_CODE_COUNT
+                return f"Unused codes: {unused_count}/{total_count}\nSeed: {'[ENCRYPTED]' if seed else 'None'}"
 
-            return f"Unused codes: {unused_count}/{total_count}\nSeed: {'[ENCRYPTED]' if seed else 'None'}"
-
-        # Generic fallback
-        data_keys = list(obj.data.keys())
-        return f"Keys: {', '.join(data_keys)}"
+            # Generic fallback
+            data_keys = list(obj.data.keys())
+            return f"Keys: {', '.join(data_keys)}"
 
 
 # is_superuser: global site administrator

--- a/users/forms.py
+++ b/users/forms.py
@@ -1,8 +1,7 @@
 import logging
 
-from allauth.mfa.base.forms import AuthenticateForm
-from allauth.mfa.totp.forms import ActivateTOTPForm
 from django import forms
+from django.apps import apps
 from django.utils.translation import gettext_lazy as _
 from kombu.exceptions import OperationalError
 
@@ -12,6 +11,13 @@ from files.tasks import subscribe_user
 from .models import Channel, User
 
 logger = logging.getLogger(__name__)
+
+if apps.is_installed("allauth.mfa"):
+    from allauth.mfa.base.forms import AuthenticateForm
+    from allauth.mfa.totp.forms import ActivateTOTPForm
+else:
+    AuthenticateForm = forms.Form
+    ActivateTOTPForm = forms.Form
 
 
 class CustomAuthenticateForm(AuthenticateForm):

--- a/users/middleware.py
+++ b/users/middleware.py
@@ -1,7 +1,6 @@
-from allauth.mfa.utils import is_mfa_enabled
 from django.http import HttpResponseRedirect
 
-from cms.permissions import should_enforce_mfa_on_path, user_requires_mfa
+from cms.permissions import is_mfa_enabled_for_user, should_enforce_mfa_on_path, user_requires_mfa
 
 
 class AdminMFAMiddleware:
@@ -13,7 +12,7 @@ class AdminMFAMiddleware:
             if not request.user.is_authenticated:
                 return HttpResponseRedirect("/accounts/login/")
             if user_requires_mfa(request.user):
-                if not is_mfa_enabled(request.user):
+                if not is_mfa_enabled_for_user(request.user):
                     return HttpResponseRedirect("/accounts/2fa/totp/activate")
 
         response = self.get_response(request)


### PR DESCRIPTION
## Description
Adds a storage usage indicator to the modern sidebar. Shows how much disk space the current user's media occupies and the total site-wide usage, displayed as plain human-readable byte strings.

## Related Issue
Fixes #628

## Motivation and Context
Users have no visibility into how much storage their uploads consume. This gives them a quick at-a-glance summary directly in the sidebar without requiring a separate settings page visit. No quota enforcement — display only.

## How Has This Been Tested?
- Frontend unit tests: `npm run test:run -- StorageUsage.test.jsx formatBytes.test.js` — passed
- Django storage tests: `python manage.py test files.tests.test_storage_usage --settings=cms.dev_settings`
- Manually verified config plumbing: storage values exposed via context processor → template → JS config → React component
- Manually verified that `schedule_refresh_media_storage_usage` enqueues to the `short_tasks` queue instead of running inline on the request path

## Deployment / Post-Merge Checklist

After merging this PR to a deployed environment, the following steps must run **in order**:

1. **Run migrations** — adds the `storage_usage_bytes` column to `files_media` (`0024_media_storage_usage_bytes`).
   ```bash
   python manage.py migrate
   ```
   Safe under load on Postgres 11+ (metadata-only, no table rewrite).

2. **Backfill storage usage for existing rows** — without this, every existing Media row reads `0` and the site/user totals will be understated until the backfill completes.
   ```bash
   python manage.py backfill_media_storage_usage
   ```
   This is already wired into `restart_script.sh` and `install.sh` (non-fatal), so a normal deploy via those scripts will run it automatically. If migrations are applied manually, run this command explicitly afterwards.

3. **Restart Celery workers** — `short_tasks` workers must pick up the new `refresh_media_storage_usage` task. The systemd unit `celery_short` is restarted by `restart_script.sh`.

4. **(Optional) Clear storage usage cache** — if you want totals to repopulate immediately rather than waiting for the next signal-driven invalidation:
   ```bash
   python manage.py shell -c "from django.core.cache import cache; cache.delete('storage_usage:site')"
   ```

## Notes for Reviewers
- `schedule_refresh_media_storage_usage` now enqueues a Celery task (`refresh_media_storage_usage` on `short_tasks`) inside `transaction.on_commit`, so the filesystem walk (HLS directory + per-encoding/subtitle stat) is off the web request path.
- `STORAGE_USAGE_CACHE_TIMEOUT` raised from 60s to 6h — storage totals are display-only and do not need near-real-time freshness; explicit invalidation still runs on each refresh.
- `allauth.mfa`, `notifications`, and `waffle` were removed from `cms/dev_settings.py` `INSTALLED_APPS` (they are unrelated to this PR and were added by mistake). Runtime call sites now lazy-import via `apps.is_installed(...)` so the app still boots without them.

## Screenshots (if appropriate):
### Non-logged in 
<img width="257" height="1012" alt="image" src="https://github.com/user-attachments/assets/d0d9c9f6-fc22-48b7-b945-c2e4271d3628" />

### Logged in
<img width="242" height="946" alt="image" src="https://github.com/user-attachments/assets/e220e9c6-ac68-4862-a6d2-9f545af01368" />


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):
- [x] I have not imported `flux` in a new component
- [x] If adding a new feature, I used Modern Track patterns
- [x] New features do not create new SCSS files (use Tailwind instead)