### PR TITLE
fix: Featured by Curators row data source (#738) and mobile uploader layout (#737)

### DIFF
--- a/frontend/src/features/home/components/HomePage.jsx
+++ b/frontend/src/features/home/components/HomePage.jsx
@@ -2,7 +2,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import homeQueryClient from '../queryClient';
 import { HeroSection } from './HeroSection';
 import { SectionRow } from './SectionRow';
-import { useRecommendedMedia } from '../hooks/useRecommendedMedia';
+import { useFeaturedMedia } from '../hooks/useFeaturedMedia';
 import { useRecentMedia } from '../hooks/useRecentMedia';
 import { useIndexFeaturedPlaylists } from '../hooks/useIndexFeaturedPlaylists';
 import { usePlaylistMedia } from '../hooks/usePlaylistMedia';
@@ -22,13 +22,15 @@ function getHomepagePlaylistRowKey(playlist, index) {
 }
 
 function FeaturedByCuratorsRow() {
-	const { data, isLoading, isError } = useRecommendedMedia();
-	const items = normalizeMediaList(data);
+	const { data, isLoading, isError } = useFeaturedMedia();
+	// The hero shows featured[0]; this row shows the remaining featured media,
+	// matching the pre-modern home (featuredVideos.slice(1)).
+	const items = normalizeMediaList(data).slice(1);
 
 	return (
 		<SectionRow items={items} isLoading={isLoading} isError={isError}>
 			<div className="flex flex-col gap-2">
-				<SectionRow.Title viewAllHref="/recommended">Featured by Curators</SectionRow.Title>
+				<SectionRow.Title viewAllHref="/featured">Featured by Curators</SectionRow.Title>
 				<SectionRow.Description text="Selected by Cinemata's community curators" />
 			</div>
 			<SectionRow.Carousel />

--- a/frontend/src/features/home/components/HomePage.security.test.jsx
+++ b/frontend/src/features/home/components/HomePage.security.test.jsx
@@ -90,7 +90,10 @@ describe('HomePage accessibility baseline', () => {
 	});
 
 	it('expand toggle button has aria-expanded attribute', () => {
-		homeQueryClient.setQueryData(HOME_QUERY_KEYS.recommended, [RECOMMENDED_MEDIA]);
+		// The curators row carries the expandable description and only renders when
+		// there is featured media beyond the hero. Seed two featured items so the
+		// hero takes the first and the row renders the second.
+		homeQueryClient.setQueryData(HOME_QUERY_KEYS.featured, [FEATURED_WITH_XSS, RECOMMENDED_MEDIA]);
 		render(<HomePage />);
 		const expandBtn = screen.getByRole('button', { name: 'READ MORE' });
 		expect(expandBtn).toHaveAttribute('aria-expanded', 'false');

--- a/frontend/src/features/home/components/HomePage.test.jsx
+++ b/frontend/src/features/home/components/HomePage.test.jsx
@@ -147,8 +147,9 @@ describe('HomePage', () => {
 		});
 	});
 
-	it('FeaturedByCuratorsRow renders when recommended data is seeded', async () => {
-		homeQueryClient.setQueryData(HOME_QUERY_KEYS.recommended, [RECOMMENDED_MEDIA]);
+	it('FeaturedByCuratorsRow renders the remaining featured media after the hero', async () => {
+		// The hero consumes featured[0] (FEATURED_MEDIA); the row renders featured.slice(1).
+		homeQueryClient.setQueryData(HOME_QUERY_KEYS.featured, [FEATURED_MEDIA, RECOMMENDED_MEDIA]);
 		const { container } = render(<HomePage />);
 
 		expect(await screen.findByText('Recommended Film')).toBeInTheDocument();

--- a/templates/cms/edit_media.html
+++ b/templates/cms/edit_media.html
@@ -1276,6 +1276,24 @@
 				}
 			}
 
+			/*
+			 * Below 1024px, AddMediaPage.scss sizes the uploader with an aspect-ratio
+			 * hack: .media-uploader-bottom-left-wrap gets height: 0 + padding-top: 75%,
+			 * and .media-drag-drop-wrap must be position: absolute to fill that box.
+			 * The inline rule above sets .media-drag-drop-wrap to position: relative,
+			 * which breaks the fill and leaves a tall empty box with the content
+			 * overflowing below it. Neutralise the aspect-ratio sizing here and let
+			 * .media-drag-drop-inner (min-height: 200px, centered) drive the height.
+			 * Desktop (>=1024px) drops the hack in the SCSS, so it is left untouched.
+			 */
+			@media (max-width: 1023px) {
+				#media-file-uploader .media-uploader-bottom-left-wrap {
+					height: auto;
+					min-height: 0;
+					padding-top: 0;
+				}
+			}
+
 			/* Ensure responsive layout */
 			@media (max-width: 768px) {
 				.media-uploader-section {


### PR DESCRIPTION
## Description
Two independent bug fixes for the modern (revamp) UI:

1. **Home "Featured by Curators" row** now reads from the featured media collection and links "View all" to `/featured`, restoring the pre-modern behavior. It previously read from the recommended collection and linked to `/recommended`.
   - File: `frontend/src/features/home/components/HomePage.jsx`
   - `useRecommendedMedia()` → `useFeaturedMedia()`; row renders `featured.slice(1)` so the hero item (`featured[0]`) is not duplicated as the first card. The featured query is shared with the hero via React Query, so no extra request is added.

2. **Edit Media page uploader** no longer breaks below 1024px. The uploader rendered as a tall empty box with the drag-and-drop content overflowing beneath it on narrow viewports.
   - File: `templates/cms/edit_media.html`
   - The inline rule sets `.media-drag-drop-wrap` to `position: relative`, which defeats the `position: absolute` fill that `AddMediaPage.scss` relies on for its `height: 0` + `padding-top: 75%` aspect-ratio sizing on mobile. A new `@media (max-width: 1023px)` block neutralises the aspect-ratio sizing on the edit page, letting `.media-drag-drop-inner` (min-height: 200px, centered) drive the height. Desktop (>=1024px) is untouched.

## Related Issue
Fixes #738
Fixes #737

## Motivation and Context
- #738: The "Featured by Curators" label and description describe curated/featured content, but the row pointed at the recommended collection (a different view and route). The modern home regressed both the data source and the link. This restores parity with the legacy home, where the hero used the first featured item and the row showed `featuredVideos.slice(1)` with "View all" → `/featured`.
- #737: Inline CSS in `edit_media.html` re-implements part of the uploader layout and conflicts with the shared SCSS only below 1024px, producing a broken layout on mobile while desktop was unaffected.

## How Has This Been Tested?
- Home row: `frontend/src/features/home/components/HomePage.test.jsx` updated to seed `HOME_QUERY_KEYS.featured` with two items and assert the second renders in the row (the hero consumes the first). All 13 home tests pass (`npx vitest run src/features/home/components/HomePage.test.jsx`).
- Uploader: the `max-width: 1023px` scope leaves desktop (>=1024px) measurements unchanged; the change only affects narrow viewports where the layout was broken. The fix is a server-rendered Django template change and does not require a frontend rebuild.

## Screenshots (if appropriate):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):
- [x] I have not imported `flux` in a new component
- [x] If adding a new feature, I used Modern Track patterns
- [x] New features do not create new SCSS files (use Tailwind instead)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media uploader display on tablets and smaller devices.

* **New Features**
  * Updated the "Featured by Curators" section with refreshed content and navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->