### PR TITLE
feat: add Quick Preview panel for upload/edit form

### DIFF
--- a/frontend/src/features/upload-quick-preview/QuickPreview.jsx
+++ b/frontend/src/features/upload-quick-preview/QuickPreview.jsx
@@ -1,0 +1,64 @@
+import { VerticalMovieItem } from '../shared/components/MovieItem';
+import { cn } from '../shared/utils/classNames';
+
+// Fully transparent 1x1 GIF. While no thumbnail has been selected or
+// auto-generated yet, this lets the poster's `bg-bg-skeleton` show through as a
+// neutral placeholder instead of a broken-image icon.
+const PLACEHOLDER_THUMBNAIL = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
+
+const DEFAULT_BADGE_COLOR = 'bg/primary';
+
+function formatViews(views) {
+	if (views == null || views === '') {
+		return null;
+	}
+
+	const numeric = Number(views);
+
+	if (Number.isNaN(numeric)) {
+		return null;
+	}
+
+	return `${numeric.toLocaleString()} views`;
+}
+
+/**
+ * Live preview panel for the upload/edit form. Renders the media exactly as it
+ * will appear as a thumbnail card in listings, reusing the shared
+ * `VerticalMovieItem` media card so the preview never drifts from production.
+ *
+ * Purely presentational: it derives its display from the props the host form
+ * passes on every edit, so the card updates in real time as the user types.
+ */
+export function QuickPreview({
+	title = '',
+	thumbnailUrl = '',
+	durationLabel = '',
+	category = null,
+	subtitle = '',
+	country = '',
+	views = null,
+	className = '',
+}) {
+	const metadata = [country, formatViews(views)].filter(Boolean);
+
+	return (
+		<section
+			aria-label="Quick preview"
+			className={cn('flex w-full flex-col gap-4 rounded-2xl bg-bg-surface px-[22px] py-8', className)}
+		>
+			<h2 className="h5-24-medium m-0 text-text-strong">Quick Preview</h2>
+			<hr className="m-0 w-full border-0 border-t border-border-default" />
+			<VerticalMovieItem
+				title={title || 'Untitled media'}
+				imageSrc={thumbnailUrl || PLACEHOLDER_THUMBNAIL}
+				imageAlt={title ? `${title} thumbnail` : 'Thumbnail preview'}
+				duration={durationLabel}
+				badge={category?.title || ''}
+				badgeColor={category?.color || DEFAULT_BADGE_COLOR}
+				subtitle={subtitle}
+				metadata={metadata}
+			/>
+		</section>
+	);
+}

--- a/frontend/src/features/upload-quick-preview/QuickPreview.stories.jsx
+++ b/frontend/src/features/upload-quick-preview/QuickPreview.stories.jsx
@@ -1,0 +1,94 @@
+import { expect, within } from 'storybook/test';
+import { QuickPreview } from './QuickPreview';
+
+function createPosterDataUrl({ background, accent, glow }) {
+	return `data:image/svg+xml;utf8,${encodeURIComponent(`
+		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 90">
+			<rect width="160" height="90" rx="6" fill="${background}" />
+			<circle cx="124" cy="22" r="18" fill="${glow}" opacity="0.5" />
+			<path d="M0 64c23-18 47-26 71-26s54 12 89 36v16H0V64z" fill="${accent}" />
+		</svg>
+	`)}`;
+}
+
+const samplePoster = createPosterDataUrl({
+	background: '#102746',
+	accent: '#D0735F',
+	glow: '#85C4FF',
+});
+
+const meta = {
+	title: 'Features/Upload/QuickPreview',
+	component: QuickPreview,
+	tags: ['autodocs'],
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'Live preview panel for the unified upload/edit form. Reuses the shared `VerticalMovieItem` media card so the preview matches exactly how the media will appear in listings, updating in real time as the host form passes new values.',
+			},
+		},
+	},
+	args: {
+		title: 'Samtang Naghulat Ko Nga',
+		thumbnailUrl: samplePoster,
+		durationLabel: '23:05',
+		category: { title: 'FILM', color: 'coral-reef-700' },
+		subtitle: 'CCP Film, Broadcast and New Media',
+		country: 'Philippines',
+		views: 200,
+	},
+	render: (args) => (
+		<div className="w-full max-w-[389px] bg-bg-page p-6">
+			<QuickPreview {...args} />
+		</div>
+	),
+};
+
+export default meta;
+
+export const Default = {
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+
+		await expect(canvas.getByRole('region', { name: 'Quick preview' })).toBeVisible();
+		await expect(canvas.getByRole('heading', { name: 'Quick Preview' })).toBeVisible();
+		await expect(canvas.getByText('Samtang Naghulat Ko Nga')).toBeVisible();
+		await expect(canvas.getByText('CCP Film, Broadcast and New Media')).toBeVisible();
+		await expect(canvas.getByText('FILM')).toBeVisible();
+		await expect(canvas.getByText('23:05')).toBeVisible();
+		await expect(canvas.getByText('Philippines')).toBeVisible();
+		await expect(canvas.getByText('200 views')).toBeVisible();
+	},
+};
+
+export const EmptyState = {
+	name: 'Empty (typing)',
+	args: {
+		title: '',
+		thumbnailUrl: '',
+		durationLabel: '',
+		category: null,
+		subtitle: '',
+		country: '',
+		views: null,
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+
+		await expect(canvas.getByText('Untitled media')).toBeVisible();
+		await expect(canvas.getByRole('img', { name: 'Thumbnail preview' })).toBeVisible();
+	},
+};
+
+export const NoCategory = {
+	args: {
+		category: null,
+	},
+};
+
+export const LongTitle = {
+	args: {
+		title: 'Samtang Naghulat Ko Nga Samtang Naghulat Ko Nga Samtang Naghulat Ko Nga Samtang Naghulat Ko Nga',
+	},
+};

--- a/frontend/src/features/upload-quick-preview/QuickPreview.test.jsx
+++ b/frontend/src/features/upload-quick-preview/QuickPreview.test.jsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react';
+import { QuickPreview } from './QuickPreview';
+
+const samplePoster =
+	'data:image/svg+xml;utf8,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 90"%3E%3Crect width="160" height="90" fill="%23102746"/%3E%3C/svg%3E';
+
+describe('QuickPreview', () => {
+	it('renders the titled panel and the media card from the supplied fields', () => {
+		render(
+			<QuickPreview
+				title="Samtang Naghulat Ko Nga"
+				thumbnailUrl={samplePoster}
+				durationLabel="23:05"
+				category={{ title: 'FILM', color: 'coral-reef-700' }}
+				subtitle="CCP Film, Broadcast and New Media"
+				country="Philippines"
+				views={200}
+			/>
+		);
+
+		expect(screen.getByRole('region', { name: 'Quick preview' })).toBeVisible();
+		expect(screen.getByRole('heading', { name: 'Quick Preview' })).toBeVisible();
+		expect(screen.getByText('Samtang Naghulat Ko Nga')).toBeVisible();
+		expect(screen.getByText('FILM')).toBeVisible();
+		expect(screen.getByText('23:05')).toBeVisible();
+		expect(screen.getByText('Philippines')).toBeVisible();
+
+		const subtitle = screen.getByText('CCP Film, Broadcast and New Media');
+		expect(subtitle).toHaveClass('text-text-link');
+
+		const image = screen.getByRole('img', { name: 'Samtang Naghulat Ko Nga thumbnail' });
+		expect(image).toHaveAttribute('src', samplePoster);
+	});
+
+	it('formats the view count with a thousands separator', () => {
+		render(<QuickPreview title="A" views={12345} />);
+
+		expect(screen.getByText('12,345 views')).toBeVisible();
+	});
+
+	it('falls back to placeholders while fields are empty', () => {
+		render(<QuickPreview />);
+
+		expect(screen.getByText('Untitled media')).toBeVisible();
+		// No country/views supplied -> the metadata row is omitted entirely.
+		expect(screen.queryByText('views', { exact: false })).not.toBeInTheDocument();
+
+		const image = screen.getByRole('img', { name: 'Thumbnail preview' });
+		expect(image.getAttribute('src')).toMatch(/^data:image\/gif/);
+	});
+
+	it('omits the badge when no category is provided', () => {
+		render(<QuickPreview title="A" subtitle="Studio" country="Philippines" views={5} />);
+
+		expect(screen.queryByText('FILM')).not.toBeInTheDocument();
+		expect(screen.getByText('5 views')).toBeVisible();
+	});
+});

--- a/frontend/src/features/upload-quick-preview/index.js
+++ b/frontend/src/features/upload-quick-preview/index.js
@@ -1,0 +1,1 @@
+export { QuickPreview } from './QuickPreview';


### PR DESCRIPTION
## Description

Implements the **Upload: Quick Preview** feature (Q2-018). Adds a new modern-track
component at `frontend/src/features/upload-quick-preview/` that shows a live preview
of how media will look as a thumbnail card and in listings:

- A titled panel ("Quick Preview" heading + divider) on a `bg-bg-surface` card.
- The media card itself, rendered by reusing the existing shared
  `VerticalMovieItem` component — the same Kumquat card used across home and search
  listings (the Q2-004 atomic media card).
- Real-time-friendly: the component is purely presentational and derives its
  display from the props the host form passes on every edit, so the card updates as
  the user types. Empty fields degrade gracefully (title → "Untitled media",
  missing thumbnail → neutral skeleton, missing metadata → omitted).

**Prop contract** (the hand-off surface for the unified form in #523):
`title`, `thumbnailUrl`, `durationLabel`, `category{title,color}`, `subtitle`,
`country`, `views`.

### Scope notes

- This is a **component**, not a standalone page. Because the host upload/edit page
  (#523) does not exist yet, there is intentionally **no Django template / URL route
  / Vite entry** — those belong to #523, which will import and mount this component.
  The primary QA surface in the meantime is Storybook.
- The preview card is deliberately **not navigable** (no links): the media is not
  published yet, so dead links are avoided and there are no interactive elements to
  trap focus.

## Related Issue

Closes #534

Unblocks/feeds: #523 (unified upload/edit form) and #524 (bulk upload), both of
which embed this preview.

## Motivation and Context

Today users cannot see what their media will look like until it is published — no
preview exists in the upload or edit flows. The Quick Preview panel closes that gap
and, by reusing the production media card, guarantees the preview matches the real
listing appearance.

## How Has This Been Tested?

- `npm run test:run` — 404/404 passed (4 new tests for QuickPreview: populated card,
  view-count formatting, empty-field placeholders, no-category badge omission).
- `npm run lint:modern` — 0 problems.
- `npm run build` — Vite production build succeeds.
- `pre-commit run --files` on the four touched files — all hooks pass (Prettier
  reformatted one constant line).
- Storybook (`Features → Upload → QuickPreview`): Default, Empty (typing),
  NoCategory, and LongTitle stories with interaction assertions.

Token mapping was verified against the dark-theme Figma reference
(node `77:914`): panel `bg-bg-surface` (pacific-deep/900), heading
`text-text-strong` + `h5-24-medium`, subtitle `text-text-link`
(sunset-horizon/200 — exact match), metadata `text-text-disabled`
(pacific-deep/400 — exact match), duration `bg-bg-overlay-dark`. No new tokens were
required, so `docs/modern-track-color-system.md` / `Colors.mdx` are unchanged.

Not exercised in a real browser against the live app — there is no host page yet;
verification was through Storybook and the unit suite.

## Screenshots (if appropriate):
<img width="638" height="638" alt="image" src="https://github.com/user-attachments/assets/4400ed14-856b-4955-8a17-473b1578d282" />


## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):

- [x] I have not imported `flux` in a new component
- [x] If adding a new feature, I used Modern Track patterns
- [x] New features do not create new SCSS files (use Tailwind instead)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a quick preview panel to the upload form that displays media information, including title, thumbnail, duration, category, views count, and location details. The preview gracefully handles empty or missing data with appropriate fallback UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->