### PR TITLE
fix: Add more information and credits, fix mobile views

### DIFF
--- a/frontend/src/features/video-viewer/components/ViewerInfoContent.jsx
+++ b/frontend/src/features/video-viewer/components/ViewerInfoContent.jsx
@@ -86,14 +86,15 @@ export default function ViewerInfoContent(props) {
 	let summary = MediaPageStore.get('media-summary');
 	summary = summary ? summary.trim() : '';
 
-	const hasAboutText = '' !== description;
-	const [isAboutExpanded, setIsAboutExpanded] = useState(false);
-	const [isSummaryClamped, setIsSummaryClamped] = useState(false);
+	const hasSynopsis = '' !== summary;
+	const hasMoreInformationText = '' !== description;
+	const [isInfoExpanded, setIsInfoExpanded] = useState(false);
+	const [isInfoClamped, setIsInfoClamped] = useState(false);
+	const infoDetailsId = useId();
+	const infoTextRef = useRef(null);
 	const [communityImpacts, setCommunityImpacts] = useState(() => MediaPageStore.get('community-impacts'));
 	const [communityImpactSubmitStatus, setCommunityImpactSubmitStatus] = useState('idle');
 	const [communityImpactSubmitError, setCommunityImpactSubmitError] = useState(null);
-	const aboutDetailsId = useId();
-	const summaryTextRef = useRef(null);
 
 	function proceedMediaRemoval() {
 		MediaPageActions.removeMedia();
@@ -165,32 +166,30 @@ export default function ViewerInfoContent(props) {
 	}
 
 	useLayoutEffect(() => {
-		const summaryText = summaryTextRef.current;
+		const infoText = infoTextRef.current;
 
-		if (!summaryText || !hasAboutText || isAboutExpanded) {
-			setIsSummaryClamped(false);
+		if (!infoText || !hasMoreInformationText || isInfoExpanded) {
 			return undefined;
 		}
 
-		function measureSummaryClamp() {
-			const isBelowLg = window.matchMedia('(max-width: 1023.98px)').matches;
-			setIsSummaryClamped(isBelowLg && summaryText.scrollHeight > summaryText.clientHeight + 1);
+		function measureInfoClamp() {
+			setIsInfoClamped(infoText.scrollHeight > infoText.clientHeight + 1);
 		}
 
-		measureSummaryClamp();
-		window.addEventListener('resize', measureSummaryClamp);
+		measureInfoClamp();
+		window.addEventListener('resize', measureInfoClamp);
 
-		const resizeObserver = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(measureSummaryClamp) : null;
+		const resizeObserver = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(measureInfoClamp) : null;
 
 		if (resizeObserver) {
-			resizeObserver.observe(summaryText);
+			resizeObserver.observe(infoText);
 		}
 
 		return () => {
-			window.removeEventListener('resize', measureSummaryClamp);
+			window.removeEventListener('resize', measureInfoClamp);
 			resizeObserver?.disconnect();
 		};
-	}, [description, hasAboutText, isAboutExpanded]);
+	}, [description, hasMoreInformationText, isInfoExpanded]);
 
 	const authorLink = formatInnerLink(props.author.url, site.url);
 	const authorThumb = formatInnerLink(props.author.thumb, site.url);
@@ -246,10 +245,6 @@ export default function ViewerInfoContent(props) {
 	}
 
 	const metaFields = [
-		summary && {
-			title: 'Synopsis',
-			value: summary,
-		},
 		languagesContent.length && {
 			title: languagesContent.length > 1 ? 'Languages' : 'Language',
 			value: languagesContent,
@@ -323,26 +318,49 @@ export default function ViewerInfoContent(props) {
 											/>
 										</div>
 
-										{(hasAboutText || metaFields.length) && (
+										{(hasSynopsis || hasMoreInformationText || metaFields.length) && (
 											<div className="mt-6 border-b border-b-border-divider" />
 										)}
 									</>
 								)}
 
-								{hasAboutText && (
+								{hasSynopsis && (
+									<div className="media-content-summary mt-6 flex flex-col gap-3">
+										<Text variant="h6-medium" className="m-0">
+											Log Line / Synopsis
+										</Text>
+
+										<div className="relative">
+											<Text variant="body-16" className="m-0 wrap-break-word">
+												{hasHtmlDescription ? (
+													<span
+														dangerouslySetInnerHTML={{
+															__html: DOMPurify.sanitize(setTimestampAnchors(summary)),
+														}}
+													/>
+												) : (
+													setTimestampAnchors(summary)
+												)}
+											</Text>
+										</div>
+									</div>
+								)}
+
+								{hasMoreInformationText && (
 									<>
 										<div className="media-content-summary mt-6 flex flex-col gap-3">
 											<Text variant="h6-medium" className="m-0">
-												Log Line / Synopsis
+												More Information and Credits
 											</Text>
 
 											<div className="relative">
 												<Text
-													ref={summaryTextRef}
+													ref={infoTextRef}
+													id={infoDetailsId}
 													variant="body-16"
 													className={cn(
-														'm-0',
-														!isAboutExpanded && 'line-clamp-5 lg:line-clamp-none'
+														'm-0 wrap-break-word',
+														!isInfoExpanded && 'line-clamp-4'
 													)}
 												>
 													{hasHtmlDescription ? (
@@ -358,58 +376,46 @@ export default function ViewerInfoContent(props) {
 													)}
 												</Text>
 
-												{!isAboutExpanded && isSummaryClamped && (
-													<>
-														<Text
-															as="button"
-															action="text-button"
-															variant="body-14-bold"
-															color="accent"
-															type="button"
-															aria-controls={aboutDetailsId}
-															aria-expanded="false"
-															onClick={() => setIsAboutExpanded(true)}
-															className="inline align-baseline lg:hidden"
-														>
-															READ MORE
-														</Text>
-													</>
-												)}
-											</div>
-
-											{!isAboutExpanded && !isSummaryClamped && (
-												<>
+												{!isInfoExpanded && isInfoClamped && (
 													<Text
 														as="button"
 														action="text-button"
 														variant="body-14-bold"
 														color="accent"
 														type="button"
-														aria-controls={aboutDetailsId}
+														aria-controls={infoDetailsId}
 														aria-expanded="false"
-														onClick={() => setIsAboutExpanded(true)}
-														className="inline align-baseline lg:hidden"
+														onClick={() => setIsInfoExpanded(true)}
+														className="inline align-baseline"
 													>
 														READ MORE
 													</Text>
-												</>
-											)}
+												)}
+
+												{isInfoExpanded && (
+													<Text
+														as="button"
+														action="text-button"
+														variant="body-14-bold"
+														color="accent"
+														type="button"
+														aria-controls={infoDetailsId}
+														aria-expanded="true"
+														onClick={() => setIsInfoExpanded(false)}
+														className="inline align-baseline"
+													>
+														READ LESS
+													</Text>
+												)}
+											</div>
 										</div>
 										{metaFields.length > 0 && (
-											<div
-												className={cn(
-													'mt-6 border-b border-b-border-divider',
-													!isAboutExpanded && 'hidden lg:block'
-												)}
-											/>
+											<div className="mt-6 border-b border-b-border-divider" />
 										)}
 									</>
 								)}
 
-								<div
-									id={aboutDetailsId}
-									className={cn(hasAboutText && !isAboutExpanded ? 'hidden lg:block' : 'block')}
-								>
+								<div className="block">
 									{metaFields.length > 0 && (
 										<div className="flex flex-col gap-3 mt-6">
 											{metaFields.map((field) => (
@@ -474,22 +480,6 @@ export default function ViewerInfoContent(props) {
 										</div>
 									)}
 								</div>
-
-								{hasAboutText && isAboutExpanded && (
-									<Text
-										as="button"
-										action="text-button"
-										variant="body-14-bold"
-										color="accent"
-										type="button"
-										aria-controls={aboutDetailsId}
-										aria-expanded="true"
-										onClick={() => setIsAboutExpanded(false)}
-										className="mx-auto mt-6 flex lg:hidden"
-									>
-										CLOSE
-									</Text>
-								)}
 							</div>
 						</TabContent>
 						<TabContent title="COMMUNITY IMPACT">


### PR DESCRIPTION
  ## Description
  Reworked the media page "About the Film & Maker" tab to separate the short
  **Log Line / Synopsis** from a longer **More Information and Credits** section,
  and fixed the mobile expand/collapse behavior.

  - Swapped values: **Log Line / Synopsis** now renders the media `summary`,
    while the new **More Information and Credits** section renders the full
    `description`.
  - Removed the old `Synopsis` entry from the metadata (`metaFields`) list.
  - Added a dedicated **More Information and Credits** section, styled the same as
    the Log Line / Synopsis block.
  - Fixed mobile views: all sections now render in full by default (removed the
    old global mobile clamp + READ MORE / CLOSE that affected everything).
  - Scoped clamping to **More Information and Credits** only — it clamps to 4
    lines and exposes inline **READ MORE** / **READ LESS** toggles (measured via
    `ResizeObserver`).
  - Split rendering into two independent gates: `hasSynopsis` (`summary`) and
    `hasMoreInformationText` (`description`), so each section shows independently.
  - Removed dead state, refs, and effects from the previous clamp logic and
    pruned unused imports.

  ## Motivation and Context
  The media page conflated the log line and the synopsis under a single block,
  and the mobile READ MORE clamp applied to all content indiscriminately. This
  separates the short log line from the longer credits/info text and limits the
  clamp to the long section only, improving readability on mobile and desktop.

  ## How Has This Been Tested?
  Manual testing in the browser (mobile + desktop widths):
  - Verified Log Line / Synopsis renders `summary` and shows in full.
  - Verified More Information and Credits renders `description`, clamps at 4 lines,
    and that READ MORE / READ LESS toggle correctly only when content overflows.
  - Verified each section shows/hides independently based on its data.
  - Confirmed no leftover references to removed state and no lint/type diagnostics.

  ## Screenshots (if appropriate):
<img width="1600" height="1000" alt="image" src="https://github.com/user-attachments/assets/f83addff-245a-40f9-9e27-14aedec1cc0f" />
<img width="1600" height="1000" alt="image" src="https://github.com/user-attachments/assets/7929ab00-6345-4849-95af-2612022bc3f0" />
<img width="1600" height="1000" alt="image" src="https://github.com/user-attachments/assets/8f553df7-57f3-4e12-b5b8-0d196ed02758" />
<img width="1600" height="1000" alt="image" src="https://github.com/user-attachments/assets/b7507ac9-6f7e-4557-8454-c4bf6f2d5462" />
<img width="1600" height="1000" alt="image" src="https://github.com/user-attachments/assets/456e6dc6-1174-4ca2-ae6b-6668a16e5407" />
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/64b36006-9953-47ef-8591-61233a698809" />
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/26741c73-b84c-4c49-8a73-5632037dd59c" />

  ## Types of changes
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Documentation update

  ## Checklist:
  - [x] My code follows the code style of this project.
  - [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
  - [ ] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.

  ## Modern Track Checklist (for new features):
  - [x] I have not imported `flux` in a new component
  - [x] If adding a new feature, I used Modern Track patterns
  - [x] New features do not create new SCSS files (use Tailwind instead)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized video information display into separate "Log Line / Synopsis" and "More Information and Credits" sections
  * Enhanced expand/collapse functionality for improved content navigation and layout handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->