### PR TITLE
fix: Make button like strait-blue/800 when active, fix timestamps

### DIFF
--- a/frontend/src/features/layout/Sidebar/shell/Sidebar.jsx
+++ b/frontend/src/features/layout/Sidebar/shell/Sidebar.jsx
@@ -154,16 +154,7 @@ export function Sidebar({ id = 'app-sidebar' }) {
 		>
 			{isMobileViewport ? <SidebarRippleDecoration /> : null}
 
-			<div
-				className={cn(
-					'relative min-h-0 flex-1 overflow-y-auto overscroll-contain [scrollbar-gutter:stable]',
-					'[scrollbar-width:thin] [scrollbar-color:var(--border-default)_transparent]',
-					'[&::-webkit-scrollbar]:w-[6px] [&::-webkit-scrollbar-track]:bg-transparent',
-					'[&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:border-2',
-					'[&::-webkit-scrollbar-thumb]:border-transparent [&::-webkit-scrollbar-thumb]:bg-border-default',
-					'[&::-webkit-scrollbar-thumb]:bg-clip-content'
-				)}
-			>
+			<div className="thin-scrollbar relative min-h-0 flex-1 overflow-y-auto overscroll-contain [scrollbar-gutter:stable]">
 				<div className="relative min-h-full pb-16 md:pb-0">
 					{isMobileViewport ? null : <SidebarRippleDecoration />}
 

--- a/frontend/src/features/video-viewer/components/MediaSaveButton.jsx
+++ b/frontend/src/features/video-viewer/components/MediaSaveButton.jsx
@@ -1,12 +1,9 @@
 import React, { useEffect, useState } from 'react';
 
-import { Dialog, DialogContent, DialogTrigger } from '../../shared/components/Dialog/Dialog';
 import MediaPageStore from '../../../static/js/pages/MediaPage/store.js';
 
 import { PlaylistsSelection } from './MediaSave/PlaylistsSelection';
-import { Button } from '../../shared/components/Button/Button';
-import { Icon } from '../../shared/components/Icon/Icon';
-import { Text } from '../../shared/components/Text/Text';
+import { Button, Dialog, DialogContent, DialogTrigger, Icon, Text } from '../../shared/components';
 import { cn } from '../../shared/utils/classNames.js';
 
 function isMediaInUserPlaylist() {
@@ -60,7 +57,7 @@ export function MediaSaveButton() {
 						icon={<Icon name="bookmarkFilled" className={saveIconClassName} />}
 						className={cn(
 							'body-body-14-medium whitespace-nowrap p-size-8',
-							saveIconClassName ? 'bg-cinemata-strait-blue-800' : undefined
+							savedToPlaylist ? 'bg-bg-button-playlist-active' : undefined
 						)}
 						size="sm"
 					/>
@@ -74,7 +71,7 @@ export function MediaSaveButton() {
 						icon={<Icon name="bookmarkFilled" className={saveIconClassName} />}
 						className={cn(
 							'body-body-14-medium whitespace-nowrap',
-							savedToPlaylist ? 'bg-cinemata-strait-blue-800' : undefined
+							savedToPlaylist ? 'bg-bg-button-playlist-active' : undefined
 						)}
 						size="sm"
 					>

--- a/frontend/src/features/video-viewer/components/MediaSaveButton.jsx
+++ b/frontend/src/features/video-viewer/components/MediaSaveButton.jsx
@@ -7,6 +7,7 @@ import { PlaylistsSelection } from './MediaSave/PlaylistsSelection';
 import { Button } from '../../shared/components/Button/Button';
 import { Icon } from '../../shared/components/Icon/Icon';
 import { Text } from '../../shared/components/Text/Text';
+import { cn } from '../../shared/utils/classNames.js';
 
 function isMediaInUserPlaylist() {
 	const mediaId = MediaPageStore.get('media-id');
@@ -57,7 +58,10 @@ export function MediaSaveButton() {
 						aria-label={savedToPlaylist ? 'Added to playlist' : 'Save to playlist'}
 						variant="tertiary"
 						icon={<Icon name="bookmarkFilled" className={saveIconClassName} />}
-						className="body-body-14-medium whitespace-nowrap p-size-8"
+						className={cn(
+							'body-body-14-medium whitespace-nowrap p-size-8',
+							saveIconClassName ? 'bg-cinemata-strait-blue-800' : undefined
+						)}
 						size="sm"
 					/>
 				</DialogTrigger>
@@ -68,7 +72,10 @@ export function MediaSaveButton() {
 						aria-label={savedToPlaylist ? 'Added to playlist' : 'Save to playlist'}
 						variant="tertiary"
 						icon={<Icon name="bookmarkFilled" className={saveIconClassName} />}
-						className="body-body-14-medium whitespace-nowrap"
+						className={cn(
+							'body-body-14-medium whitespace-nowrap',
+							savedToPlaylist ? 'bg-cinemata-strait-blue-800' : undefined
+						)}
 						size="sm"
 					>
 						<Text as="span" variant="body-14-medium" className="whitespace-nowrap text-current">

--- a/frontend/src/features/video-viewer/components/MediaShare/MediaShareEmbed.jsx
+++ b/frontend/src/features/video-viewer/components/MediaShare/MediaShareEmbed.jsx
@@ -24,10 +24,11 @@ const UNIT_BOTH = [
 ];
 const UNIT_PX = [{ key: 'px', label: 'px' }];
 
-function buildEmbedCode({ embedUrl, mediaId, width, widthUnit, height, heightUnit }) {
+function buildEmbedCode({ embedUrl, mediaId, width, widthUnit, height, heightUnit, startAt }) {
 	const w = widthUnit === 'percent' ? `${width}%` : width;
 	const h = heightUnit === 'percent' ? `${height}%` : height;
-	return `<iframe width="${w}" height="${h}" src="${embedUrl}${mediaId}" frameborder="0" allowfullscreen></iframe>`;
+	const src = startAt > 0 ? `${embedUrl}${mediaId}&t=${startAt}` : `${embedUrl}${mediaId}`;
+	return `<iframe width="${w}" height="${h}" src="${src}" frameborder="0" allowfullscreen></iframe>`;
 }
 
 function DimensionInput({ label, value, unit, units, onValueChange, onUnitChange }) {
@@ -68,7 +69,7 @@ DimensionInput.propTypes = {
 	onUnitChange: PropTypes.func.isRequired,
 };
 
-export function MediaShareEmbed({ triggerPopupClose }) {
+export function MediaShareEmbed({ triggerPopupClose, startAt = 0 }) {
 	const links = useContext(LinksContext);
 	const textareaRef = useRef(null);
 
@@ -144,6 +145,7 @@ export function MediaShareEmbed({ triggerPopupClose }) {
 		widthUnit,
 		height: heightValue,
 		heightUnit,
+		startAt: Math.trunc(startAt),
 	});
 
 	return (
@@ -230,4 +232,5 @@ export function MediaShareEmbed({ triggerPopupClose }) {
 
 MediaShareEmbed.propTypes = {
 	triggerPopupClose: PropTypes.func,
+	startAt: PropTypes.number,
 };

--- a/frontend/src/features/video-viewer/components/MediaShare/MediaShareOptions.jsx
+++ b/frontend/src/features/video-viewer/components/MediaShare/MediaShareOptions.jsx
@@ -1,4 +1,5 @@
-import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useContext, useEffect, useMemo, useRef } from 'react';
+import PropTypes from 'prop-types';
 
 import ShareOptionsContext from '../../../../static/js/contexts/ShareOptionsContext';
 
@@ -93,11 +94,10 @@ const SHARE_OPTION_META = {
 	},
 };
 
-function buildShareOptions(socialMedia) {
-	const mediaUrl = MediaPageStore.get('media-url');
+function buildShareOptions(socialMedia, shareUrl) {
 	const mediaTitle = MediaPageStore.get('media-data').title;
 	const mediaType = MediaPageStore.get('media-data').media_type;
-	const encodedUrl = encodeURIComponent(mediaUrl || '');
+	const encodedUrl = encodeURIComponent(shareUrl || '');
 	const encodedTitle = encodeURIComponent(mediaTitle || '');
 
 	const result = [];
@@ -121,11 +121,6 @@ function toHHMMSS(timeInt) {
 	const s = total - h * 3600 - m * 60;
 	const pad = (n) => String(n).padStart(2, '0');
 	return h >= 1 ? `${pad(h)}:${pad(m)}:${pad(s)}` : `${pad(m)}:${pad(s)}`;
-}
-
-function getCurrentVideoTimestamp() {
-	const videoElem = document.querySelector('.viewer-container video');
-	return videoElem?.currentTime ?? 0;
 }
 
 const SHARE_TILE_CLASSES =
@@ -171,18 +166,18 @@ function ShareTile({ icon, label, bgColor, iconColor, href, target, dataPageId, 
 	);
 }
 
-export function MediaShareOptions() {
+export function MediaShareOptions({ timestamp = 0, startAtSelected = false, onToggleStartAt }) {
 	const containerRef = useRef(null);
 	const inputRef = useRef(null);
 	const mediaUrl = MediaPageStore.get('media-url');
 	const socialMedia = useContext(ShareOptionsContext);
-	const shareOptions = useMemo(() => buildShareOptions(socialMedia), [socialMedia]);
-
-	const [timestamp, setTimestamp] = useState(0);
-	const [formattedTimestamp, setFormattedTimestamp] = useState('00:00');
-	const [startAtSelected, setStartAtSelected] = useState(false);
+	const formattedTimestamp = toHHMMSS(timestamp);
 
 	const shareMediaLink = startAtSelected ? `${mediaUrl}&t=${Math.trunc(timestamp)}` : mediaUrl;
+	const shareOptions = useMemo(
+		() => buildShareOptions(socialMedia, shareMediaLink),
+		[socialMedia, shareMediaLink]
+	);
 
 	function onClickCopy() {
 		if (inputRef.current) {
@@ -194,15 +189,7 @@ export function MediaShareOptions() {
 		PageActions.addNotification('Link copied to clipboard', 'clipboardLinkCopy');
 	}
 
-	function onToggleStartAt() {
-		setStartAtSelected((prev) => !prev);
-	}
-
 	useEffect(() => {
-		const current = getCurrentVideoTimestamp();
-		setTimestamp(current);
-		setFormattedTimestamp(toHHMMSS(current));
-
 		MediaPageStore.on('copied_media_link', onCompleteCopy);
 		return () => {
 			MediaPageStore.removeListener('copied_media_link', onCompleteCopy);
@@ -216,7 +203,16 @@ export function MediaShareOptions() {
 			</Text>
 
 			{shareOptions.length > 0 && (
-				<div className="mx-size-4 flex flex-nowrap items-start gap-size-16 overflow-x-auto px-size-4 pb-size-4 [scrollbar-width:thin]">
+				<div
+					className={cn(
+						'mx-size-4 flex flex-nowrap items-start gap-size-16 overflow-x-auto px-size-4 pb-size-4',
+						'[scrollbar-width:thin] [scrollbar-color:var(--border-default)_transparent]',
+						'[&::-webkit-scrollbar]:h-[6px] [&::-webkit-scrollbar-track]:bg-transparent',
+						'[&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:border-2',
+						'[&::-webkit-scrollbar-thumb]:border-transparent [&::-webkit-scrollbar-thumb]:bg-border-default',
+						'[&::-webkit-scrollbar-thumb]:bg-clip-content'
+					)}
+				>
 					{shareOptions.map((opt) =>
 						opt.key === 'embed' ? (
 							<ShareTile
@@ -261,3 +257,9 @@ export function MediaShareOptions() {
 		</div>
 	);
 }
+
+MediaShareOptions.propTypes = {
+	timestamp: PropTypes.number,
+	startAtSelected: PropTypes.bool,
+	onToggleStartAt: PropTypes.func,
+};

--- a/frontend/src/features/video-viewer/components/MediaShare/MediaShareOptions.jsx
+++ b/frontend/src/features/video-viewer/components/MediaShare/MediaShareOptions.jsx
@@ -174,10 +174,7 @@ export function MediaShareOptions({ timestamp = 0, startAtSelected = false, onTo
 	const formattedTimestamp = toHHMMSS(timestamp);
 
 	const shareMediaLink = startAtSelected ? `${mediaUrl}&t=${Math.trunc(timestamp)}` : mediaUrl;
-	const shareOptions = useMemo(
-		() => buildShareOptions(socialMedia, shareMediaLink),
-		[socialMedia, shareMediaLink]
-	);
+	const shareOptions = useMemo(() => buildShareOptions(socialMedia, shareMediaLink), [socialMedia, shareMediaLink]);
 
 	function onClickCopy() {
 		if (inputRef.current) {

--- a/frontend/src/features/video-viewer/components/MediaShare/MediaShareOptions.jsx
+++ b/frontend/src/features/video-viewer/components/MediaShare/MediaShareOptions.jsx
@@ -200,16 +200,7 @@ export function MediaShareOptions({ timestamp = 0, startAtSelected = false, onTo
 			</Text>
 
 			{shareOptions.length > 0 && (
-				<div
-					className={cn(
-						'mx-size-4 flex flex-nowrap items-start gap-size-16 overflow-x-auto px-size-4 pb-size-4',
-						'[scrollbar-width:thin] [scrollbar-color:var(--border-default)_transparent]',
-						'[&::-webkit-scrollbar]:h-[6px] [&::-webkit-scrollbar-track]:bg-transparent',
-						'[&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:border-2',
-						'[&::-webkit-scrollbar-thumb]:border-transparent [&::-webkit-scrollbar-thumb]:bg-border-default',
-						'[&::-webkit-scrollbar-thumb]:bg-clip-content'
-					)}
-				>
+				<div className="thin-scrollbar mx-size-4 flex flex-nowrap items-start gap-size-16 overflow-x-auto px-size-4 pb-size-4">
 					{shareOptions.map((opt) =>
 						opt.key === 'embed' ? (
 							<ShareTile

--- a/frontend/src/features/video-viewer/components/MediaShareButton.jsx
+++ b/frontend/src/features/video-viewer/components/MediaShareButton.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 
 import { Dialog, DialogContent, DialogTrigger } from '../../shared/components/Dialog/Dialog';
@@ -10,22 +10,24 @@ import { Button } from '../../shared/components/Button/Button';
 import { Icon } from '../../shared/components/Icon/Icon';
 import { Text } from '../../shared/components/Text/Text';
 
-function mediaSharePopupPages() {
-	return {
-		shareOptions: <MediaShareOptions />,
-	};
-}
-
-function videoSharePopupPages(onTriggerPopupClose) {
-	return {
-		...mediaSharePopupPages(),
-		shareEmbed: <MediaShareEmbed triggerPopupClose={onTriggerPopupClose} />,
-	};
+function getCurrentVideoTimestamp() {
+	const videoElem = document.querySelector('.viewer-container video');
+	return videoElem?.currentTime ?? 0;
 }
 
 export function MediaShareButton({ isVideo }) {
 	const [isOpen, setIsOpen] = useState(false);
 	const [popupCurrentPage, setPopupCurrentPage] = useState('shareOptions');
+	const [timestamp, setTimestamp] = useState(0);
+	const [startAtSelected, setStartAtSelected] = useState(false);
+
+	useEffect(() => {
+		if (isOpen) {
+			setTimestamp(getCurrentVideoTimestamp());
+		} else {
+			setStartAtSelected(false);
+		}
+	}, [isOpen]);
 
 	function onOpenChange(nextOpen) {
 		setIsOpen(nextOpen);
@@ -35,6 +37,20 @@ export function MediaShareButton({ isVideo }) {
 	function triggerPopupClose() {
 		onOpenChange(false);
 	}
+
+	const sharedOptionsProps = {
+		timestamp,
+		startAtSelected,
+		onToggleStartAt: () => setStartAtSelected((prev) => !prev),
+	};
+	const embedStartAt = startAtSelected ? timestamp : 0;
+
+	const pages = isVideo
+		? {
+				shareOptions: <MediaShareOptions {...sharedOptionsProps} />,
+				shareEmbed: <MediaShareEmbed triggerPopupClose={triggerPopupClose} startAt={embedStartAt} />,
+		  }
+		: { shareOptions: <MediaShareOptions {...sharedOptionsProps} /> };
 
 	return (
 		<Dialog open={isOpen} onOpenChange={onOpenChange}>
@@ -73,7 +89,7 @@ export function MediaShareButton({ isVideo }) {
 					initPage={popupCurrentPage}
 					pageChangeSelector=".change-page"
 					pageIdSelectorAttr="data-page-id"
-					pages={isVideo ? videoSharePopupPages(triggerPopupClose) : mediaSharePopupPages()}
+					pages={pages}
 					focusFirstItemOnPageChange={false}
 					pageChangeCallback={setPopupCurrentPage}
 				/>

--- a/frontend/src/features/video-viewer/components/MediaShareButton.jsx
+++ b/frontend/src/features/video-viewer/components/MediaShareButton.jsx
@@ -49,7 +49,7 @@ export function MediaShareButton({ isVideo }) {
 		? {
 				shareOptions: <MediaShareOptions {...sharedOptionsProps} />,
 				shareEmbed: <MediaShareEmbed triggerPopupClose={triggerPopupClose} startAt={embedStartAt} />,
-		  }
+			}
 		: { shareOptions: <MediaShareOptions {...sharedOptionsProps} /> };
 
 	return (

--- a/frontend/src/static/css/tailwind.css
+++ b/frontend/src/static/css/tailwind.css
@@ -595,6 +595,7 @@ body {
 	--bg-control: var(--cinemata-neutral-300);
 	--bg-primary: var(--cinemata-strait-blue-600p);
 	--bg-primary-hover: var(--cinemata-strait-blue-800);
+	--bg-button-playlist-active: var(--cinemata-strait-blue-800);
 	--bg-secondary: var(--cinemata-sunset-horizon-400p);
 	--bg-secondary-hover: var(--cinemata-sunset-horizon-500);
 	--bg-danger: var(--cinemata-red-500);
@@ -656,6 +657,7 @@ body.dark_theme {
 	--bg-control: var(--cinemata-pacific-deep-900);
 	--bg-primary: var(--cinemata-strait-blue-500);
 	--bg-primary-hover: var(--cinemata-strait-blue-700);
+	--bg-button-playlist-active: var(--cinemata-strait-blue-700);
 	--bg-secondary: var(--cinemata-sunset-horizon-500);
 	--bg-secondary-hover: var(--cinemata-sunset-horizon-400p);
 	--bg-danger-strong: var(--cinemata-red-950);
@@ -706,6 +708,7 @@ body.dark_theme {
 	--color-bg-control: var(--bg-control);
 	--color-bg-primary: var(--bg-primary);
 	--color-bg-primary-hover: var(--bg-primary-hover);
+	--color-bg-button-playlist-active: var(--bg-button-playlist-active);
 	--color-bg-secondary: var(--bg-secondary);
 	--color-bg-secondary-hover: var(--bg-secondary-hover);
 	--color-bg-danger: var(--bg-danger);

--- a/frontend/src/static/css/tailwind.css
+++ b/frontend/src/static/css/tailwind.css
@@ -830,6 +830,32 @@ header[data-topbar] button:not(:disabled) {
 		background-color: var(--border-scrollbar);
 		background-clip: content-box;
 	}
+
+	/*
+	 * Thin scrollbar utility using --border-default. Works for both
+	 * vertical and horizontal overflow (sets width + height).
+	 * Used by sidebar shell and horizontal share-tile row.
+	 */
+	.thin-scrollbar {
+		scrollbar-color: var(--border-default) transparent;
+		scrollbar-width: thin;
+	}
+
+	.thin-scrollbar::-webkit-scrollbar {
+		width: 6px;
+		height: 6px;
+	}
+
+	.thin-scrollbar::-webkit-scrollbar-track {
+		background: transparent;
+	}
+
+	.thin-scrollbar::-webkit-scrollbar-thumb {
+		border: 2px solid transparent;
+		border-radius: 999px;
+		background-color: var(--border-default);
+		background-clip: content-box;
+	}
 }
 
 header[data-topbar] button:focus-visible,

--- a/frontend/src/storybook/Colors.mdx
+++ b/frontend/src/storybook/Colors.mdx
@@ -50,6 +50,7 @@ This page is the working reference for the token catalogue. For the underlying d
 - **`bg-bg-control`** — standard small control surfaces, including radio backgrounds. Light: `neutral-300` / Dark: `pacific-deep-900`
 - **`bg-bg-primary`** — primary action surfaces. Light: `strait-blue-600p` / Dark: `strait-blue-500`
 - **`bg-bg-primary-hover`** — hover for `bg-bg-primary`. Light: `strait-blue-800` / Dark: `strait-blue-700`
+- **`bg-bg-button-playlist-active`** — active playlist/save button background. Light: `strait-blue-800` / Dark: `strait-blue-700`
 - **`bg-bg-secondary`** — brand action / CTA buttons (orange). What `bg-brand-primary` legacy utility now routes through. Light: `sunset-horizon-400p` / Dark: `sunset-horizon-500`
 - **`bg-bg-secondary-hover`** — hover for `bg-bg-secondary`. Light: `sunset-horizon-500` / Dark: `sunset-horizon-400p`
 - **`bg-bg-danger`** — destructive surfaces. Constant `red-500`.


### PR DESCRIPTION
## Description
Updated media action UI behavior for save and share controls.

- Adds active styling for saved playlist state using `bg-cinemata-strait-blue-800`.
- Fixes share timestamp handling by capturing the current video time when the share dialog opens.
- Applies the selected start timestamp to copied share links and embed iframe URLs.
- Resets the “Start at” option when the share dialog closes.
- Adds prop validation and small styling refinements for share options scrolling.

## Related Issue
Fixes #711 

## Motivation and Context
This change improves feedback and correctness in the video viewer media actions. Saved media now has a clearer active visual state, and timestamp-based sharing now works consistently across direct share links and embed code.

## How Has This Been Tested?
Not run. PR description generated from the latest commit only.

## Screenshots (if appropriate):
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/6579bd51-e222-4810-9027-3498172afbe9" />
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/bb24ace9-4873-47d1-8687-908be6522fd5" />
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/a091438d-4237-4582-b765-040b3d957786" />

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Modern Track Checklist (for new features):
- [x] I have not imported `flux` in a new component
- [ ] If adding a new feature, I used Modern Track patterns
- [x] New features do not create new SCSS files (use Tailwind instead)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Share/embed now supports specifying a start time so recipients can begin playback at a chosen moment.
  * Share dialog/options now expose a toggle to include the current playback time when sharing.

* **Improvements**
  * Save/bookmark buttons gain conditional active background styling to better indicate saved state.
  * Sidebar scrolling uses a simplified, consistent thin-scrollbar behavior.

* **Style**
  * Added a semantic color token for playlist-button active background and a reusable thin-scrollbar utility.

* **Documentation**
  * Storybook updated to show the new playlist-button background token.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->