### PR TITLE
fix: show "comments disabled" notice for private/closed videos

### DIFF
--- a/frontend/src/features/comments/components/CommentsPanel.jsx
+++ b/frontend/src/features/comments/components/CommentsPanel.jsx
@@ -34,10 +34,19 @@ function ScrollMorePill({ count, onClick }) {
 	);
 }
 
-export function CommentsPanel({ friendlyToken, variant = 'inline', onExpandToggle, isExpanded = false }) {
+export function CommentsPanel({
+	friendlyToken,
+	variant = 'inline',
+	onExpandToggle,
+	isExpanded = false,
+	commentsDisabled = false,
+}) {
 	const showTabs = variant === 'sidebar';
 	const isModal = variant === 'modal';
-	const { data, isLoading, isError, refetch } = useComments(friendlyToken);
+	// When the owner has turned comments off (commentsDisabled prop) we skip the
+	// request entirely; the private-video case is detected from the response.
+	const { data, isLoading, isError, refetch } = useComments(friendlyToken, { enabled: !commentsDisabled });
+	const isDisabled = commentsDisabled || data?.commentsDisabled === true;
 	const comments = Array.isArray(data?.results) ? data.results : [];
 	const loadedCount = comments.length;
 	const totalCount = typeof data?.count === 'number' ? data.count : loadedCount;
@@ -50,6 +59,34 @@ export function CommentsPanel({ friendlyToken, variant = 'inline', onExpandToggl
 		if (!el) return;
 		el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
 	};
+
+	if (isDisabled) {
+		return (
+			<section
+				aria-label="Comments"
+				className={cn(
+					'flex w-full flex-col gap-4',
+					variant === 'sidebar' && 'max-h-[706px] lg:max-h-[calc(100vh-7rem)] lg:sticky lg:top-24',
+					isModal && 'h-full'
+				)}
+			>
+				<div className="relative flex min-h-0 flex-1 flex-col">
+					{showTabs ? <CommentsTab count={totalCount} /> : null}
+					<div
+						className={cn(
+							'flex min-h-0 flex-1 flex-col items-center justify-center gap-2 bg-bg-surface px-4 py-10 text-center',
+							showTabs ? 'rounded-b-lg rounded-tr-lg' : 'rounded-lg'
+						)}
+					>
+						<i aria-hidden="true" className="material-icons text-text-muted" style={{ fontSize: 32 }}>
+							lock
+						</i>
+						<p className="m-0 text-sm leading-5 text-text-muted">Comments are disabled for this video.</p>
+					</div>
+				</div>
+			</section>
+		);
+	}
 
 	return (
 		<section

--- a/frontend/src/features/comments/components/CommentsPanel.test.jsx
+++ b/frontend/src/features/comments/components/CommentsPanel.test.jsx
@@ -1,14 +1,10 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { CommentsPanel } from './CommentsPanel';
+import { useComments } from '../hooks/useComments';
 
 vi.mock('../hooks/useComments', () => ({
-	useComments: () => ({
-		data: { count: 0, results: [] },
-		isLoading: false,
-		isError: false,
-		refetch: vi.fn(),
-	}),
+	useComments: vi.fn(),
 }));
 
 vi.mock('../hooks/useHiddenBelowCount', () => ({
@@ -23,7 +19,19 @@ vi.mock('./CommentItem', () => ({
 	CommentItem: () => <li data-testid="comment-item" />,
 }));
 
+const loaded = (overrides = {}) => ({
+	data: { count: 0, results: [], commentsDisabled: false },
+	isLoading: false,
+	isError: false,
+	refetch: vi.fn(),
+	...overrides,
+});
+
 describe('CommentsPanel', () => {
+	beforeEach(() => {
+		useComments.mockReturnValue(loaded());
+	});
+
 	it('uses the shared primary action token for the expand comments button', () => {
 		render(<CommentsPanel friendlyToken="media-token" variant="sidebar" onExpandToggle={() => {}} />);
 
@@ -31,5 +39,22 @@ describe('CommentsPanel', () => {
 
 		expect(button).toHaveClass('bg-bg-primary');
 		expect(button).toHaveClass('hover:bg-bg-primary-hover');
+	});
+
+	it('shows a disabled notice and hides the form when comments are turned off', () => {
+		render(<CommentsPanel friendlyToken="media-token" variant="sidebar" commentsDisabled />);
+
+		expect(screen.getByText('Comments are disabled for this video.')).toBeInTheDocument();
+		expect(screen.queryByTestId('comment-form')).not.toBeInTheDocument();
+		expect(useComments).toHaveBeenCalledWith('media-token', { enabled: false });
+	});
+
+	it('shows a disabled notice when the response marks the media as private', () => {
+		useComments.mockReturnValue(loaded({ data: { count: 0, results: [], commentsDisabled: true } }));
+
+		render(<CommentsPanel friendlyToken="media-token" variant="sidebar" />);
+
+		expect(screen.getByText('Comments are disabled for this video.')).toBeInTheDocument();
+		expect(screen.queryByTestId('comment-form')).not.toBeInTheDocument();
 	});
 });

--- a/frontend/src/features/comments/components/CommentsSection.jsx
+++ b/frontend/src/features/comments/components/CommentsSection.jsx
@@ -31,7 +31,7 @@ function CommentsStyleTag() {
 	);
 }
 
-function CommentsSectionInner({ friendlyToken, variant }) {
+function CommentsSectionInner({ friendlyToken, variant, commentsDisabled }) {
 	const isExpanded = useCommentsStore((s) => s.isExpanded);
 	const openExpanded = useCommentsStore((s) => s.openExpanded);
 	const closeExpanded = useCommentsStore((s) => s.closeExpanded);
@@ -45,6 +45,7 @@ function CommentsSectionInner({ friendlyToken, variant }) {
 			<CommentsPanel
 				friendlyToken={friendlyToken}
 				variant={variant}
+				commentsDisabled={commentsDisabled}
 				onExpandToggle={openExpanded}
 				isExpanded={false}
 			/>
@@ -58,6 +59,7 @@ function CommentsSectionInner({ friendlyToken, variant }) {
 					<CommentsPanel
 						friendlyToken={friendlyToken}
 						variant="modal"
+						commentsDisabled={commentsDisabled}
 						onExpandToggle={closeExpanded}
 						isExpanded={true}
 					/>
@@ -67,12 +69,12 @@ function CommentsSectionInner({ friendlyToken, variant }) {
 	);
 }
 
-export function CommentsSection({ friendlyToken, variant = 'inline' }) {
+export function CommentsSection({ friendlyToken, variant = 'inline', commentsDisabled = false }) {
 	const resolvedToken = friendlyToken || getFriendlyTokenFromLocation();
 	return (
 		<QueryClientProvider client={commentsQueryClient}>
 			<CommentsStyleTag />
-			<CommentsSectionInner friendlyToken={resolvedToken} variant={variant} />
+			<CommentsSectionInner friendlyToken={resolvedToken} variant={variant} commentsDisabled={commentsDisabled} />
 		</QueryClientProvider>
 	);
 }

--- a/frontend/src/features/comments/hooks/useComments.js
+++ b/frontend/src/features/comments/hooks/useComments.js
@@ -13,12 +13,29 @@ export function useComments(friendlyToken, { enabled = true } = {}) {
 				headers: { Accept: 'application/json' },
 				credentials: 'same-origin',
 			});
-			if (!r.ok) throw new Error(`Failed to load comments: ${r.status}`);
+			if (!r.ok) {
+				// A private video answers the comments endpoint with a 400 for
+				// anyone other than its owner. Surface that as a "disabled" state
+				// instead of a generic load error so the panel can explain it.
+				if (r.status === 400) {
+					let detail;
+					try {
+						detail = (await r.json())?.detail;
+					} catch {
+						detail = undefined;
+					}
+					if (detail === 'media is private') {
+						return { results: [], count: 0, commentsDisabled: true };
+					}
+				}
+				throw new Error(`Failed to load comments: ${r.status}`);
+			}
 			const data = await r.json();
 			const results = Array.isArray(data?.results) ? data.results : Array.isArray(data) ? data : [];
 			return {
 				results,
 				count: typeof data?.count === 'number' ? data.count : results.length,
+				commentsDisabled: false,
 			};
 		},
 	});

--- a/frontend/src/features/video-viewer/components/VideoViewerPage.jsx
+++ b/frontend/src/features/video-viewer/components/VideoViewerPage.jsx
@@ -130,7 +130,11 @@ export class VideoViewerPage extends Page {
 		const viewerNestedClassname = 'viewer-section-nested' + (this.state.theaterMode ? ' viewer-section' : '');
 		const commentsPanel = this.state.mediaLoaded ? (
 			<div className="viewer-sidebar-comments mb-6 box-border w-full" key="viewer-comments">
-				<CommentsSection friendlyToken={MediaPageStore.get('media-id')} variant="sidebar" />
+				<CommentsSection
+					friendlyToken={MediaPageStore.get('media-id')}
+					variant="sidebar"
+					commentsDisabled={MediaPageStore.get('media-data')?.enable_comments === false}
+				/>
 			</div>
 		) : null;
 


### PR DESCRIPTION
## Description

The comments panel now distinguishes "comments are not available here" from
"the request actually failed":

- `useComments` inspects a `400` response body; when the detail is
  `media is private` it resolves with `{ commentsDisabled: true }` instead of
  throwing, so the panel can explain the state rather than show the retry box.
  Any other non-OK response still throws and keeps the existing error/Retry UI.
- `CommentsPanel` accepts a `commentsDisabled` prop and also reads
  `data.commentsDisabled` from the hook. When either is true it renders a lock
  icon + "Comments are disabled for this video." and hides the comment form. The
  prop path also skips the network request via the hook's `enabled` option.
- `CommentsSection` forwards the prop, and `VideoViewerPage` derives it from the
  already-loaded media data (`media-data.enable_comments === false`) so videos
  whose owner turned comments off get the same notice — including the owner, who
  also cannot post when comments are off.

## Related Issue

Fixes #739

## Motivation and Context

A private video's comments endpoint returns `400 {"detail": "media is private"}`
to anyone other than the owner. The frontend treated every non-OK response as a
load failure, so viewers saw a red "Could not load comments. Retry" box that
would never succeed no matter how many times they clicked Retry. The expected
behaviour (per the issue) is a message indicating comments are disabled.

The fix mirrors the backend's permission model exactly: the owner of a private
video still receives a `200` and sees/posts comments as normal; everyone else
sees the disabled notice. The companion `enable_comments` path covers the
adjacent case of a public video whose owner has switched comments off, where the
comment form would otherwise invite a post that the API rejects.

## How Has This Been Tested?

- `npm run test:run` — 402/402 passing, including three new `CommentsPanel`
  cases covering the prop-driven disabled state, the response-driven (private)
  disabled state, and that the comment form is hidden in both.
- `npm run lint:modern` — 0 problems. `npm run lint:legacy` — no new warnings on
  touched files. `npm run build` — Vite production build succeeds.
- `uv run pre-commit run --files <touched files>` — all hooks pass (Prettier
  reflow applied).
- **Exercised live in Chromium via Playwright** against the local dev stack
  (revamp watch page, `UI_VARIANT_REVAMP_PAGES=["media"]`):
  - **Owner / private video** — all 15 comments + the write form render; no notice.
  - **Public video, comments turned off** — lock icon + "Comments are disabled
    for this video.", no form, no error box (prop-driven path).
  - **Non-owner editor / private video** — the actual #739 repro: the video plays
    and the comments panel mounts, the comments API returns
    `400 "media is private"`, and the panel shows the disabled notice instead of
    the old "Could not load comments. Retry" box (response-driven path).
  - Confirmed the notice is legible in both light and dark themes.
- **Reachability note:** a plain non-owner / anonymous user can't reach a private
  video's comments panel at all — `MediaDetail` returns 401 and the page shows a
  full "Media is private" gate. The comments-panel path is reachable only for an
  editor/curator who is not the owner (`MediaDetail` allows owner/editor/curator;
  `CommentDetail` allows owner only).

## Screenshots (if appropriate):
<img width="2844" height="1462" alt="image" src="https://github.com/user-attachments/assets/0b6e36d3-53cc-4a10-aa24-4b610df1224e" />


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):
- [x] I have not imported `flux` in a new component
- [x] If adding a new feature, I used Modern Track patterns
- [x] New features do not create new SCSS files (use Tailwind instead)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Comments can now be disabled per video. When disabled, viewers see a "Comments are disabled for this video" message instead of the comment section.
  * Comment submission form is hidden when comments are disabled.

* **Tests**
  * Added test coverage for disabled comments functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->