### PR TITLE
fix: preserve player controls and edit form contrast

### DIFF
--- a/frontend/src/features/home/components/HeroVideoPlayer.css
+++ b/frontend/src/features/home/components/HeroVideoPlayer.css
@@ -1,4 +1,4 @@
-.video-js.vjs-mediacms.vjs-hero-player {
+.cinemata-hero-legacy-player .video-js.vjs-mediacms {
 	--hero-play-circle-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 106 106'%3E%3Cpath fill='%23000' fill-rule='evenodd' d='M52.8125 0C42.3672 0 32.1564 3.0974 23.4715 8.90051C14.7865 14.7036 8.01739 22.9518 4.02014 32.602C0.0228828 42.2523 -1.02298 52.8711 1.0148 63.1157C3.05258 73.3603 8.08249 82.7706 15.4684 90.1566C22.8544 97.5425 32.2647 102.572 42.5093 104.61C52.7539 106.648 63.3728 105.602 73.023 101.605C82.6732 97.6076 90.9214 90.8385 96.7245 82.1535C102.528 73.4686 105.625 63.2578 105.625 52.8125C105.61 38.8103 100.041 25.3858 90.1403 15.4848C80.2392 5.58369 66.8147 0.0147866 52.8125 0ZM73.4043 56.1539L46.9981 74.4352C46.3885 74.8567 45.6751 75.1034 44.9354 75.1486C44.1956 75.1939 43.4575 75.0358 42.8011 74.6917C42.1447 74.3475 41.5949 73.8303 41.2114 73.1961C40.8278 72.562 40.625 71.8349 40.625 71.0938V34.5312C40.625 33.7901 40.8278 33.063 41.2114 32.4289C41.5949 31.7947 42.1447 31.2775 42.8011 30.9333C43.4575 30.5892 44.1956 30.4311 44.9354 30.4764C45.6751 30.5216 46.3885 30.7683 46.9981 31.1898L73.4043 49.4711C73.9448 49.8448 74.3866 50.3441 74.6917 50.9261C74.9968 51.5081 75.1562 52.1554 75.1562 52.8125C75.1562 53.4696 74.9968 54.1169 74.6917 54.6989C74.3866 55.2809 73.9448 55.7802 73.4043 56.1539Z'/%3E%3C/svg%3E");
 
 	position: absolute !important;
@@ -15,17 +15,17 @@
 	aspect-ratio: auto;
 }
 
-.video-js.vjs-mediacms.vjs-hero-player.vjs-fluid:not(.vjs-audio-only-mode),
-.video-js.vjs-mediacms.vjs-hero-player.vjs-16-9:not(.vjs-audio-only-mode),
-.video-js.vjs-mediacms.vjs-hero-player.vjs-4-3:not(.vjs-audio-only-mode),
-.video-js.vjs-mediacms.vjs-hero-player.vjs-9-16:not(.vjs-audio-only-mode),
-.video-js.vjs-mediacms.vjs-hero-player.vjs-1-1:not(.vjs-audio-only-mode) {
+.cinemata-hero-legacy-player .video-js.vjs-mediacms.vjs-fluid:not(.vjs-audio-only-mode),
+.cinemata-hero-legacy-player .video-js.vjs-mediacms.vjs-16-9:not(.vjs-audio-only-mode),
+.cinemata-hero-legacy-player .video-js.vjs-mediacms.vjs-4-3:not(.vjs-audio-only-mode),
+.cinemata-hero-legacy-player .video-js.vjs-mediacms.vjs-9-16:not(.vjs-audio-only-mode),
+.cinemata-hero-legacy-player .video-js.vjs-mediacms.vjs-1-1:not(.vjs-audio-only-mode) {
 	height: 100% !important;
 	padding-top: 0 !important;
 }
 
-.video-js.vjs-mediacms.vjs-hero-player .vjs-tech,
-.video-js.vjs-mediacms.vjs-hero-player video {
+.cinemata-hero-legacy-player .video-js.vjs-mediacms .vjs-tech,
+.cinemata-hero-legacy-player .video-js.vjs-mediacms video {
 	position: absolute;
 	inset: 0;
 	width: 100% !important;
@@ -36,7 +36,7 @@
 	object-fit: contain;
 }
 
-.video-js.vjs-mediacms.vjs-hero-player .vjs-big-play-button {
+.cinemata-hero-legacy-player .video-js.vjs-mediacms .vjs-big-play-button {
 	width: 72px !important;
 	height: 72px !important;
 	top: auto !important;
@@ -54,13 +54,13 @@
 	line-height: 1 !important;
 }
 
-.video-js.vjs-mediacms.vjs-hero-player .vjs-big-play-button .vjs-icon-placeholder {
+.cinemata-hero-legacy-player .video-js.vjs-mediacms .vjs-big-play-button .vjs-icon-placeholder {
 	position: absolute;
 	inset: 0;
 	display: block;
 }
 
-.video-js.vjs-mediacms.vjs-hero-player .vjs-big-play-button .vjs-icon-placeholder::before {
+.cinemata-hero-legacy-player .video-js.vjs-mediacms .vjs-big-play-button .vjs-icon-placeholder::before {
 	content: '' !important;
 	position: absolute;
 	inset: 9.375%;
@@ -76,29 +76,29 @@
 	mask-size: contain;
 }
 
-.video-js.vjs-mediacms.vjs-hero-player .vjs-big-play-button:hover,
-.video-js.vjs-mediacms.vjs-hero-player .vjs-big-play-button:focus {
+.cinemata-hero-legacy-player .video-js.vjs-mediacms .vjs-big-play-button:hover,
+.cinemata-hero-legacy-player .video-js.vjs-mediacms .vjs-big-play-button:focus {
 	background: transparent !important;
 	transform: none !important;
 }
 
-.video-js.vjs-mediacms.vjs-hero-player .vjs-big-play-button:hover .vjs-icon-placeholder::before,
-.video-js.vjs-mediacms.vjs-hero-player .vjs-big-play-button:focus .vjs-icon-placeholder::before {
+.cinemata-hero-legacy-player .video-js.vjs-mediacms .vjs-big-play-button:hover .vjs-icon-placeholder::before,
+.cinemata-hero-legacy-player .video-js.vjs-mediacms .vjs-big-play-button:focus .vjs-icon-placeholder::before {
 	background-color: var(--site-player-progress-color) !important;
 }
 
-.video-js.vjs-mediacms.vjs-hero-player .vjs-big-play-button:focus-visible {
+.cinemata-hero-legacy-player .video-js.vjs-mediacms .vjs-big-play-button:focus-visible {
 	outline: 2px solid var(--site-player-control-color);
 	outline-offset: 4px;
 }
 
-.video-js.vjs-mediacms.vjs-hero-player .vjs-control-bar,
-.video-js.vjs-mediacms.vjs-hero-player .vjs-control,
-.video-js.vjs-mediacms.vjs-hero-player .vjs-time-control {
+.cinemata-hero-legacy-player .video-js.vjs-mediacms .vjs-control-bar,
+.cinemata-hero-legacy-player .video-js.vjs-mediacms .vjs-control,
+.cinemata-hero-legacy-player .video-js.vjs-mediacms .vjs-time-control {
 	color: var(--site-player-control-color) !important;
 }
 
-.video-js.vjs-mediacms.vjs-hero-player .vjs-control-bar {
+.cinemata-hero-legacy-player .video-js.vjs-mediacms .vjs-control-bar {
 	right: 12px !important;
 	left: 12px !important;
 	width: auto !important;
@@ -108,7 +108,7 @@
 	text-shadow: 0 1px 3px var(--site-player-shadow-color);
 }
 
-.video-js.vjs-mediacms.vjs-hero-player .vjs-bottom-bg {
+.cinemata-hero-legacy-player .video-js.vjs-mediacms .vjs-bottom-bg {
 	right: -12px !important;
 	left: -12px !important;
 	height: 36px;
@@ -116,88 +116,94 @@
 	background: linear-gradient(to bottom, transparent, var(--site-player-control-surface-color));
 }
 
-.video-js.vjs-mediacms.vjs-hero-player .vjs-progress-control {
+.cinemata-hero-legacy-player .video-js.vjs-mediacms .vjs-progress-control {
 	top: -0.3em;
 }
 
-.video-js.vjs-mediacms.vjs-hero-player .vjs-progress-holder {
+.cinemata-hero-legacy-player .video-js.vjs-mediacms .vjs-progress-holder {
 	height: 0.3em !important;
 	box-shadow: 0 1px 0 color-mix(in srgb, var(--site-player-control-color) 12%, transparent);
 }
 
-.video-js.vjs-mediacms.vjs-hero-player .vjs-button:hover,
-.video-js.vjs-mediacms.vjs-hero-player .vjs-button:focus {
+.cinemata-hero-legacy-player .video-js.vjs-mediacms .vjs-button:hover,
+.cinemata-hero-legacy-player .video-js.vjs-mediacms .vjs-button:focus {
 	color: var(--site-player-progress-color) !important;
 }
 
-.video-js.vjs-mediacms.vjs-hero-player .vjs-slider,
-.video-js.vjs-mediacms.vjs-hero-player .vjs-progress-holder,
-.video-js.vjs-mediacms.vjs-hero-player .vjs-volume-bar {
+.cinemata-hero-legacy-player .video-js.vjs-mediacms .vjs-slider,
+.cinemata-hero-legacy-player .video-js.vjs-mediacms .vjs-progress-holder,
+.cinemata-hero-legacy-player .video-js.vjs-mediacms .vjs-volume-bar {
 	background-color: var(--site-player-track-color) !important;
 }
 
-.video-js.vjs-mediacms.vjs-hero-player .vjs-load-progress,
-.video-js.vjs-mediacms.vjs-hero-player .vjs-load-progress div {
+.cinemata-hero-legacy-player .video-js.vjs-mediacms .vjs-load-progress,
+.cinemata-hero-legacy-player .video-js.vjs-mediacms .vjs-load-progress div {
 	background-color: var(--site-player-loaded-color) !important;
 }
 
-.video-js.vjs-mediacms.vjs-hero-player .vjs-play-progress,
-.video-js.vjs-mediacms.vjs-hero-player .vjs-volume-level {
+.cinemata-hero-legacy-player .video-js.vjs-mediacms .vjs-play-progress,
+.cinemata-hero-legacy-player .video-js.vjs-mediacms .vjs-volume-level {
 	background-color: var(--site-player-progress-color) !important;
 }
 
-.video-js.vjs-mediacms.vjs-hero-player .vjs-play-progress::before,
-.video-js.vjs-mediacms.vjs-hero-player .vjs-volume-level::before {
+.cinemata-hero-legacy-player .video-js.vjs-mediacms .vjs-play-progress::before,
+.cinemata-hero-legacy-player .video-js.vjs-mediacms .vjs-volume-level::before {
 	color: var(--site-player-progress-color) !important;
 }
 
-.video-js.vjs-mediacms.vjs-hero-player.vjs-subtitles-on .vjs-subtitles-control .vjs-icon-placeholder::after {
+.cinemata-hero-legacy-player
+	.video-js.vjs-mediacms.vjs-subtitles-on
+	.vjs-subtitles-control
+	.vjs-icon-placeholder::after {
 	background-color: var(--site-player-progress-color) !important;
 }
 
-.video-js.vjs-mediacms.vjs-hero-player .vjs-settings-menu-item.vjs-selected-menu-item,
-.video-js.vjs-mediacms.vjs-hero-player .vjs-settings-menu-item.vjs-selected-quality,
-.video-js.vjs-mediacms.vjs-hero-player .vjs-settings-menu-item.vjs-selected-speed {
+.cinemata-hero-legacy-player .video-js.vjs-mediacms .vjs-settings-menu-item.vjs-selected-menu-item,
+.cinemata-hero-legacy-player .video-js.vjs-mediacms .vjs-settings-menu-item.vjs-selected-quality,
+.cinemata-hero-legacy-player .video-js.vjs-mediacms .vjs-settings-menu-item.vjs-selected-speed {
 	color: var(--site-player-control-color) !important;
 }
 
-.video-js.vjs-mediacms.vjs-hero-player
+.cinemata-hero-legacy-player
+	.video-js.vjs-mediacms
 	.vjs-settings-menu-item.vjs-selected-menu-item
 	.vjs-setting-menu-item-content::before,
-.video-js.vjs-mediacms.vjs-hero-player
+.cinemata-hero-legacy-player
+	.video-js.vjs-mediacms
 	.vjs-settings-menu-item.vjs-selected-quality
 	.vjs-setting-menu-item-content::after,
-.video-js.vjs-mediacms.vjs-hero-player
+.cinemata-hero-legacy-player
+	.video-js.vjs-mediacms
 	.vjs-settings-menu-item.vjs-selected-speed
 	.vjs-setting-menu-item-content::after {
 	color: var(--site-player-progress-color) !important;
 }
 
-.video-js.vjs-mediacms.vjs-hero-player .vjs-time-tooltip,
-.video-js.vjs-mediacms.vjs-hero-player .vjs-mouse-display .vjs-time-tooltip,
-.video-js.vjs-mediacms.vjs-hero-player .vjs-play-progress .vjs-time-tooltip {
+.cinemata-hero-legacy-player .video-js.vjs-mediacms .vjs-time-tooltip,
+.cinemata-hero-legacy-player .video-js.vjs-mediacms .vjs-mouse-display .vjs-time-tooltip,
+.cinemata-hero-legacy-player .video-js.vjs-mediacms .vjs-play-progress .vjs-time-tooltip {
 	background-color: var(--site-player-tooltip-bg-color) !important;
 	color: var(--site-player-control-color) !important;
 }
 
-.video-js.vjs-mediacms.vjs-hero-player .vjs-text-track-display {
+.cinemata-hero-legacy-player .video-js.vjs-mediacms .vjs-text-track-display {
 	color: var(--site-player-subtitle-color) !important;
 	text-shadow: 0 2px 4px var(--site-player-canvas-color);
 }
 
-.video-js.vjs-mediacms.vjs-hero-player .vjs-text-track-cue {
+.cinemata-hero-legacy-player .video-js.vjs-mediacms .vjs-text-track-cue {
 	background-color: transparent !important;
 	color: var(--site-player-subtitle-color) !important;
 }
 
-.video-js.vjs-mediacms.vjs-hero-player .vjs-text-track-cue > * {
+.cinemata-hero-legacy-player .video-js.vjs-mediacms .vjs-text-track-cue > * {
 	border-radius: 4px;
 	background-color: var(--site-player-subtitle-bg-color) !important;
 	color: var(--site-player-subtitle-color) !important;
 }
 
 @media screen and (width <= 640px) {
-	.video-js.vjs-mediacms.vjs-hero-player .vjs-big-play-button {
+	.cinemata-hero-legacy-player .video-js.vjs-mediacms .vjs-big-play-button {
 		width: 48px !important;
 		height: 48px !important;
 		bottom: 24px !important;

--- a/frontend/src/features/home/components/HeroVideoPlayer.jsx
+++ b/frontend/src/features/home/components/HeroVideoPlayer.jsx
@@ -1,153 +1,58 @@
-/**
- * React wrapper around the @mediacms/media-player VideoJS class.
- */
-import { useRef, useEffect, useState } from 'react';
-import 'video.js/dist/video-js.css';
-import videojs from 'video.js/dist/video.es.js';
-import '@mediacms/media-player/dist/mediacms-media-player.css';
+import { VideoPlayer } from '../../../static/js/components/-NEW-/VideoPlayer.js';
 import './HeroVideoPlayer.css';
 
 const DEFAULT_PLAYER_CLASS = 'relative w-full aspect-video rounded-[6px] overflow-hidden bg-site-player-canvas';
-let mediaPlayerClassPromise;
+const EMPTY_SUBTITLES = [];
 
-function getVideoJsPlayer(videoElement) {
-	if (!videoElement) return null;
-	return videojs.getPlayer?.(videoElement) ?? videojs(videoElement);
+function getSiteSettings() {
+	const site = globalThis.MediaCMS?.site ?? {};
+	const fallbackUrl = globalThis.location?.origin ?? '';
+
+	return {
+		id: String(site.id ?? site.site_id ?? 'cinemata'),
+		url: String(site.url ?? fallbackUrl),
+	};
 }
 
-function loadMediaPlayerClass() {
-	globalThis.videojs = videojs;
-
-	if (!mediaPlayerClassPromise) {
-		mediaPlayerClassPromise = import('@mediacms/media-player')
-			.then(({ default: MediaPlayerClass }) => MediaPlayerClass)
-			.catch((error) => {
-				mediaPlayerClassPromise = undefined;
-				throw error;
-			});
-	}
-
-	return mediaPlayerClassPromise;
+function getSubtitlesInfo(subtitles) {
+	return Array.isArray(subtitles?.languages) ? subtitles.languages : EMPTY_SUBTITLES;
 }
 
 export default function HeroVideoPlayer({
 	sources = [],
 	videoInfo = {},
 	poster = '',
-	preload = 'metadata',
 	subtitles = {},
 	className = DEFAULT_PLAYER_CLASS,
 }) {
-	const videoRef = useRef(null);
-	const playerRef = useRef(null);
-	const latestConfigRef = useRef({ sources, videoInfo, poster, preload, subtitles });
-	const [playerReadyVersion, setPlayerReadyVersion] = useState(0);
-	const sourcesKey = JSON.stringify(sources);
-	latestConfigRef.current = { sources, videoInfo, poster, preload, subtitles };
-
-	// Player instances are created once per mounted media item; HeroSection remounts this boundary when media changes.
-	useEffect(() => {
-		if (!videoRef.current || playerRef.current) {
-			return;
-		}
-
-		const videoElement = videoRef.current;
-		let isCancelled = false;
-
-		loadMediaPlayerClass().then((MediaPlayerClass) => {
-			if (isCancelled || !videoElement.isConnected || playerRef.current) {
-				return;
-			}
-
-			const {
-				sources: currentSources,
-				videoInfo: currentVideoInfo,
-				poster: currentPoster,
-				preload: currentPreload,
-				subtitles: currentSubtitles,
-			} = latestConfigRef.current;
-			const subtitleLanguages = Array.isArray(currentSubtitles?.languages) ? currentSubtitles.languages : [];
-			const playerOptions = {
-				enabledTouchControls: true,
-				sources: currentSources,
-				poster: currentPoster,
-				autoplay: false,
-				preload: currentPreload,
-				bigPlayButton: true,
-				controlBar: {
-					theaterMode: false,
-					pictureInPicture: false,
-					next: false,
-					previous: false,
-				},
-				subtitles: {
-					on: subtitleLanguages.length > 0,
-					languages: subtitleLanguages,
-				},
-				cornerLayers: {},
-				videoPreviewThumb: {},
-				vhsOptions: {
-					useBandwidthFromLocalStorage: false,
-					enableLowInitialPlaylist: true,
-					limitRenditionByPlayerDimensions: true,
-					useDevicePixelRatio: true,
-					handlePartialData: true,
-					maxPlaylistRetries: 2,
-					playlistExclusionDuration: 60,
-					withCredentials: true,
-				},
-			};
-
-			playerRef.current = new MediaPlayerClass(
-				videoElement,
-				playerOptions,
-				{
-					volume: 1,
-					soundMuted: false,
-					theaterMode: false,
-					theSelectedQuality: undefined,
-					theSelectedPlaybackSpeed: 1,
-				},
-				currentVideoInfo,
-				[0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2],
-				null,
-				null,
-				null
-			);
-			setPlayerReadyVersion((version) => version + 1);
-		});
-
-		return () => {
-			isCancelled = true;
-			if (playerRef.current?.dispose) {
-				playerRef.current.dispose();
-			} else {
-				videojs.getPlayer?.(videoElement)?.dispose();
-			}
-			playerRef.current = null;
-		};
-	}, []);
-
-	useEffect(() => {
-		if (!playerRef.current) return;
-		const player = getVideoJsPlayer(videoRef.current);
-		if (!player) return;
-
-		player.poster(poster || '');
-		player.preload(preload);
-		player.src(sources);
-	}, [poster, preload, sourcesKey, playerReadyVersion]);
+	const site = getSiteSettings();
 
 	return (
 		<div className={className || DEFAULT_PLAYER_CLASS}>
-			<video
-				ref={videoRef}
-				className="video-js vjs-mediacms vjs-hero-player vjs-fill h-full w-full"
-				style={{ width: '100%', height: '100%' }}
-				poster={poster}
-				preload={preload}
-				playsInline
-			/>
+			<div className="cinemata-hero-legacy-player video-player h-full w-full">
+				<VideoPlayer
+					playerVolume="1"
+					playerSoundMuted={false}
+					videoQuality="Auto"
+					videoPlaybackSpeed={1}
+					inTheaterMode={false}
+					siteId={site.id}
+					siteUrl={site.url}
+					info={videoInfo}
+					cornerLayers={{}}
+					sources={sources}
+					poster={poster}
+					previewSprite={null}
+					subtitlesInfo={getSubtitlesInfo(subtitles)}
+					enableAutoplay={false}
+					inEmbed={true}
+					hasTheaterMode={false}
+					hasNextLink={false}
+					hasPreviousLink={false}
+					errorMessage={null}
+					debug={false}
+				/>
+			</div>
 		</div>
 	);
 }

--- a/frontend/src/features/home/components/HeroVideoPlayer.test.jsx
+++ b/frontend/src/features/home/components/HeroVideoPlayer.test.jsx
@@ -1,56 +1,37 @@
-import { cleanup, render, waitFor } from '@testing-library/react';
+import { cleanup, render, screen } from '@testing-library/react';
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import HeroVideoPlayer from './HeroVideoPlayer';
 
-const mediaPlayerImportState = vi.hoisted(() => ({ videojs: undefined }));
-const mediaPlayerDisposeMock = vi.hoisted(() => vi.fn());
-const mediaPlayerMock = vi.hoisted(() =>
-	vi.fn(function MediaPlayerMock() {
-		this.dispose = mediaPlayerDisposeMock;
-		this.player = { dispose: vi.fn() };
+const videoPlayerMock = vi.hoisted(() =>
+	vi.fn(function VideoPlayerMock(props) {
+		return (
+			<div
+				data-testid="legacy-video-player"
+				data-site-id={props.siteId}
+				data-site-url={props.siteUrl}
+				data-sources={JSON.stringify(props.sources)}
+				data-video-info={JSON.stringify(props.info)}
+				data-subtitles={JSON.stringify(props.subtitlesInfo)}
+				data-enable-autoplay={String(props.enableAutoplay)}
+				data-in-embed={String(props.inEmbed)}
+				data-has-theater-mode={String(props.hasTheaterMode)}
+			/>
+		);
 	})
 );
-const videoJsPlayerMock = vi.hoisted(() => ({
-	poster: vi.fn(),
-	preload: vi.fn(),
-	src: vi.fn(),
-	dispose: vi.fn(),
-}));
-const videojsMock = vi.hoisted(() => {
-	const fn = vi.fn(() => videoJsPlayerMock);
-	fn.getPlayer = vi.fn(() => videoJsPlayerMock);
-	return fn;
-});
 
-vi.mock('@mediacms/media-player', () => {
-	mediaPlayerImportState.videojs = globalThis.videojs;
-	return { default: mediaPlayerMock };
-});
-vi.mock('video.js/dist/video.es.js', () => ({ default: videojsMock }));
+vi.mock('../../../static/js/components/-NEW-/VideoPlayer.js', () => ({
+	VideoPlayer: videoPlayerMock,
+}));
 
 describe('HeroVideoPlayer', () => {
 	afterEach(() => {
 		cleanup();
-		mediaPlayerMock.mockClear();
-		mediaPlayerDisposeMock.mockClear();
-		videojsMock.mockClear();
-		videojsMock.getPlayer.mockClear();
-		videoJsPlayerMock.poster.mockClear();
-		videoJsPlayerMock.preload.mockClear();
-		videoJsPlayerMock.src.mockClear();
-		videoJsPlayerMock.dispose.mockClear();
+		videoPlayerMock.mockClear();
+		delete globalThis.MediaCMS;
 	});
 
-	it('sets global videojs before importing the MediaCMS player package', async () => {
-		render(<HeroVideoPlayer sources={[{ src: '/media/video.mp4', type: 'video/mp4' }]} />);
-
-		await waitFor(() => expect(mediaPlayerMock).toHaveBeenCalledTimes(1));
-
-		expect(globalThis.videojs).toBe(videojsMock);
-		expect(mediaPlayerImportState.videojs).toBe(videojsMock);
-	});
-
-	it('initializes the MediaCMS player with the proven legacy player option shape', async () => {
+	it('delegates to the legacy MediaCMS VideoPlayer with hero-safe playback options', () => {
 		const sources = [{ src: '/media/video.mp4?v=1', type: 'video/mp4' }];
 		const videoInfo = { 360: { format: ['h264'], url: ['/media/video.mp4?v=1'] } };
 		const subtitles = {
@@ -62,202 +43,91 @@ describe('HeroVideoPlayer', () => {
 				sources={sources}
 				videoInfo={videoInfo}
 				poster="/media/poster.jpg"
-				preload="none"
 				subtitles={subtitles}
+				className="hero-frame"
 			/>
 		);
 
-		await waitFor(() => expect(mediaPlayerMock).toHaveBeenCalledTimes(1));
-
-		const [videoNode, options, state, receivedVideoInfo] = mediaPlayerMock.mock.calls[0];
-		expect(videoNode.tagName).toBe('VIDEO');
-		expect(videoNode).toHaveClass('vjs-fill');
-		expect(container.querySelector('source')).toBeNull();
-		expect(options).toMatchObject({
-			enabledTouchControls: true,
-			sources,
-			poster: '/media/poster.jpg',
-			autoplay: false,
-			preload: 'none',
-			bigPlayButton: true,
-			controlBar: {
-				theaterMode: false,
-				pictureInPicture: false,
-				next: false,
-				previous: false,
-			},
-			subtitles: {
-				on: true,
-				languages: subtitles.languages,
-			},
-		});
-		expect(state).toMatchObject({
-			volume: 1,
-			soundMuted: false,
-			theaterMode: false,
-			theSelectedPlaybackSpeed: 1,
-		});
-		expect(receivedVideoInfo).toBe(videoInfo);
+		const player = screen.getByTestId('legacy-video-player');
+		expect(container.firstElementChild).toHaveClass('hero-frame');
+		expect(player.closest('.cinemata-hero-legacy-player')).toBeInTheDocument();
+		expect(JSON.parse(player.dataset.sources)).toEqual(sources);
+		expect(JSON.parse(player.dataset.videoInfo)).toEqual(videoInfo);
+		expect(JSON.parse(player.dataset.subtitles)).toEqual(subtitles.languages);
+		expect(player).toHaveAttribute('data-enable-autoplay', 'false');
+		expect(player).toHaveAttribute('data-in-embed', 'true');
+		expect(player).toHaveAttribute('data-has-theater-mode', 'false');
+		expect(videoPlayerMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				playerVolume: '1',
+				playerSoundMuted: false,
+				videoQuality: 'Auto',
+				videoPlaybackSpeed: 1,
+				inTheaterMode: false,
+				poster: '/media/poster.jpg',
+				cornerLayers: {},
+				previewSprite: null,
+				hasNextLink: false,
+				hasPreviousLink: false,
+				errorMessage: null,
+				debug: false,
+			}),
+			undefined
+		);
 	});
 
-	it('keeps MediaCMS touch controls enabled for tap-to-pause on mobile', async () => {
+	it('uses MediaCMS site settings when the page boot payload provides them', () => {
+		globalThis.MediaCMS = { site: { id: 'cinemata-site', url: 'https://cinemata.test' } };
+
 		render(<HeroVideoPlayer sources={[{ src: '/media/video.mp4', type: 'video/mp4' }]} />);
 
-		await waitFor(() => expect(mediaPlayerMock).toHaveBeenCalledTimes(1));
-
-		const [, options] = mediaPlayerMock.mock.calls[0];
-		expect(options.enabledTouchControls).toBe(true);
+		const player = screen.getByTestId('legacy-video-player');
+		expect(player).toHaveAttribute('data-site-id', 'cinemata-site');
+		expect(player).toHaveAttribute('data-site-url', 'https://cinemata.test');
 	});
 
-	it('updates the VideoJS source when sources change after mount', async () => {
-		const initialSources = [{ src: '/media/initial.mp4', type: 'video/mp4' }];
-		const nextSources = [{ src: '/media/next.mp4', type: 'video/mp4' }];
-
-		const { rerender } = render(<HeroVideoPlayer sources={initialSources} poster="/media/poster.jpg" />);
-		await waitFor(() => expect(mediaPlayerMock).toHaveBeenCalledTimes(1));
-
-		rerender(<HeroVideoPlayer sources={nextSources} poster="/media/poster-2.jpg" preload="auto" />);
-
-		expect(videoJsPlayerMock.poster).toHaveBeenLastCalledWith('/media/poster-2.jpg');
-		expect(videoJsPlayerMock.preload).toHaveBeenLastCalledWith('auto');
-		expect(videoJsPlayerMock.src).toHaveBeenLastCalledWith(nextSources);
-	});
-
-	it('disposes through the MediaPlayerClass wrapper on unmount', async () => {
-		const { unmount } = render(<HeroVideoPlayer sources={[{ src: '/media/video.mp4', type: 'video/mp4' }]} />);
-		await waitFor(() => expect(mediaPlayerMock).toHaveBeenCalledTimes(1));
-
-		const disposeCallsBeforeUnmount = mediaPlayerDisposeMock.mock.calls.length;
-		const videojsDisposeCallsBeforeUnmount = videoJsPlayerMock.dispose.mock.calls.length;
-
-		unmount();
-
-		expect(mediaPlayerDisposeMock).toHaveBeenCalledTimes(disposeCallsBeforeUnmount + 1);
-		expect(videoJsPlayerMock.dispose).toHaveBeenCalledTimes(videojsDisposeCallsBeforeUnmount);
-	});
-
-	it('does not create a VideoJS player while cleaning up a cancelled async initialization', () => {
-		videojsMock.getPlayer.mockReturnValueOnce(undefined);
-
-		const { unmount } = render(<HeroVideoPlayer sources={[{ src: '/media/video.mp4', type: 'video/mp4' }]} />);
-		unmount();
-
-		expect(videojsMock.getPlayer).toHaveBeenCalledTimes(1);
-		expect(videojsMock).not.toHaveBeenCalled();
-	});
-
-	it('owns the modern hero player skin import', async () => {
+	it('keeps the hero adapter on the legacy player import path', async () => {
 		const source = await import('./HeroVideoPlayer.jsx?raw');
 
+		expect(source.default).toContain(
+			"import { VideoPlayer } from '../../../static/js/components/-NEW-/VideoPlayer.js';"
+		);
 		expect(source.default).toContain("import './HeroVideoPlayer.css';");
+		expect(source.default).not.toContain('video.js/dist/video.es.js');
+		expect(source.default).not.toContain("import('@mediacms/media-player')");
 	});
 
-	it('keeps only the MediaCMS player import behind the videojs global setup', async () => {
-		const source = await import('./HeroVideoPlayer.jsx?raw');
-
-		expect(source.default).toContain("import videojs from 'video.js/dist/video.es.js';");
-		expect(source.default).not.toContain("import videojs from 'video.js';");
-		expect(source.default).not.toContain("import MediaPlayerClass from '@mediacms/media-player';");
-		expect(source.default).not.toContain("import('video.js')");
-		expect(source.default).toContain("import('@mediacms/media-player')");
-		expect(source.default).toContain('mediaPlayerClassPromise = undefined;');
-	});
-
-	it('overrides plugin active indicators with shared player semantic tokens', async () => {
+	it('keeps the hero skin scoped around the legacy player without overriding touch glyphs', async () => {
 		const source = await import('./HeroVideoPlayer.css?raw');
 
-		expect(source.default).toContain('var(--site-player-progress-color)');
-		expect(source.default).toContain('.vjs-subtitles-control');
-		expect(source.default).toContain('.vjs-selected-menu-item');
-		expect(source.default).not.toContain('--hero-player-');
-	});
-
-	it('relies on global light and dark player token definitions', async () => {
-		const lightTheme = await import('../../../static/css/config/_light_theme.scss?raw');
-		const darkTheme = await import('../../../static/css/config/_dark_theme.scss?raw');
-
-		expect(lightTheme.default).toContain('--site-player-progress-color: var(--cinemata-sunset-horizon-500)');
-		expect(darkTheme.default).toContain('--site-player-progress-color: var(--cinemata-sunset-horizon-400p)');
-	});
-
-	it('uses Pacific Deep for the seek rail without blue-tinted control icons', async () => {
-		const source = await import('./HeroVideoPlayer.css?raw');
-		const lightTheme = await import('../../../static/css/config/_light_theme.scss?raw');
-
-		expect(source.default).toContain('color: var(--site-player-control-color) !important;');
-		expect(source.default).toContain('background-color: var(--site-player-track-color) !important;');
-		expect(source.default).toContain('background-color: var(--site-player-loaded-color) !important;');
-		expect(lightTheme.default).toContain('--site-player-track-color: rgb(0 12 32 / 0.78);');
-		expect(lightTheme.default).toContain('--site-player-loaded-color: var(--cinemata-pacific-deep-700)');
-		expect(source.default).not.toContain('#b5f4ff');
-		expect(source.default).not.toContain('#defbff');
-	});
-
-	it('keeps the hero play button on shared player semantic tokens', async () => {
-		const source = await import('./HeroVideoPlayer.css?raw');
-
+		expect(source.default).toContain('.cinemata-hero-legacy-player .video-js.vjs-mediacms');
 		expect(source.default).toContain('background-color: var(--site-player-accent-color) !important;');
 		expect(source.default).toContain('background-color: var(--site-player-progress-color) !important;');
+		expect(source.default).toContain('object-fit: contain');
+		expect(source.default).not.toContain('.vjs-touch-play-button .vjs-icon-play');
 	});
 
 	it('relies on the shared MediaCMS touch play button glyph fix', async () => {
 		const source = await import('../../../../packages/vjs-plugin/src/styles.scss?raw');
-		const heroSource = await import('./HeroVideoPlayer.css?raw');
 
 		expect(source.default).toContain('.vjs-touch-play-button');
 		expect(source.default).toContain('font-family: VideoJS;');
 		expect(source.default).toContain("content: '\\f101'; /* play */");
 		expect(source.default).toContain("content: '\\f103'; /* pause */");
 		expect(source.default).toContain("content: '\\f116'; /* replay */");
-		expect(heroSource.default).not.toContain('.vjs-touch-play-button .vjs-icon-play');
 	});
 
-	it('keeps Safari fullscreen in VideoJS full-window mode for custom 5 second seek controls', async () => {
-		const source = await import('../../../../packages/media-player/src/MediaPlayer.js?raw');
+	it('keeps Safari playback inline so fullscreen can use VideoJS controls', async () => {
+		const source = await import('../../../static/js/components/-NEW-/VideoPlayer.js?raw');
 
-		expect(source.default).toContain('vjopt.playsinline = true;');
-		expect(source.default).toContain('vjopt.preferFullWindow = true;');
+		expect(source.default).toContain('playsInline');
 	});
 
-	it('keeps the hero play button in the production bottom-left placement', async () => {
-		const source = await import('./HeroVideoPlayer.css?raw');
+	it('restores fullscreen through VideoJS so preferFullWindow is respected on Safari', async () => {
+		const source = await import('../../../static/js/components/MediaViewer/VideoViewer/index.js?raw');
 
-		expect(source.default).toContain('bottom: 48px !important;');
-		expect(source.default).toContain('left: 48px !important;');
-		expect(source.default).toContain('width: 72px !important;');
-		expect(source.default).toContain('@media screen and (width <= 640px)');
-		expect(source.default).toContain('bottom: 24px !important;');
-		expect(source.default).toContain('width: 48px !important;');
-		expect(source.default).not.toContain('top: 50% !important;');
-	});
-
-	it('keeps subtitle cues black and white instead of themed control colors', async () => {
-		const source = await import('./HeroVideoPlayer.css?raw');
-		const lightTheme = await import('../../../static/css/config/_light_theme.scss?raw');
-
-		expect(lightTheme.default).toContain('--site-player-subtitle-bg-color: rgb(0 0 0 / 0.78);');
-		expect(lightTheme.default).toContain('--site-player-subtitle-color: var(--cinemata-white)');
-		expect(source.default).toContain('.vjs-text-track-cue > *');
-		expect(source.default).toContain('background-color: transparent !important;');
-		expect(source.default).toContain('background-color: var(--site-player-subtitle-bg-color) !important;');
-		expect(source.default).toContain('color: var(--site-player-subtitle-color) !important;');
-		expect(source.default).not.toContain('.vjs-text-track-cue div');
-	});
-
-	it('constrains the VideoJS layout to the hero frame during shell width changes', async () => {
-		const source = await import('./HeroVideoPlayer.css?raw');
-
-		expect(source.default).toContain('position: absolute !important;');
-		expect(source.default).toContain('padding-top: 0 !important;');
-		expect(source.default).toContain('background-color: var(--site-player-canvas-color);');
-		expect(source.default).toContain('object-fit: contain');
-		expect(source.default).toContain('max-width: calc(100% - 24px)');
-		expect(source.default).toContain('.vjs-bottom-bg');
-		expect(source.default).toContain('var(--site-player-control-surface-color)');
-		expect(source.default).toContain('right: -12px !important;');
-		expect(source.default).toContain('height: 36px;');
-		expect(source.default).toContain(
-			'linear-gradient(to bottom, transparent, var(--site-player-control-surface-color))'
-		);
+		expect(source.default).toContain('const player = this.playerInstance?.player;');
+		expect(source.default).toContain('player.requestFullscreen()');
+		expect(source.default).not.toContain('element.webkitRequestFullscreen');
 	});
 });

--- a/frontend/src/static/css/_extra.css
+++ b/frontend/src/static/css/_extra.css
@@ -1992,7 +1992,9 @@ body .video-js.vjs-mediacms .vjs-big-play-button {
 }
 
 .user-action-form-inner .post-form > .requiredField {
-	color: var(--text-primary);
+	color: var(--body-text-color);
+	font-size: 120%;
+	font-weight: 700;
 }
 
 .user-action-form-inner .post-form > .requiredField .asteriskField {

--- a/frontend/src/static/js/components/-NEW-/VideoPlayer.js
+++ b/frontend/src/static/js/components/-NEW-/VideoPlayer.js
@@ -1,7 +1,7 @@
 import React, { useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import urlParse from 'url-parse';
-import videojs from 'video.js';
+import videojs from '../../videojsGlobal.js';
 
 import '@mediacms/media-player/dist/mediacms-media-player.css';
 import MediaPlayerClass from '@mediacms/media-player';
@@ -341,7 +341,7 @@ export function VideoPlayer(props) {
 	}, []);
 
 	return null === props.errorMessage ? (
-		<video ref={videoElemRef} className="video-js vjs-mediacms native-dimensions"></video>
+		<video ref={videoElemRef} className="video-js vjs-mediacms native-dimensions" playsInline></video>
 	) : (
 		<div className="error-container">
 			<div className="error-container-inner">

--- a/frontend/src/static/js/components/MediaViewer/AudioViewer/index.js
+++ b/frontend/src/static/js/components/MediaViewer/AudioViewer/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import videojs from 'video.js';
+import videojs from '../../../videojsGlobal.js';
 
 import SiteContext from '../../../contexts/SiteContext';
 

--- a/frontend/src/static/js/components/MediaViewer/VideoViewer/index.js
+++ b/frontend/src/static/js/components/MediaViewer/VideoViewer/index.js
@@ -578,20 +578,14 @@ export default class VideoViewer extends React.PureComponent {
 	}
 
 	requestFullscreen() {
-		const element = this.playerInstance.player.el();
+		const player = this.playerInstance?.player;
 
-		const fn =
-			element.requestFullscreen ||
-			element.webkitRequestFullscreen ||
-			element.mozRequestFullScreen ||
-			element.msRequestFullscreen;
-
-		if (!fn) {
+		if (!player?.requestFullscreen) {
 			return Promise.reject(new Error('Fullscreen API not supported'));
 		}
 
 		try {
-			const result = fn.call(element);
+			const result = player.requestFullscreen();
 			return result && typeof result.then === 'function' ? result : Promise.resolve();
 		} catch (error) {
 			return Promise.reject(error);

--- a/frontend/src/static/js/videojsGlobal.js
+++ b/frontend/src/static/js/videojsGlobal.js
@@ -1,0 +1,5 @@
+import videojs from 'video.js';
+
+globalThis.videojs = videojs;
+
+export default videojs;

--- a/templates/cms/edit_media.html
+++ b/templates/cms/edit_media.html
@@ -558,10 +558,6 @@
 
 			});
 
-			document.querySelector('.requiredField').style.fontSize = '120%';
-			document.querySelector('.requiredField').style.fontWeight = 'bold';
-			document.querySelector('.requiredField').style.color = 'white';
-
         	function removeClassname(el, cls) {
 			    if (el.classList) {
 			        el.classList.remove(cls);


### PR DESCRIPTION
## Summary

Homepage hero playback now uses the same MediaCMS player path as the media view, so mobile controls share the correct player skin instead of diverging through a separate VideoJS wrapper.

Safari fullscreen restore now goes through Video.js with inline playback preserved, keeping the custom 5-second seek controls available where Safari would otherwise fall back to native 10-second controls.

The edit media required marker now inherits theme text color instead of being forced white, restoring light-mode contrast.

## Testing

- `npm run test -- HeroVideoPlayer.test.jsx HeroSection.test.jsx HomePage.test.jsx contract.test.jsx`
- `npm run lint:modern`
- `npm run build`
- `npm run lint:legacy` (0 errors, existing warnings)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced visual emphasis for required form fields with increased font size and weight.

* **Bug Fixes**
  * Improved mobile video playback behavior with inline playback support.
  * Enhanced fullscreen request handling for the video player.

* **Refactor**
  * Simplified video player component architecture for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->