### PR TITLE
test(comments): assert expand button uses bg/primary

### DIFF
--- a/frontend/src/features/comments/components/CommentsPanel.test.jsx
+++ b/frontend/src/features/comments/components/CommentsPanel.test.jsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { CommentsPanel } from './CommentsPanel';
+
+vi.mock('../hooks/useComments', () => ({
+	useComments: () => ({
+		data: { count: 0, results: [] },
+		isLoading: false,
+		isError: false,
+		refetch: vi.fn(),
+	}),
+}));
+
+vi.mock('../hooks/useHiddenBelowCount', () => ({
+	useHiddenBelowCount: () => 0,
+}));
+
+vi.mock('./CommentForm', () => ({
+	CommentForm: () => <div data-testid="comment-form" />,
+}));
+
+vi.mock('./CommentItem', () => ({
+	CommentItem: () => <li data-testid="comment-item" />,
+}));
+
+describe('CommentsPanel', () => {
+	it('uses the shared primary action token for the expand comments button', () => {
+		render(<CommentsPanel friendlyToken="media-token" variant="sidebar" onExpandToggle={() => {}} />);
+
+		const button = screen.getByRole('button', { name: 'Expand comments' });
+
+		expect(button).toHaveClass('bg-bg-primary');
+		expect(button).toHaveClass('hover:bg-bg-primary-hover');
+	});
+});


### PR DESCRIPTION
## Description

Add a `CommentsPanel` render test that guards the comments expand/collapse button on the shared `bg/primary` purpose token (`bg-bg-primary` / `hover:bg-bg-primary-hover`). The test prevents reintroduction of a feature-scoped token for this control.

> Note: an earlier version of this PR introduced a dedicated `bg-comment-expand-button` token pair. That was reverted after review — the project convention is to use purpose-based semantic tokens and to keep shared roles on a shared token rather than create feature/component-scoped ones. The button stays on the existing `bg/primary` purpose token, so the net change here is the test only.

## Related Issue

Not linked to an issue.

## Motivation and Context

The expand button is a primary action affordance and already has a purpose-based token (`bg/primary`). A component-scoped token would couple the design system to one control without a real need. This test documents and guards the intended usage.

## How Has This Been Tested?

- `npx vitest run frontend/src/features/comments/components/CommentsPanel.test.jsx` — 1 test passes.
- `npm run build` succeeds; ESLint and Prettier clean on the changed file.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):

- [x] I have not imported `flux` in a new component
- [x] If adding a new feature, I used Modern Track patterns
- [x] New features do not create new SCSS files (use Tailwind instead)