### PR TITLE
fix(home): mobile carousel dots, card badge/duration row, and hero responsive layout

### DIFF
--- a/frontend/src/features/home/components/Carousel.jsx
+++ b/frontend/src/features/home/components/Carousel.jsx
@@ -318,28 +318,68 @@ function CarouselOverlayArrows() {
 	);
 }
 
+// Cap how many page dots render at once so a long playlist (up to 20 pages on
+// mobile, where one item fills the viewport) cannot overflow the screen. The
+// window slides to keep the active page centered; boundary dots shrink to
+// signal that more pages exist beyond the visible range.
+const MAX_VISIBLE_DOTS = 7;
+
+function getDotWindow(count, activeIndex, maxVisible) {
+	if (count <= maxVisible) {
+		return { start: 0, end: count - 1 };
+	}
+	const half = Math.floor(maxVisible / 2);
+	let start = activeIndex - half;
+	let end = activeIndex + half;
+	if (start < 0) {
+		end -= start;
+		start = 0;
+	}
+	if (end > count - 1) {
+		start -= end - (count - 1);
+		end = count - 1;
+	}
+	return { start: Math.max(0, start), end };
+}
+
 function CarouselIndicator({ count, activeIndex, onSelect }) {
+	const { start, end } = getDotWindow(count, activeIndex, MAX_VISIBLE_DOTS);
+	const indices = [];
+	for (let i = start; i <= end; i += 1) {
+		indices.push(i);
+	}
+
 	return (
 		<div className="flex items-center gap-2" role="group" aria-label="Page navigation">
-			{Array.from({ length: count }, (_, i) => (
-				<button
-					key={i}
-					type="button"
-					onClick={() => onSelect(i)}
-					aria-label={`Go to page ${i + 1}`}
-					aria-current={i === activeIndex ? 'true' : undefined}
-					className="inline-flex size-6 min-w-6 items-center justify-center rounded-full border-0 bg-transparent p-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-bg-page"
-				>
-					<span
-						aria-hidden="true"
-						className={`rounded-full transition-[width,background-color] duration-300 ${
-							i === activeIndex
-								? 'h-2 w-6 bg-bg-primary'
-								: 'size-2 bg-border-strong/30 hover:bg-border-strong/50'
-						}`}
-					/>
-				</button>
-			))}
+			{indices.map((i) => {
+				const isActive = i === activeIndex;
+				const isEdge = !isActive && ((i === start && start > 0) || (i === end && end < count - 1));
+
+				let dotClass;
+				if (isActive) {
+					dotClass = 'h-2 w-6 bg-bg-primary';
+				} else if (isEdge) {
+					dotClass = 'size-1.5 bg-border-strong/30 hover:bg-border-strong/50';
+				} else {
+					dotClass = 'size-2 bg-border-strong/30 hover:bg-border-strong/50';
+				}
+
+				return (
+					<button
+						key={i}
+						type="button"
+						onClick={() => onSelect(i)}
+						aria-label={`Go to page ${i + 1}`}
+						aria-current={isActive ? 'true' : undefined}
+						className="inline-flex size-6 min-w-6 items-center justify-center rounded-full border-0 bg-transparent p-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-bg-page"
+					>
+						<span
+							aria-hidden="true"
+							className={`rounded-full transition-[width,background-color] duration-300 ${dotClass}`}
+						/>
+					</button>
+				);
+			})}
 		</div>
 	);
 }

--- a/frontend/src/features/home/components/Carousel.stories.jsx
+++ b/frontend/src/features/home/components/Carousel.stories.jsx
@@ -1,0 +1,85 @@
+import { expect, within } from 'storybook/test';
+
+import { Carousel } from './Carousel';
+
+function createPosterDataUrl(index) {
+	const hue = (index * 37) % 360;
+	return `data:image/svg+xml;utf8,${encodeURIComponent(`
+		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 180">
+			<rect width="320" height="180" fill="hsl(${hue} 38% 22%)" />
+			<rect x="0" y="120" width="320" height="60" fill="hsl(${hue} 42% 16%)" />
+			<text x="16" y="40" fill="#F9FAFB" font-family="Inter, sans-serif" font-size="20">Clip ${index + 1}</text>
+		</svg>
+	`)}`;
+}
+
+function makeItems(count) {
+	return Array.from({ length: count }, (_, index) => ({
+		friendly_token: `token-${index}`,
+		title: `Hilakbot ng Lente (Horrors Through the Lens) ${index + 1}`,
+		thumbnail_url: createPosterDataUrl(index),
+		url: `/media/item-${index}/`,
+		duration_in_seconds: 1120 + index * 7,
+		author_name: 'TAM DokyuFest',
+		media_country: 'Philippines',
+		views: 161 + index * 11,
+		categories_info: [{ title: 'Documentary', color: 'bg/primary' }],
+	}));
+}
+
+const meta = {
+	title: 'Features/Home/Carousel',
+	component: Carousel,
+	tags: ['autodocs'],
+	parameters: {
+		layout: 'fullscreen',
+		docs: {
+			description: {
+				component:
+					'Home page media carousel. Uses native horizontal scroll-snap with overlay arrows on wider viewports and pagination dots below. The number of visible items per page is responsive, defaulting to one item per page on phone widths. Pagination dots are capped at seven with a sliding window centered on the active page so a long playlist cannot overflow a narrow viewport.',
+			},
+		},
+	},
+};
+
+export default meta;
+
+// Wide viewport: several items per page, a small number of pages, every dot shown.
+export const Default = {
+	render: () => (
+		<div className="mx-auto w-full max-w-[1100px] px-6 py-8">
+			<Carousel items={makeItems(12)} visibleCount={4} />
+		</div>
+	),
+};
+
+// Phone width: one item per page across 20 pages. Demonstrates the windowed
+// pagination dots staying inside the viewport instead of overflowing.
+export const MobileManyPages = {
+	render: () => (
+		<div className="mx-auto w-[360px] px-3 py-6">
+			<Carousel items={makeItems(20)} visibleCount={1} />
+		</div>
+	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const dots = canvas.getAllByRole('button', { name: /^Go to page \d+$/ });
+		await expect(dots).toHaveLength(7);
+		await expect(canvas.getByRole('button', { name: 'Go to page 1' })).toBeInTheDocument();
+		await expect(canvas.queryByRole('button', { name: 'Go to page 8' })).toBeNull();
+	},
+};
+
+// Phone width with few pages: no window needed, all dots render.
+export const MobileFewPages = {
+	render: () => (
+		<div className="mx-auto w-[360px] px-3 py-6">
+			<Carousel items={makeItems(4)} visibleCount={1} />
+		</div>
+	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const dots = canvas.getAllByRole('button', { name: /^Go to page \d+$/ });
+		await expect(dots).toHaveLength(4);
+	},
+};

--- a/frontend/src/features/home/components/Carousel.test.jsx
+++ b/frontend/src/features/home/components/Carousel.test.jsx
@@ -158,6 +158,33 @@ describe('Carousel — default shape', () => {
 		expect(dot.firstElementChild).toHaveClass('size-2');
 	});
 
+	it('caps page dots at seven so many pages cannot overflow the row', () => {
+		render(<Carousel items={makeItems(20)} visibleCount={1} />);
+
+		const dots = screen.getAllByRole('button', { name: /^Go to page \d+$/ });
+		expect(dots).toHaveLength(7);
+		expect(screen.getByRole('button', { name: 'Go to page 1' })).toBeInTheDocument();
+		expect(screen.queryByRole('button', { name: 'Go to page 8' })).toBeNull();
+	});
+
+	it('shrinks the boundary dot when more pages exist beyond the window', () => {
+		render(<Carousel items={makeItems(20)} visibleCount={1} />);
+
+		const trailingEdge = screen.getByRole('button', { name: 'Go to page 7' });
+		expect(trailingEdge.firstElementChild).toHaveClass('size-1.5');
+	});
+
+	it('slides the dot window to keep the active page in view', async () => {
+		const user = userEvent.setup();
+		render(<Carousel items={makeItems(20)} visibleCount={1} />);
+
+		await user.click(screen.getByRole('button', { name: 'Go to page 7' }));
+
+		expect(screen.getByRole('button', { name: 'Go to page 7' })).toHaveAttribute('aria-current', 'true');
+		expect(screen.getByRole('button', { name: 'Go to page 10' })).toBeInTheDocument();
+		expect(screen.queryByRole('button', { name: 'Go to page 1' })).toBeNull();
+	});
+
 	it('defaults to one visible item on phone viewports', () => {
 		mockViewportWidth(390);
 		render(<Carousel items={makeItems(4)} />);

--- a/frontend/src/features/home/components/HeroMediaCard.jsx
+++ b/frontend/src/features/home/components/HeroMediaCard.jsx
@@ -55,7 +55,7 @@ function AuthorName({ href, name }) {
 	);
 }
 
-export function HeroMediaCard({ className = '', media }) {
+export function HeroMediaCard({ className = '', media, style, isDesktop = false }) {
 	if (!media) {
 		return null;
 	}
@@ -67,8 +67,18 @@ export function HeroMediaCard({ className = '', media }) {
 	const mediaHref = getMediaHref(media);
 
 	return (
-		<div className={cn('w-full min-w-0', className)}>
-			<Card className="flex h-full min-h-[360px] flex-col justify-between gap-8 overflow-hidden px-[22px] pb-6 pt-[22px] lg:min-h-0">
+		<div className={cn('flex min-w-0 flex-col', className)} style={style}>
+			<Card
+				className={cn(
+					// justify-between pins the author/country/views block to the card bottom
+					// when the summary is short (the spare height goes into the gap). When the
+					// summary is long there is no spare height, so the groups sit at the gap-4
+					// minimum (16px) and the card grows past its floor without clipping. The
+					// card fills its minHeight floor via flex-1.
+					'flex flex-1 flex-col justify-between gap-4 overflow-hidden px-[22px] pb-6 pt-[22px]',
+					isDesktop ? '' : 'min-h-[360px]'
+				)}
+			>
 				<div className="flex min-w-0 flex-col gap-3">
 					<Text as="h2" variant="h6" className="m-0 max-w-full overflow-hidden break-words text-text-primary">
 						{mediaHref ? (
@@ -87,7 +97,13 @@ export function HeroMediaCard({ className = '', media }) {
 						<Text
 							variant="body-14"
 							color="description"
-							className="m-0 max-h-[260px] overflow-hidden lg:max-h-[280px]"
+							// The card height is a floor, not a cap (see heroCardStyle and
+							// the flex-1 card), so the full text always renders and the card
+							// grows when needed. The displayed field is `summary`, capped at
+							// 60 words server-side (files/forms.py clean_summary);
+							// `description` is the rare unbounded fallback used only when
+							// summary is empty.
+							className="m-0"
 						>
 							{description}
 						</Text>
@@ -122,9 +138,9 @@ export function HeroMediaCard({ className = '', media }) {
 	);
 }
 
-export function HeroMediaCardSkeleton({ className = '' }) {
+export function HeroMediaCardSkeleton({ className = '', style }) {
 	return (
-		<Card as="div" className={cn('w-full min-w-0 p-[22px]', className)}>
+		<Card as="div" className={cn('min-w-0 p-[22px]', className)} style={style}>
 			<div className="h-8 w-3/4 animate-pulse rounded bg-bg-skeleton" />
 			<div className="mt-3 h-4 w-1/2 animate-pulse rounded bg-bg-skeleton" />
 		</Card>

--- a/frontend/src/features/home/components/HeroSection.jsx
+++ b/frontend/src/features/home/components/HeroSection.jsx
@@ -12,16 +12,73 @@ import HeroPlayButtonIcon from '../../shared/icons/hero-play-button.svg?react';
 
 const HeroContext = createContext(null);
 
-const HERO_DESKTOP_MIN_WIDTH = 1175;
+// Two-column layout engages by VIEWPORT width at the common 1366px laptop width.
+// The common desktop CSS widths are 1280, 1366, 1440, 1536, 1920; 1366 and above
+// render two columns (1366, 1440, 1536, 1920) and below it (1024, 1280) renders
+// one column in both sidebar states. Two columns at 1280 left the text card too
+// narrow, so the switch is set at 1366 where the card has more room. A
+// container-width threshold cannot separate the close cases reliably: 1024 with
+// the sidebar closed (~906px container) and 1280 with the sidebar open (~922px)
+// are only ~16px apart. The container is still measured with a ResizeObserver to
+// size the player and card, and must clear a floor (the `md` breakpoint, 768px)
+// so two columns never render in a container too narrow to hold them.
+const HERO_DESKTOP_MIN_VIEWPORT = 1366;
+const HERO_CONTAINER_MIN_WIDTH = 768;
+const HERO_GAP_PX = 26;
+const HERO_CARD_MIN_WIDTH_PX = 320;
+const HERO_CARD_MAX_WIDTH_PX = 466;
+const HERO_CARD_WIDTH_RATIO = 0.36;
+const HERO_HEIGHT_MIN_PX = 300;
+const HERO_HEIGHT_MAX_PX = 440;
+const HERO_PLAYER_ASPECT = 9 / 16;
 const HERO_LAYOUT = 'flex w-full flex-col gap-6';
 const HERO_LAYOUT_DESKTOP = 'flex-row items-start gap-[26px]';
 const PLAYER_AREA = 'w-full min-w-0';
 const PLAYER_AREA_DESKTOP = 'flex-1';
 const PLAYER_FRAME = 'relative aspect-video w-full overflow-hidden rounded-[6px] bg-site-player-canvas';
-const PLAYER_FRAME_DESKTOP = 'h-[440px] aspect-auto';
+const PLAYER_FRAME_DESKTOP = 'aspect-auto';
 const PLAYER_CLASS = 'relative h-full w-full overflow-hidden rounded-[6px] bg-site-player-canvas';
-const CARD_AREA = 'w-full min-w-0';
-const CARD_AREA_DESKTOP = 'h-[440px] w-[466px] shrink-0';
+// The card width is set via the computed inline style on desktop. Tailwind
+// utilities are generated with !important in this project, so `w-full` would
+// override that inline width and collapse the player. The card therefore takes
+// `w-full` only on mobile (CARD_AREA_MOBILE) and relies on the inline width plus
+// `shrink-0` on desktop.
+const CARD_AREA = 'min-w-0';
+const CARD_AREA_MOBILE = 'w-full';
+const CARD_AREA_DESKTOP = 'shrink-0';
+
+// Fluid two-column metrics. The card width scales with the container (clamped to
+// a 320-466px band) and the shared player/card height is derived from the
+// remaining player width at a 16:9 ratio (clamped to 300-440px). This keeps the
+// player at a correct aspect ratio at every desktop width instead of forcing a
+// fixed 440px height that squashes the video on narrower screens.
+function computeHeroDesktopMetrics(containerWidth) {
+	const cardWidth = Math.round(
+		Math.min(HERO_CARD_MAX_WIDTH_PX, Math.max(HERO_CARD_MIN_WIDTH_PX, containerWidth * HERO_CARD_WIDTH_RATIO))
+	);
+	const playerWidth = containerWidth - cardWidth - HERO_GAP_PX;
+	const height = Math.round(
+		Math.min(HERO_HEIGHT_MAX_PX, Math.max(HERO_HEIGHT_MIN_PX, playerWidth * HERO_PLAYER_ASPECT))
+	);
+	return { cardWidth, height };
+}
+
+function heroPlayerFrameStyle(metrics) {
+	// Fixed height keeps the player at a true 16:9 frame (the height is derived from
+	// the player width at a 9/16 ratio in computeHeroDesktopMetrics). The card uses
+	// the same value as a minHeight floor, so the two columns match while the player
+	// never letterboxes.
+	return metrics ? { height: metrics.height } : undefined;
+}
+
+function heroCardStyle(metrics) {
+	// The card width is fixed, but the height is a floor, not a cap. It matches the
+	// player height when the synopsis is short and grows past it when the text is
+	// longer, so the card never clips the description or the author/country/views
+	// block. The wrapper is a flex column and the card is flex-1 (see HeroMediaCard),
+	// which lets the card fill the floor yet expand to its content height.
+	return metrics ? { width: metrics.cardWidth, minHeight: metrics.height } : undefined;
+}
 
 class HeroPlayerErrorBoundary extends Component {
 	constructor(props) {
@@ -58,29 +115,41 @@ function useHeroMediaDetail(media) {
 
 function useHeroDesktopLayout() {
 	const rootRef = useRef(null);
-	const [isDesktopLayout, setIsDesktopLayout] = useState(false);
+	const [containerWidth, setContainerWidth] = useState(0);
+	const [viewportWidth, setViewportWidth] = useState(0);
 
 	useLayoutEffect(() => {
 		const root = rootRef.current;
 		if (!root) return undefined;
 
 		const updateLayout = () => {
-			setIsDesktopLayout(root.getBoundingClientRect().width >= HERO_DESKTOP_MIN_WIDTH);
+			setContainerWidth(root.getBoundingClientRect().width);
+			setViewportWidth(window.innerWidth);
 		};
 
 		updateLayout();
 
+		let resizeObserver;
 		if ('undefined' !== typeof ResizeObserver) {
-			const resizeObserver = new ResizeObserver(updateLayout);
+			resizeObserver = new ResizeObserver(updateLayout);
 			resizeObserver.observe(root);
-			return () => resizeObserver.disconnect();
 		}
-
 		window.addEventListener('resize', updateLayout);
-		return () => window.removeEventListener('resize', updateLayout);
+		return () => {
+			if (resizeObserver) {
+				resizeObserver.disconnect();
+			}
+			window.removeEventListener('resize', updateLayout);
+		};
 	}, []);
 
-	return { rootRef, isDesktopLayout };
+	const isDesktopLayout = viewportWidth >= HERO_DESKTOP_MIN_VIEWPORT && containerWidth >= HERO_CONTAINER_MIN_WIDTH;
+	const desktopMetrics = useMemo(
+		() => (isDesktopLayout ? computeHeroDesktopMetrics(containerWidth) : null),
+		[isDesktopLayout, containerWidth]
+	);
+
+	return { rootRef, isDesktopLayout, desktopMetrics };
 }
 
 function PlayAffordance() {
@@ -146,11 +215,14 @@ function Player() {
 	const playerKey = playback.sources[0]?.src ?? poster ?? media?.friendly_token;
 
 	if (!ctx || !media) return null;
-	const { isDesktopLayout, isHeroDetailError, retryHeroDetail } = ctx;
+	const { isDesktopLayout, desktopMetrics, isHeroDetailError, retryHeroDetail } = ctx;
 
 	return (
 		<div className={cn(PLAYER_AREA, isDesktopLayout ? PLAYER_AREA_DESKTOP : '')}>
-			<div className={cn(PLAYER_FRAME, isDesktopLayout ? PLAYER_FRAME_DESKTOP : '')}>
+			<div
+				className={cn(PLAYER_FRAME, isDesktopLayout ? PLAYER_FRAME_DESKTOP : '')}
+				style={heroPlayerFrameStyle(desktopMetrics)}
+			>
 				{playback.sources.length ? (
 					<HeroPlayerErrorBoundary fallback={<HeroPosterFallback src={poster} />} key={playerKey}>
 						<HeroVideoPlayer
@@ -187,14 +259,21 @@ function Player() {
 function Card() {
 	const ctx = use(HeroContext);
 	if (!ctx) return null;
-	const { media, isDesktopLayout } = ctx;
+	const { media, isDesktopLayout, desktopMetrics } = ctx;
 
-	return <HeroMediaCard media={media} className={cn(CARD_AREA, isDesktopLayout ? CARD_AREA_DESKTOP : '')} />;
+	return (
+		<HeroMediaCard
+			media={media}
+			isDesktop={isDesktopLayout}
+			className={cn(CARD_AREA, isDesktopLayout ? CARD_AREA_DESKTOP : CARD_AREA_MOBILE)}
+			style={heroCardStyle(desktopMetrics)}
+		/>
+	);
 }
 
 export function HeroSection({ children }) {
 	const { data, isLoading, isError, refetch } = useFeaturedMedia();
-	const { rootRef, isDesktopLayout } = useHeroDesktopLayout();
+	const { rootRef, isDesktopLayout, desktopMetrics } = useHeroDesktopLayout();
 
 	const items = normalizeMediaList(data);
 	const listMedia = items[0] ?? null;
@@ -208,8 +287,8 @@ export function HeroSection({ children }) {
 	}, [media?.thumbnail_url]);
 
 	const value = useMemo(
-		() => ({ media, isDesktopLayout, isHeroDetailError, retryHeroDetail }),
-		[media, isDesktopLayout, isHeroDetailError, retryHeroDetail]
+		() => ({ media, isDesktopLayout, desktopMetrics, isHeroDetailError, retryHeroDetail }),
+		[media, isDesktopLayout, desktopMetrics, isHeroDetailError, retryHeroDetail]
 	);
 
 	if (isError && !media) {
@@ -220,7 +299,10 @@ export function HeroSection({ children }) {
 					aria-label="Featured media"
 				>
 					<div className={cn(PLAYER_AREA, isDesktopLayout ? PLAYER_AREA_DESKTOP : '')}>
-						<div className={cn(PLAYER_FRAME, isDesktopLayout ? PLAYER_FRAME_DESKTOP : '')}>
+						<div
+							className={cn(PLAYER_FRAME, isDesktopLayout ? PLAYER_FRAME_DESKTOP : '')}
+							style={heroPlayerFrameStyle(desktopMetrics)}
+						>
 							<div className="flex h-full w-full items-center justify-center">
 								<button
 									type="button"
@@ -232,7 +314,10 @@ export function HeroSection({ children }) {
 							</div>
 						</div>
 					</div>
-					<HeroMediaCardSkeleton className={cn(CARD_AREA, isDesktopLayout ? CARD_AREA_DESKTOP : '')} />
+					<HeroMediaCardSkeleton
+						className={cn(CARD_AREA, isDesktopLayout ? CARD_AREA_DESKTOP : CARD_AREA_MOBILE)}
+						style={heroCardStyle(desktopMetrics)}
+					/>
 				</section>
 			</div>
 		);
@@ -257,8 +342,12 @@ export function HeroSection({ children }) {
 							'aspect-video rounded-[6px] bg-bg-skeleton animate-pulse',
 							isDesktopLayout ? `${PLAYER_AREA_DESKTOP} ${PLAYER_FRAME_DESKTOP}` : ''
 						)}
+						style={heroPlayerFrameStyle(desktopMetrics)}
 					/>
-					<HeroMediaCardSkeleton className={cn(CARD_AREA, isDesktopLayout ? CARD_AREA_DESKTOP : '')} />
+					<HeroMediaCardSkeleton
+						className={cn(CARD_AREA, isDesktopLayout ? CARD_AREA_DESKTOP : CARD_AREA_MOBILE)}
+						style={heroCardStyle(desktopMetrics)}
+					/>
 				</div>
 			</div>
 		);

--- a/frontend/src/features/home/components/HeroSection.test.jsx
+++ b/frontend/src/features/home/components/HeroSection.test.jsx
@@ -43,6 +43,7 @@ const SAMPLE_MEDIA = {
 };
 
 const originalResizeObserver = window.ResizeObserver;
+const originalInnerWidth = window.innerWidth;
 
 function makeClient(seededData) {
 	const client = new QueryClient({ defaultOptions: { queries: { retry: false, staleTime: 60_000 } } });
@@ -68,10 +69,23 @@ describe('HeroSection', () => {
 			writable: true,
 			value: originalResizeObserver,
 		});
+		Object.defineProperty(window, 'innerWidth', {
+			configurable: true,
+			writable: true,
+			value: originalInnerWidth,
+		});
 		vi.restoreAllMocks();
 	});
 
 	function mockHeroWidth(width) {
+		// Two-column layout requires both a desktop viewport and a container that
+		// clears the floor, so mock the viewport alongside the container width.
+		Object.defineProperty(window, 'innerWidth', {
+			configurable: true,
+			writable: true,
+			value: Math.max(width, 1366),
+		});
+
 		vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
 			bottom: 0,
 			height: 0,
@@ -154,11 +168,15 @@ describe('HeroSection', () => {
 		await waitFor(() => expect(region).toHaveClass('flex-row'));
 
 		const player = screen.getByTestId('hero-video-player');
-		expect(player.parentElement).toHaveClass('h-[440px]');
 		expect(player.parentElement).toHaveClass('aspect-auto');
+		// The player frame keeps a fixed 16:9 height; the card uses the same value as a
+		// minHeight floor so the two columns match without the player letterboxing.
+		expect(player.parentElement).toHaveStyle({ height: '440px' });
 		expect(player.parentElement.parentElement).toHaveClass('flex-1');
-		expect(screen.getByRole('article').parentElement).toHaveClass('w-[466px]');
-		expect(screen.getByRole('article').parentElement).toHaveClass('h-[440px]');
+		expect(screen.getByRole('article').parentElement).toHaveClass('shrink-0');
+		// The card width is fixed; its height is a floor (minHeight), so the card
+		// grows past the player height when the synopsis is long instead of clipping.
+		expect(screen.getByRole('article').parentElement).toHaveStyle({ width: '466px', minHeight: '440px' });
 	});
 
 	it('uses the light mode Figma color mapping for the metadata card', () => {

--- a/frontend/src/features/shared/components/MovieItem/MovieItem.jsx
+++ b/frontend/src/features/shared/components/MovieItem/MovieItem.jsx
@@ -121,19 +121,23 @@ function MoviePoster({
 				decoding="async"
 			/>
 
-			{badge ? (
-				<Badge color={badgeColor} className="absolute bottom-3 left-3" data-movie-item-badge>
-					{badge}
-				</Badge>
-			) : null}
+			{badge || duration ? (
+				<div className="absolute inset-x-2 bottom-2 flex items-center gap-2">
+					{badge ? (
+						<Badge color={badgeColor} data-movie-item-badge>
+							{badge}
+						</Badge>
+					) : null}
 
-			{duration ? (
-				<span
-					className="absolute right-1 bottom-1 inline-flex rounded-[2px] bg-bg-overlay-dark px-1 py-[2px] font-sans text-[12px] font-medium leading-[13.5px] tracking-[0.5px] text-text-on-chrome"
-					data-movie-item-duration
-				>
-					{duration}
-				</span>
+					{duration ? (
+						<span
+							className="ml-auto inline-flex rounded-[2px] bg-bg-overlay-dark px-1 py-[2px] font-sans text-[12px] font-medium leading-[13.5px] tracking-[0.5px] text-text-on-chrome"
+							data-movie-item-duration
+						>
+							{duration}
+						</span>
+					) : null}
+				</div>
 			) : null}
 
 			{showTopRightIcon && iconName ? (

--- a/frontend/src/features/shared/components/MovieItem/MovieItem.test.jsx
+++ b/frontend/src/features/shared/components/MovieItem/MovieItem.test.jsx
@@ -25,8 +25,10 @@ describe('MovieItem', () => {
 		expect(screen.getByText('PG-13')).toBeVisible();
 		expect(screen.getByText('4K')).toBeVisible();
 		expect(screen.getByText('Premiere')).toBeVisible();
-		expect(screen.getByText('2h 3m')).toHaveClass('right-1');
-		expect(screen.getByText('2h 3m')).toHaveClass('bottom-1');
+		// Badge and duration share one bottom row; duration is pushed to the right edge with ml-auto.
+		expect(screen.getByText('2h 3m')).toHaveClass('ml-auto');
+		expect(screen.getByText('2h 3m').closest('div')).toHaveClass('inset-x-2');
+		expect(screen.getByText('2h 3m').closest('div')).toHaveClass('bottom-2');
 		expect(screen.getByText('2h 3m')).toHaveClass('text-[12px]');
 		expect(screen.getByText('2h 3m')).toHaveClass('leading-[13.5px]');
 		expect(screen.getByText('2h 3m')).toHaveClass('tracking-[0.5px]');


### PR DESCRIPTION
## Description
Three mobile and responsive fixes for the home page revamp.

1. Carousel pagination dots overflow on mobile. On phone widths the carousel shows one item per page, so a 20-item playlist produced 20 page dots. Each dot is a 24px tap-target button, so the row exceeded the viewport width and overflowed the screen. The visible dots are now capped at seven using a sliding window centered on the active page. Boundary dots shrink to indicate that more pages exist. All pages remain reachable by swiping the track or by clicking a boundary dot to shift the window.

2. Media card badge and duration alignment. The category badge and the duration timestamp were two separate overlays at different vertical offsets, so they sat on different lines. They are now wrapped in a single flex row anchored at `inset-x-2 bottom-2`. The badge stays on the left and the duration is pushed to the right with `ml-auto`, so they align on one horizontal line.

3. Hero section layout and viewport breakpoint. The hero card meta is pinned to the bottom of the card, the player keeps a 16:9 ratio, and the desktop two-column layout now switches on viewport width rather than container width. See the breakpoint change below.

A Storybook story for the home carousel is also added (Default, MobileManyPages, MobileFewPages), with play assertions for the dot cap.

## Related Issue
None.

## Motivation and Context
The pagination dots extended past the screen edge on narrow viewports, which broke the layout. The card category badge and duration timestamp were on separate lines and looked inconsistent. The hero two-column layout switched on container width, which could not separate close cases reliably. All three are visual or responsive defects in the home page revamp.

### Hero section viewport breakpoint change
The hero previously switched to the two-column desktop layout based on the measured container width (`HERO_DESKTOP_MIN_WIDTH = 1175`). A container-width threshold cannot separate close cases: 1024px with the sidebar closed gives an approximately 906px container, and 1280px with the sidebar open gives approximately 922px, only about 16px apart. The switch now uses the viewport width instead, with a container floor:

| Constant | Before | After | Measured against |
| --- | --- | --- | --- |
| `HERO_DESKTOP_MIN_VIEWPORT` | (none) | `1366` | `window.innerWidth` |
| `HERO_CONTAINER_MIN_WIDTH` | (none) | `768` (the `md` breakpoint) | container width via ResizeObserver |
| `HERO_DESKTOP_MIN_WIDTH` | `1175` | removed | container width |

The two-column layout now engages only when the viewport width is at least 1366px and the container width is at least 768px; otherwise it renders one column. 1366px was chosen because at 1280px the two-column layout left the text card too narrow; the common desktop CSS widths are 1280, 1366, 1440, 1536, and 1920, so 1366 and above render two columns. The container is still measured with a ResizeObserver to size the player and card, and the 768px floor ensures two columns never render in a container too narrow to hold them.

### Carousel items per page (context, not changed by this PR)
The carousel items-per-page values in `carouselLayout.js` are unchanged. They determine the page and dot count: one item per page at `<= 639px` (up to 20 dots for a 20-item playlist), two at `<= 1023px`, and up to four above that. The dot cap added here keeps the dot row inside the viewport at all of these without changing the values.

## How Has This Been Tested?
Vitest unit tests in `frontend`:
- `Carousel.test.jsx`: added tests for the dot cap (seven maximum), boundary dot shrinking, and window sliding on navigation.
- `MovieItem.test.jsx`: updated the duration overlay assertions to the new single-row layout.
- `HeroSection.test.jsx` and `HeroMediaCard.test.jsx`: existing hero tests pass with the breakpoint change (30 tests).
- `MediaTile.test.jsx`: existing duration attribute tests pass.

All carousel, MovieItem, MediaTile, SectionRow, contract, and hero tests pass.

## Screenshots (if appropriate):
768px
<img width="733" height="652" alt="image" src="https://github.com/user-attachments/assets/16345a87-9262-4c92-af75-13efbb52d96b" />

1024px
<img width="865" height="656" alt="image" src="https://github.com/user-attachments/assets/4e0b2faf-5a93-4afc-966d-63b4f16cb2ee" />

1366px
<img width="1097" height="659" alt="image" src="https://github.com/user-attachments/assets/3d8612e6-be98-421d-b7ce-dd3bc90564af" />

1440px
<img width="1112" height="662" alt="image" src="https://github.com/user-attachments/assets/071ce670-abd6-44a0-9818-fc3c766806ed" />



Mobile Dots & Category - timestamp alignment

https://github.com/user-attachments/assets/3d47adfb-0772-4224-94ad-3ec9c645246d



## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):
- [x] I have not imported `flux` in a new component
- [x] If adding a new feature, I used Modern Track patterns
- [x] New features do not create new SCSS files (use Tailwind instead)
