### PR TITLE
fix: Divider gone from synopsis section when it doesn't have more information

### DIFF
--- a/frontend/src/features/video-viewer/components/ViewerInfoContent.jsx
+++ b/frontend/src/features/video-viewer/components/ViewerInfoContent.jsx
@@ -409,10 +409,11 @@ export default function ViewerInfoContent(props) {
 												)}
 											</div>
 										</div>
-										{metaFields.length > 0 && (
-											<div className="mt-6 border-b border-b-border-divider" />
-										)}
 									</>
+								)}
+
+								{(hasMoreInformationText || hasSynopsis) && metaFields.length > 0 && (
+									<div className="mt-6 border-b border-b-border-divider" />
 								)}
 
 								<div className="block">

--- a/frontend/src/features/video-viewer/components/ViewerInfoContent.jsx
+++ b/frontend/src/features/video-viewer/components/ViewerInfoContent.jsx
@@ -359,7 +359,7 @@ export default function ViewerInfoContent(props) {
 													id={infoDetailsId}
 													variant="body-16"
 													className={cn(
-														'm-0 wrap-break-word',
+														'm-0 whitespace-pre-wrap wrap-break-word',
 														!isInfoExpanded && 'line-clamp-4'
 													)}
 												>

--- a/frontend/src/features/video-viewer/components/ViewerInfoContent.test.jsx
+++ b/frontend/src/features/video-viewer/components/ViewerInfoContent.test.jsx
@@ -160,7 +160,9 @@ describe('ViewerInfoContent', () => {
 
 		renderViewerInfoContent({ description });
 
-		const moreInformation = screen.getByText((_, element) => element?.tagName === 'P' && element.textContent === description);
+		const moreInformation = screen.getByText(
+			(_, element) => element?.tagName === 'P' && element.textContent === description
+		);
 
 		expect(moreInformation).toHaveClass('whitespace-pre-wrap');
 		expect(moreInformation.textContent).toBe(description);

--- a/frontend/src/features/video-viewer/components/ViewerInfoContent.test.jsx
+++ b/frontend/src/features/video-viewer/components/ViewerInfoContent.test.jsx
@@ -108,7 +108,7 @@ vi.mock('../../../static/js/contexts/SiteContext', async () => {
 	};
 });
 
-function renderViewerInfoContent() {
+function renderViewerInfoContent(overrides = {}) {
 	return render(
 		<ViewerInfoContent
 			author={{
@@ -118,7 +118,7 @@ function renderViewerInfoContent() {
 				thumb: '',
 				url: '/members/test-author',
 			}}
-			description=""
+			description={overrides.description ?? ''}
 			published="2026-05-31"
 			yearProduced=""
 		/>
@@ -153,5 +153,16 @@ describe('ViewerInfoContent', () => {
 		renderViewerInfoContent();
 
 		expect(screen.queryByText('Content Sensitivity')).not.toBeInTheDocument();
+	});
+
+	it('preserves paragraph breaks in more information and credits text', () => {
+		const description = 'Director statement.\n\nCredits and thanks.';
+
+		renderViewerInfoContent({ description });
+
+		const moreInformation = screen.getByText((_, element) => element?.tagName === 'P' && element.textContent === description);
+
+		expect(moreInformation).toHaveClass('whitespace-pre-wrap');
+		expect(moreInformation.textContent).toBe(description);
 	});
 });


### PR DESCRIPTION
## Description
Fixes the media viewer info layout so the divider before metadata is still shown when a media item has a synopsis but no “More Information and Credits” description.

Previously, the divider was only rendered inside the “More Information and Credits” block. When that block was absent, metadata could appear directly after the synopsis without the expected visual separation.

## Motivation and Context
This change keeps the media detail page layout consistent across content variations. Media with only a synopsis should still visually separate descriptive content from metadata fields.

## How Has This Been Tested?
Reviewed the latest commit diff and verified the divider condition now renders when either:
- synopsis content exists, or
- more information text exists, and metadata fields are present.

Automated tests were not run.

## Screenshots (if appropriate):
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/2ee2c735-69c3-4479-97b6-ff190b85180a" />
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/c248ef3e-63d3-4036-ac7f-d03c662abded" />
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/f733a66f-5173-4ca6-bf6f-ad898635e036" />

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Modern Track Checklist (for new features):
- [x] I have not imported `flux` in a new component
- [ ] If adding a new feature, I used Modern Track patterns
- [x] New features do not create new SCSS files (use Tailwind instead)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed display of the divider in the video metadata section to only appear when relevant content is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->