### PR TITLE
feat(ui): uppercase button labels and group sidebar Manage links under a section title

### DIFF
--- a/frontend/src/features/layout/Sidebar/navigation/NavigationMenuList.jsx
+++ b/frontend/src/features/layout/Sidebar/navigation/NavigationMenuList.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useId } from 'react';
 import PropTypes from 'prop-types';
 
 import { Icon } from '../../../shared/components/Icon';
@@ -210,19 +210,33 @@ NavigationMenuListItem.propTypes = {
 	linkAttr: PropTypes.object,
 };
 
-export function NavigationMenuList({ removeVerticalPadding = false, items }) {
+export function NavigationMenuList({ removeVerticalPadding = false, title = null, items }) {
+	const headingId = useId();
 	const menuItems = items.map((item, index) => <NavigationMenuListItem key={index} itemType="label" {...item} />);
 
-	return menuItems.length ? (
+	if (!menuItems.length) {
+		return null;
+	}
+
+	return (
 		<div className={joinClasses(removeVerticalPadding ? 'py-0' : 'py-3')}>
-			<nav>
+			{title ? (
+				<h2
+					id={headingId}
+					className="mx-4 mb-1 px-4 pt-1 body-body-12-medium uppercase tracking-wide text-text-muted"
+				>
+					{title}
+				</h2>
+			) : null}
+			<nav aria-labelledby={title ? headingId : undefined}>
 				<ul className="m-0 list-none p-0">{menuItems}</ul>
 			</nav>
 		</div>
-	) : null;
+	);
 }
 
 NavigationMenuList.propTypes = {
 	removeVerticalPadding: PropTypes.bool,
+	title: PropTypes.string,
 	items: PropTypes.arrayOf(PropTypes.shape(NavigationMenuListItem.propTypes)).isRequired,
 };

--- a/frontend/src/features/layout/Sidebar/navigation/NavigationMenuList.test.jsx
+++ b/frontend/src/features/layout/Sidebar/navigation/NavigationMenuList.test.jsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+
+import { NavigationMenuList } from './NavigationMenuList';
+
+const ITEMS = [
+	{
+		itemType: 'link',
+		link: '/manage/media',
+		icon: 'gear',
+		text: 'Media',
+		itemAttr: { className: 'nav-item-manage-media' },
+	},
+	{
+		itemType: 'link',
+		link: '/manage/users',
+		icon: 'gear',
+		text: 'Users',
+		itemAttr: { className: 'nav-item-manage-users' },
+	},
+];
+
+describe('NavigationMenuList', () => {
+	it('renders a section heading and labels the nav when a title is provided', () => {
+		render(<NavigationMenuList title="Manage" items={ITEMS} />);
+
+		const heading = screen.getByRole('heading', { name: 'Manage' });
+		const nav = screen.getByRole('navigation', { name: 'Manage' });
+
+		expect(heading).toBeInTheDocument();
+		expect(nav).toHaveAttribute('aria-labelledby', heading.getAttribute('id'));
+	});
+
+	it('omits the heading and nav label when no title is provided', () => {
+		render(<NavigationMenuList items={ITEMS} />);
+
+		expect(screen.queryByRole('heading')).not.toBeInTheDocument();
+		expect(screen.getByRole('navigation')).not.toHaveAttribute('aria-labelledby');
+	});
+
+	it('renders the provided items as links to their destinations', () => {
+		render(<NavigationMenuList title="Manage" items={ITEMS} />);
+
+		expect(screen.getByRole('link', { name: 'Media' })).toHaveAttribute('href', '/manage/media');
+		expect(screen.getByRole('link', { name: 'Users' })).toHaveAttribute('href', '/manage/users');
+	});
+
+	it('renders nothing when there are no items', () => {
+		const { container } = render(<NavigationMenuList title="Manage" items={[]} />);
+
+		expect(container).toBeEmptyDOMElement();
+	});
+});

--- a/frontend/src/features/layout/Sidebar/navigation/SidebarNavigationMenu.jsx
+++ b/frontend/src/features/layout/Sidebar/navigation/SidebarNavigationMenu.jsx
@@ -149,7 +149,7 @@ export function SidebarNavigationMenu() {
 			items.push({
 				link: links.manage.media,
 				icon: 'gear',
-				text: 'Manage media',
+				text: 'Media',
 				className: 'nav-item-manage-media',
 			});
 		}
@@ -158,7 +158,7 @@ export function SidebarNavigationMenu() {
 			items.push({
 				link: links.manage.users,
 				icon: 'gear',
-				text: 'Manage users',
+				text: 'Users',
 				className: 'nav-item-manage-users',
 			});
 		}
@@ -167,7 +167,7 @@ export function SidebarNavigationMenu() {
 			items.push({
 				link: links.manage.comments,
 				icon: 'gear',
-				text: 'Manage comments',
+				text: 'Comments',
 				className: 'nav-item-manage-comments',
 			});
 		}
@@ -176,12 +176,12 @@ export function SidebarNavigationMenu() {
 			items.push({
 				link: links.manage.filmImpact,
 				icon: 'gear',
-				text: 'Manage film impact',
+				text: 'Film Impact',
 				className: 'nav-item-manage-film-impact',
 			});
 		}
 
-		return items.length ? <NavigationMenuList key="admin" items={formatItems(items)} /> : null;
+		return items.length ? <NavigationMenuList key="admin" title="Manage" items={formatItems(items)} /> : null;
 	}
 
 	const sections = [

--- a/frontend/src/features/layout/Sidebar/preview/NavigationMenuList.stories.jsx
+++ b/frontend/src/features/layout/Sidebar/preview/NavigationMenuList.stories.jsx
@@ -56,6 +56,11 @@ const meta = {
 			control: 'boolean',
 			description: 'Removes the vertical padding wrapper used by the legacy menu list.',
 		},
+		title: {
+			control: 'text',
+			description:
+				'Optional section title rendered as a heading above the list and used as the nav accessible name.',
+		},
 		items: {
 			control: 'object',
 			description: 'Navigation item objects rendered by the legacy list.',
@@ -74,5 +79,41 @@ export const Default = {};
 export const WithoutVerticalPadding = {
 	args: {
 		removeVerticalPadding: true,
+	},
+};
+
+export const WithSectionTitle = {
+	args: {
+		title: 'Manage',
+		items: [
+			{
+				itemType: 'link',
+				link: '/manage/media',
+				icon: 'gear',
+				text: 'Media',
+				itemAttr: { className: 'nav-item-manage-media' },
+			},
+			{
+				itemType: 'link',
+				link: '/manage/users',
+				icon: 'gear',
+				text: 'Users',
+				itemAttr: { className: 'nav-item-manage-users' },
+			},
+			{
+				itemType: 'link',
+				link: '/manage/comments',
+				icon: 'gear',
+				text: 'Comments',
+				itemAttr: { className: 'nav-item-manage-comments' },
+			},
+			{
+				itemType: 'link',
+				link: '/manage/film-impact',
+				icon: 'gear',
+				text: 'Film Impact',
+				itemAttr: { className: 'nav-item-manage-film-impact' },
+			},
+		],
 	},
 };

--- a/frontend/src/features/shared/components/Button/Button.jsx
+++ b/frontend/src/features/shared/components/Button/Button.jsx
@@ -128,7 +128,7 @@ export function Button({
 		<button
 			type={type}
 			className={cn(
-				'inline-flex cursor-pointer items-center transition-colors duration-200 disabled:cursor-not-allowed disabled:opacity-60 body-body-14-bold',
+				'inline-flex cursor-pointer items-center uppercase transition-colors duration-200 disabled:cursor-not-allowed disabled:opacity-60 body-body-14-bold',
 				getAlignClasses(shouldCenterIcon ? 'center' : align),
 				getVariantClasses(variant),
 				layoutClasses,


### PR DESCRIPTION
## Description

Two presentational changes requested in review:

- Button: all labels rendered by the shared `Button` component now display in uppercase.
- Sidebar: the administration links that were each prefixed with "Manage" are now grouped under a single "Manage" section title. The items are shortened to Media, Users, Comments, and Film Impact. Their destinations and permission gates are unchanged.

## Related Issue

Not applicable. These changes come from direct review feedback.

## Motivation and Context

- Uppercase button labels follow the updated design language.
- Repeating the "Manage" prefix on every administration link was redundant. Promoting it to a section title removes the repetition and improves scannability, while keeping the same links and permissions.

## How Has This Been Tested?

Environment: worktree based on upstream `main` (`f8a0801b`), Storybook in Chrome, Vitest component tests.

Automated:

- `npx vitest run` (full component suite): 59 files, 378 tests passed.
- `Button.test.jsx`: 15 passed. Confirms the uppercase change is CSS only, so the DOM text content and accessible names are unchanged.
- `NavigationMenuList.test.jsx`: 4 passed. New test covering the section title and `nav` labelling.
- ESLint (modern config) and Prettier pass on all changed files.

Manual test cases (Storybook, Chrome):

| # | Area | Steps | Expected | Result |
| - | ---- | ----- | -------- | ------ |
| 1 | Button uppercase | Open the Button stories and view a text button | Label displays uppercase (for example "READ MORE") | Pass |
| 2 | Button accessible name | Run the Button tests that query by original-case name | `getByRole` name queries still resolve | Pass |
| 3 | Sidebar section title | Open Sidebar > Navigation Menu List > With Section Title | A "MANAGE" heading appears above Media, Users, Comments, Film Impact | Pass |
| 4 | Links and permissions | Inspect the diff for the admin section | Only labels and grouping change; `links.manage.*` and `can.manage*` are unchanged | Pass |
| 5 | Accessibility | Inspect the `nav` landmark | `nav` is labelled by the heading via `aria-labelledby`, accessible name "Manage" | Pass |

## Screenshots (if appropriate):

### Sidebar: Manage section title

The administration links previously prefixed with "Manage" are grouped under a single "Manage" heading. Items: Media, Users, Comments, Film Impact.

![Sidebar Manage section with Media, Users, Comments, Film Impact](https://raw.githubusercontent.com/adryanev/cinematacms/assets-kumquat-feedback/sidebar_manage.png)

### Button: uppercase labels

![Button label rendered in uppercase](https://raw.githubusercontent.com/adryanev/cinematacms/assets-kumquat-feedback/button_uppercase.png)

### Demo

![Demo of both changes in Storybook](https://raw.githubusercontent.com/adryanev/cinematacms/assets-kumquat-feedback/demo.gif)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):

- [x] I have not imported `flux` in a new component
- [x] If adding a new feature, I used Modern Track patterns
- [x] New features do not create new SCSS files (use Tailwind instead)
