### PR TITLE
fix(notifications): reorder preference rows

### DIFF
--- a/frontend/src/features/notifications/components/NotificationPage.jsx
+++ b/frontend/src/features/notifications/components/NotificationPage.jsx
@@ -157,8 +157,8 @@ function NotificationPageContent() {
 
 	return (
 		<div className="mx-auto max-w-[1054px] px-4 py-6 sm:px-6 xl:px-0">
-			<div className="grid grid-cols-1 gap-[26px] lg:grid-cols-[minmax(0,1fr)_minmax(320px,406px)] lg:items-start xl:grid-cols-[minmax(0,622px)_406px]">
-				<section aria-label="Notification list">
+			<div className="grid grid-cols-1 gap-[26px] lg:grid-cols-5 lg:items-start">
+				<section aria-label="Notification list" className="lg:col-span-3">
 					<div className="flex w-full items-center justify-between">
 						<div
 							role="tablist"
@@ -220,7 +220,7 @@ function NotificationPageContent() {
 					id={HASH_PREFERENCES}
 					ref={preferencesRef}
 					aria-label="Notification preferences"
-					className="scroll-mt-6 rounded-[8px] bg-bg-surface px-[16px] pb-[16px] pt-[22px]"
+					className="scroll-mt-6 rounded-[8px] bg-bg-surface px-[16px] pb-[16px] pt-[22px] lg:col-span-2"
 				>
 					<NotificationPreferencesForm />
 				</aside>

--- a/frontend/src/features/notifications/components/NotificationPage.jsx
+++ b/frontend/src/features/notifications/components/NotificationPage.jsx
@@ -156,8 +156,8 @@ function NotificationPageContent() {
 	];
 
 	return (
-		<div className="mx-auto max-w-[1054px] px-4 py-6 lg:px-0">
-			<div className="grid grid-cols-1 gap-[26px] lg:grid-cols-[minmax(0,622px)_406px] lg:items-start">
+		<div className="mx-auto max-w-[1054px] px-4 py-6 sm:px-6 xl:px-0">
+			<div className="grid grid-cols-1 gap-[26px] lg:grid-cols-[minmax(0,1fr)_minmax(320px,406px)] lg:items-start xl:grid-cols-[minmax(0,622px)_406px]">
 				<section aria-label="Notification list">
 					<div className="flex w-full items-center justify-between">
 						<div

--- a/frontend/src/features/user-settings/components/NotificationPreferencesForm.jsx
+++ b/frontend/src/features/user-settings/components/NotificationPreferencesForm.jsx
@@ -1,18 +1,15 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useNotificationPreferences } from '../hooks/useNotificationPreferences';
 import { useUpdateNotificationPreferences } from '../hooks/useUpdateNotificationPreferences';
-import { Switch } from '../../shared/components/Switch';
 
 const PREFERENCE_CATEGORIES = [
 	{
-		id: 'security',
-		title: 'Security & Privacy Alerts',
+		id: 'engagement',
+		title: 'Engagement & Discussions',
 		items: [
-			{ label: 'Account login from new device', status: 'coming_soon' },
-			{ label: 'Changes to film visibility', status: 'coming_soon' },
-			{ label: 'Download enabled on your film', status: 'coming_soon' },
-			{ label: 'Password removed or changed', status: 'coming_soon' },
-			{ label: 'Suspicious activity detected', status: 'coming_soon' },
+			{ key: 'on_comment', label: 'New comment on your film', status: 'active' },
+			{ label: 'Replies to your comment', status: 'coming_soon' },
+			{ key: 'on_like', label: 'New reactions to your film', status: 'active' },
 		],
 	},
 	{
@@ -22,19 +19,8 @@ const PREFERENCE_CATEGORIES = [
 			{ label: 'Upload completed', status: 'coming_soon' },
 			{ label: 'Upload failed', status: 'coming_soon' },
 			{ label: 'Processing completed', status: 'coming_soon' },
-			{ key: 'on_new_media_from_following', label: 'New films from people you follow', status: 'active' },
 			{ label: 'Scheduled visibility change', status: 'coming_soon' },
-		],
-	},
-	{
-		id: 'engagement',
-		title: 'Engagement & Discussions',
-		items: [
-			{ key: 'on_comment', label: 'New comment on your film', status: 'active' },
-			{ key: 'on_reply', label: 'Replies to your comment', status: 'active' },
-			{ key: 'on_like', label: 'New reactions to your film', status: 'active' },
-			{ key: 'on_follow', label: 'New followers', status: 'active' },
-			{ key: 'on_mention', label: 'Mentions in comments', status: 'active' },
+			{ label: 'New films from filmmakers you follow', status: 'coming_soon' },
 		],
 	},
 	{
@@ -47,7 +33,7 @@ const PREFERENCE_CATEGORIES = [
 				label: 'Film added to a curated collection',
 				status: 'active',
 			},
-			{ label: 'Request for screening or usage permission', status: 'coming_soon' },
+			{ label: 'Request for screening or usage', status: 'coming_soon' },
 		],
 	},
 ];
@@ -56,9 +42,11 @@ const ALL_KEYS = PREFERENCE_CATEGORIES.flatMap((cat) =>
 	cat.items.filter((i) => i.status === 'active' && i.key).map((i) => i.key)
 );
 
-function activeKeysFor(category) {
-	return category.items.filter((i) => i.status === 'active' && i.key).map((i) => i.key);
-}
+const CHANNEL_OPTIONS = [
+	{ value: 'none', label: 'Off' },
+	{ value: 'in_app', label: 'App', ariaLabel: 'In-App' },
+	{ value: 'email', label: 'Email', ariaLabel: 'In-App + Email' },
+];
 
 function arePrefsEqual(a, b) {
 	if (!a || !b) return false;
@@ -67,9 +55,41 @@ function arePrefsEqual(a, b) {
 
 function ComingSoonPill() {
 	return (
-		<span className="rounded-[4px] bg-bg-surface-muted px-[6px] py-[2px] text-[11px] font-medium leading-[14px] tracking-normal text-text-muted">
+		<span className="inline-flex min-h-[24px] items-center rounded-full bg-bg-surface-muted px-3 text-[11px] font-medium leading-[14px] tracking-normal text-text-muted">
 			Coming soon
 		</span>
+	);
+}
+
+function ChannelSegmentedControl({ disabled, label, value, onChange }) {
+	return (
+		<div
+			role="group"
+			aria-label={`${label} notification channel`}
+			className="grid w-[140px] max-w-full grid-cols-[0.7fr_0.75fr_1fr] overflow-hidden rounded-full border border-border-default bg-bg-surface-muted p-0.5"
+		>
+			{CHANNEL_OPTIONS.map((option) => {
+				const isSelected = value === option.value;
+
+				return (
+					<button
+						key={option.value}
+						type="button"
+						aria-pressed={isSelected}
+						aria-label={option.ariaLabel ?? option.label}
+						disabled={disabled}
+						onClick={() => onChange(option.value)}
+						className={`min-h-[24px] min-w-0 rounded-full border-0 px-1.5 text-[11px] font-medium leading-[14px] tracking-normal transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring-focus focus-visible:ring-offset-1 focus-visible:ring-offset-bg-surface disabled:cursor-not-allowed disabled:opacity-60 ${
+							isSelected
+								? 'bg-bg-primary text-text-on-primary'
+								: 'bg-transparent text-text-secondary hover:bg-bg-surface hover:text-text-primary'
+						}`}
+					>
+						<span className="block truncate">{option.label}</span>
+					</button>
+				);
+			})}
+		</div>
 	);
 }
 
@@ -110,48 +130,11 @@ export function NotificationPreferencesForm() {
 		if (isSuccess || isSaveError) reset();
 	}
 
-	function setEventEnabled(key, enabled, categoryEmailOn) {
+	function setPreferenceChannel(key, channel) {
 		setDraft((prev) => ({
 			...prev,
-			[key]: enabled ? (categoryEmailOn ? 'email' : 'in_app') : 'none',
+			[key]: channel,
 		}));
-		clearSaveStatus();
-	}
-
-	function setCategoryPush(category, enabled) {
-		const keys = activeKeysFor(category);
-		setDraft((prev) => {
-			const next = { ...prev };
-			if (enabled) {
-				const emailOn = keys.some((k) => prev[k] === 'email');
-				keys.forEach((k) => {
-					next[k] = emailOn ? 'email' : 'in_app';
-				});
-			} else {
-				keys.forEach((k) => {
-					next[k] = 'none';
-				});
-			}
-			return next;
-		});
-		clearSaveStatus();
-	}
-
-	function setCategoryEmail(category, enabled) {
-		const keys = activeKeysFor(category);
-		setDraft((prev) => {
-			const next = { ...prev };
-			if (enabled) {
-				keys.forEach((k) => {
-					next[k] = 'email';
-				});
-			} else {
-				keys.forEach((k) => {
-					if (prev[k] === 'email') next[k] = 'in_app';
-				});
-			}
-			return next;
-		});
 		clearSaveStatus();
 	}
 
@@ -171,8 +154,6 @@ export function NotificationPreferencesForm() {
 		clearSaveStatus();
 	}
 
-	const disabledActionStyle = { cursor: !isDirty || isPending ? 'not-allowed' : 'pointer' };
-
 	return (
 		<form onSubmit={handleSave} className="flex flex-col gap-[26px]">
 			<div className="flex flex-col gap-[8px]">
@@ -180,17 +161,12 @@ export function NotificationPreferencesForm() {
 					Notification Preference
 				</h2>
 				<p className="m-0 text-[14px] font-normal leading-[20px] tracking-normal text-text-secondary">
-					Choose how and when you&apos;d like to be notified about activity on your films, account security,
-					and discussions, so you stay informed without unnecessary noise.
+					Choose how and when you&apos;d like to be notified about activity on your films and discussions, so
+					you stay informed without unnecessary noise.
 				</p>
 			</div>
 
 			{PREFERENCE_CATEGORIES.map((category, idx) => {
-				const keys = activeKeysFor(category);
-				const pushOn = keys.length > 0 ? keys.some((k) => draft[k] !== 'none') : true;
-				const emailOn = keys.length > 0 ? keys.some((k) => draft[k] === 'email') : true;
-				const isCategoryInteractive = keys.length > 0;
-
 				return (
 					<React.Fragment key={category.id}>
 						{idx > 0 && <div className="h-px bg-border-subtle" aria-hidden="true" />}
@@ -200,22 +176,20 @@ export function NotificationPreferencesForm() {
 							</legend>
 							{category.items.map((item) => {
 								const isActive = item.status === 'active' && item.key;
-								const checked = isActive ? draft[item.key] !== 'none' : true;
 								return (
 									<div
 										key={item.label}
-										className="flex min-h-[24px] items-center justify-between gap-3 pb-[1.3px] pt-[2.5px]"
+										className="grid min-h-[24px] min-w-0 grid-cols-1 gap-2 pb-[1.3px] pt-[2.5px] sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center"
 									>
-										<span className="text-[14px] font-normal leading-[20px] tracking-normal text-text-secondary">
+										<span className="min-w-0 whitespace-nowrap text-[13px] font-normal leading-[20px] tracking-normal text-text-secondary">
 											{item.label}
 										</span>
 										{isActive ? (
-											<Switch
-												aria-label={item.label}
-												checked={checked}
+											<ChannelSegmentedControl
+												label={item.label}
+												value={draft[item.key]}
 												disabled={isPending}
-												className="opacity-100"
-												onChange={(e) => setEventEnabled(item.key, e.target.checked, emailOn)}
+												onChange={(channel) => setPreferenceChannel(item.key, channel)}
 											/>
 										) : (
 											<ComingSoonPill />
@@ -223,38 +197,6 @@ export function NotificationPreferencesForm() {
 									</div>
 								);
 							})}
-							<div className="flex min-h-[24px] items-center justify-between gap-3 pb-[1.3px] pt-[2.5px]">
-								<span className="text-[14px] font-normal leading-[20px] tracking-normal text-text-secondary">
-									Push notification
-								</span>
-								{isCategoryInteractive ? (
-									<Switch
-										aria-label={`${category.title} push notifications`}
-										checked={pushOn}
-										disabled={isPending}
-										className="opacity-100"
-										onChange={(e) => setCategoryPush(category, e.target.checked)}
-									/>
-								) : (
-									<ComingSoonPill />
-								)}
-							</div>
-							<div className="flex min-h-[24px] items-center justify-between gap-3 pb-[1.3px] pt-[2.5px]">
-								<span className="text-[14px] font-normal leading-[20px] tracking-normal text-text-secondary">
-									Email Notification
-								</span>
-								{isCategoryInteractive ? (
-									<Switch
-										aria-label={`${category.title} email notifications`}
-										checked={emailOn}
-										disabled={isPending}
-										className="opacity-100"
-										onChange={(e) => setCategoryEmail(category, e.target.checked)}
-									/>
-								) : (
-									<ComingSoonPill />
-								)}
-							</div>
 						</fieldset>
 					</React.Fragment>
 				);
@@ -271,26 +213,14 @@ export function NotificationPreferencesForm() {
 					type="button"
 					onClick={handleReset}
 					disabled={!isDirty || isPending}
-					className="border-0 bg-transparent p-0 text-sm text-text-link hover:text-text-link-hover hover:underline disabled:opacity-40"
-					style={disabledActionStyle}
+					className="border-0 bg-transparent p-0 text-sm text-text-link hover:text-text-link-hover hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-bg-surface disabled:cursor-not-allowed disabled:opacity-40"
 				>
 					Reset
 				</button>
 				<button
 					type="submit"
 					disabled={!isDirty || isPending}
-					className="transition-all disabled:opacity-40"
-					style={{
-						padding: '6px 18px',
-						border: 'none',
-						fontSize: '13px',
-						fontWeight: 500,
-						borderRadius: 'var(--radius-4)',
-						backgroundColor: 'var(--bg-primary)',
-						color: 'var(--text-on-primary)',
-						boxShadow: 'none',
-						...disabledActionStyle,
-					}}
+					className="rounded-ds-4 border-0 bg-bg-primary px-[18px] py-[6px] text-[13px] font-medium leading-5 tracking-normal text-text-on-primary transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-bg-surface disabled:cursor-not-allowed disabled:opacity-40"
 				>
 					{isPending ? 'Saving…' : 'Save changes'}
 				</button>

--- a/frontend/src/features/user-settings/components/NotificationPreferencesForm.test.jsx
+++ b/frontend/src/features/user-settings/components/NotificationPreferencesForm.test.jsx
@@ -1,0 +1,157 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { NotificationPreferencesForm } from './NotificationPreferencesForm';
+
+const hookMocks = vi.hoisted(() => {
+	const defaultPreferences = {
+		on_comment: 'email',
+		on_like: 'in_app',
+		on_added_to_playlist: 'in_app',
+		on_follow: 'email',
+		on_mention: 'email',
+		on_new_media_from_following: 'email',
+		on_reply: 'email',
+	};
+
+	return {
+		defaultPreferences,
+		mutate: vi.fn(),
+		reset: vi.fn(),
+		queryState: {
+			data: defaultPreferences,
+			isLoading: false,
+			isError: false,
+			error: null,
+		},
+		mutationState: {
+			isPending: false,
+			isSuccess: false,
+			isError: false,
+			error: null,
+		},
+		resetMocks() {
+			this.mutate.mockReset();
+			this.reset.mockReset();
+			this.queryState.data = { ...defaultPreferences };
+			this.queryState.isLoading = false;
+			this.queryState.isError = false;
+			this.queryState.error = null;
+			this.mutationState.isPending = false;
+			this.mutationState.isSuccess = false;
+			this.mutationState.isError = false;
+			this.mutationState.error = null;
+		},
+	};
+});
+
+vi.mock('../hooks/useNotificationPreferences', () => ({
+	useNotificationPreferences: () => hookMocks.queryState,
+}));
+
+vi.mock('../hooks/useUpdateNotificationPreferences', () => ({
+	useUpdateNotificationPreferences: () => ({
+		mutate: hookMocks.mutate,
+		reset: hookMocks.reset,
+		...hookMocks.mutationState,
+	}),
+}));
+
+function renderForm() {
+	return render(<NotificationPreferencesForm />);
+}
+
+function channelGroup(label) {
+	return screen.getByRole('group', { name: `${label} notification channel` });
+}
+
+describe('NotificationPreferencesForm', () => {
+	beforeEach(() => {
+		hookMocks.resetMocks();
+	});
+
+	it('renders the available preference groups in the issue order', () => {
+		renderForm();
+
+		const engagement = screen.getByText('Engagement & Discussions');
+		const upload = screen.getByText('Upload & Archive Updates');
+		const institutional = screen.getByText('Institutional / Access Notifications');
+
+		expect(engagement.compareDocumentPosition(upload)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+		expect(upload.compareDocumentPosition(institutional)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+	});
+
+	it('hides unavailable security and platform announcement groups', () => {
+		renderForm();
+
+		expect(screen.queryByText('Security & Privacy Alerts')).not.toBeInTheDocument();
+		expect(screen.queryByText('Platform announcements')).not.toBeInTheDocument();
+		expect(screen.queryByText('Account login from new device')).not.toBeInTheDocument();
+	});
+
+	it('only exposes Comments, Likes, and Added to playlist as editable rows', () => {
+		renderForm();
+
+		expect(screen.getAllByRole('group', { name: /notification channel/i })).toHaveLength(3);
+		expect(channelGroup('New comment on your film')).toBeInTheDocument();
+		expect(channelGroup('New reactions to your film')).toBeInTheDocument();
+		expect(channelGroup('Film added to a curated collection')).toBeInTheDocument();
+		expect(screen.queryByRole('switch')).not.toBeInTheDocument();
+		expect(screen.queryByText('Push notification')).not.toBeInTheDocument();
+		expect(screen.queryByText('Email Notification')).not.toBeInTheDocument();
+	});
+
+	it('uses compact channel labels with full accessible names', () => {
+		renderForm();
+
+		for (const label of [
+			'New comment on your film',
+			'New reactions to your film',
+			'Film added to a curated collection',
+		]) {
+			const group = within(channelGroup(label));
+
+			expect(group.getAllByRole('button').map((button) => button.textContent)).toEqual(['Off', 'App', 'Email']);
+			expect(group.getByRole('button', { name: 'In-App' })).toBeInTheDocument();
+			expect(group.getByRole('button', { name: 'In-App + Email' })).toBeInTheDocument();
+		}
+	});
+
+	it('does not mutate other editable rows when one row changes', async () => {
+		const user = userEvent.setup();
+		renderForm();
+
+		await user.click(within(channelGroup('New comment on your film')).getByRole('button', { name: 'Off' }));
+
+		expect(within(channelGroup('New comment on your film')).getByRole('button', { name: 'Off' })).toHaveAttribute(
+			'aria-pressed',
+			'true'
+		);
+		expect(
+			within(channelGroup('New reactions to your film')).getByRole('button', { name: 'In-App' })
+		).toHaveAttribute('aria-pressed', 'true');
+		expect(
+			within(channelGroup('Film added to a curated collection')).getByRole('button', { name: 'In-App' })
+		).toHaveAttribute('aria-pressed', 'true');
+	});
+
+	it('saves only changed editable preference keys', async () => {
+		const user = userEvent.setup();
+		renderForm();
+
+		await user.click(within(channelGroup('New comment on your film')).getByRole('button', { name: 'Off' }));
+		await user.click(
+			within(channelGroup('Film added to a curated collection')).getByRole('button', {
+				name: 'In-App + Email',
+			})
+		);
+		await user.click(screen.getByRole('button', { name: 'Save changes' }));
+
+		expect(hookMocks.mutate).toHaveBeenCalledTimes(1);
+		expect(hookMocks.mutate).toHaveBeenCalledWith({
+			on_comment: 'none',
+			on_added_to_playlist: 'email',
+		});
+	});
+});

--- a/frontend/src/features/video-viewer/components/community-impact/AddImpactDialog.test.jsx
+++ b/frontend/src/features/video-viewer/components/community-impact/AddImpactDialog.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import { AddImpactDialog, normalizeImpactLink } from './AddImpactDialog';
@@ -44,10 +44,10 @@ describe('AddImpactDialog', () => {
 
 		render(<AddImpactDialog open />);
 
-		await user.type(screen.getByLabelText('Where did you see this film'), 'Jakarta');
+		fireEvent.change(screen.getByLabelText('Where did you see this film'), { target: { value: 'Jakarta' } });
 		await user.click(screen.getByRole('button', { name: 'Select community impact category' }));
 		await user.click(screen.getByRole('menuitemradio', { name: 'Screened In' }));
-		await user.type(screen.getByLabelText('Add more details'), tooManyWords);
+		fireEvent.change(screen.getByLabelText('Add more details'), { target: { value: tooManyWords } });
 
 		expect(screen.getByText('Maximum 80 Words • 81/80')).toBeVisible();
 		expect(screen.getByRole('button', { name: 'SUBMIT COMMUNITY IMPACT' })).toBeDisabled();
@@ -71,10 +71,10 @@ describe('AddImpactDialog', () => {
 
 		render(<AddImpactDialog onClose={onClose} onSubmit={onSubmit} open />);
 
-		await user.type(screen.getByLabelText('Where did you see this film'), 'Jakarta');
+		fireEvent.change(screen.getByLabelText('Where did you see this film'), { target: { value: 'Jakarta' } });
 		await user.click(screen.getByRole('button', { name: 'Select community impact category' }));
 		await user.click(screen.getByRole('menuitemradio', { name: 'Screened In' }));
-		await user.type(screen.getByLabelText('Add a link'), 'javascript:alert(1)');
+		fireEvent.change(screen.getByLabelText('Add a link'), { target: { value: 'javascript:alert(1)' } });
 		await user.click(screen.getByRole('button', { name: 'SUBMIT COMMUNITY IMPACT' }));
 
 		expect(onSubmit).not.toHaveBeenCalled();
@@ -88,10 +88,10 @@ describe('AddImpactDialog', () => {
 
 		render(<AddImpactDialog onSubmit={onSubmit} open />);
 
-		await user.type(screen.getByLabelText('Where did you see this film'), 'Jakarta');
+		fireEvent.change(screen.getByLabelText('Where did you see this film'), { target: { value: 'Jakarta' } });
 		await user.click(screen.getByRole('button', { name: 'Select community impact category' }));
 		await user.click(screen.getByRole('menuitemradio', { name: 'Screened In' }));
-		await user.type(screen.getByLabelText('Add a link'), 'example.com/path');
+		fireEvent.change(screen.getByLabelText('Add a link'), { target: { value: 'example.com/path' } });
 		await user.click(screen.getByRole('button', { name: 'SUBMIT COMMUNITY IMPACT' }));
 
 		expect(onSubmit).toHaveBeenCalledWith(


### PR DESCRIPTION
## Description

This PR updates the `/notifications/#preferences` panel to match the revised
issue #721 ordering and availability rules. The preferences UI now starts with
the editable engagement rows, keeps upload/archive rows read-only, and only
allows the three backend-wired preference fields to be changed:

- `on_comment`
- `on_like`
- `on_added_to_playlist`

The old category-level Push and Email switches have been removed. Each editable
row now uses a compact segmented control with the actual backend channel values:

| UI label | API value |
| -------- | --------- |
| Off | `none` |
| App | `in_app` |
| Email | `email` |

This keeps the frontend behavior aligned with the existing notification model:
there is no email-only state, and choosing `Email` still means in-app plus email.
The shorter label is intentional UX copy: if an email is sent, the app
notification should also exist, so the UI does not need to spell out
`App + Email` in the compact control. Screen readers still get the full
`In-App + Email` accessible label. No backend API or schema change is required.

The notifications page wrapper also keeps horizontal padding at tablet and
narrow desktop widths. The two-column layout no longer drops to `lg:px-0` while
using fixed-width columns, so the notification list and preference panel do not
sit flush against the viewport edges around the `lg` breakpoint.

I also stabilized the existing `AddImpactDialog` tests by replacing a few long
`user.type` operations with direct change events. That test file was passing in
isolation but timing out during the full Vitest suite; the change keeps the same
behavioral assertions while making the suite reliable under full load.

## Related Issue

Fixes #721

## Motivation and Context

The previous preferences layout started with an unavailable security category
and exposed several model fields whose event sources are not product-ready in
the current notification pipeline. It also had category-level switches that
could update multiple event preferences at once, making it easy for a user to
change one preference while unintentionally changing another.

Issue #721 asks for the UI to reflect what is actually available today. This
change narrows editable controls to the notification sources currently wired
through `NotificationService`, keeps future sources visible as coming-soon rows,
and removes bulk controls that do not map cleanly to the backend contract.

## How Has This Been Tested?

- `uv run python manage.py test notifications --settings=cms.ci_settings` — 101/101 passed.
- `cd frontend && npm run lint:modern` — 0 problems.
- `cd frontend && npm run lint:legacy` — 384 pre-existing warnings, 0 errors; no legacy files touched.
- `cd frontend && npm run test:run` — 57/57 files passed, 373/373 tests passed.
- `cd frontend && npm run build` — Vite production build succeeds.
- `uv run pre-commit run --files frontend/src/features/user-settings/components/NotificationPreferencesForm.jsx frontend/src/features/user-settings/components/NotificationPreferencesForm.test.jsx frontend/src/features/video-viewer/components/community-impact/AddImpactDialog.test.jsx frontend/src/features/notifications/components/NotificationPage.jsx` — passed.

The default local `python manage.py test notifications` command uses the local
mirrored database with migrations disabled and failed because the local DB is
missing `files_communityimpact`. The CI settings run above creates a fresh test
database and passes.

## Screenshots (if appropriate)
<img width="2847" height="1460" alt="image" src="https://github.com/user-attachments/assets/e973ce77-eaee-4c14-a394-f8be4f1f2fd6" />


## Types of changes

- [x] Bug fix (non-breaking change which fixes issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist

- [x] I have not imported `flux` in a new component.
- [x] If adding a new feature, I used Modern Track patterns.
- [x] New features do not create new SCSS files (use Tailwind instead).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced notification preferences with improved controls to select notification delivery method (off, in-app, or email) for each notification type.

* **Style**
  * Optimized responsive design for notification pages across various screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->