### PR TITLE
fix: load global stylesheet as render-blocking link to prevent FOUC

### DIFF
--- a/frontend/src/features/layout/components/AppLayout.jsx
+++ b/frontend/src/features/layout/components/AppLayout.jsx
@@ -1,7 +1,8 @@
 import React, { useEffect } from 'react';
 
-// Required global resets; do not remove.
-import '../../../static/css/styles.scss';
+// Global styles.scss is loaded as a render-blocking <link> in root.html so the
+// page is styled before JS executes (avoids a flash of unstyled content on slow
+// connections). Do not import it here.
 import '../../../static/js/components/styles/PageMain.scss';
 
 import { PageSidebarContentOverlay } from '../../../static/js/components/-NEW-/PageSidebarContentOverlay';

--- a/frontend/src/features/layout/topbar/LegacyTopbarMount.jsx
+++ b/frontend/src/features/layout/topbar/LegacyTopbarMount.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 
-// Legacy pages don't load AppLayout, so these globals must reload here.
-import '../../../static/css/styles.scss';
+// Global styles.scss is loaded as a render-blocking <link> in root.html, so it
+// is not imported here (that caused a flash of unstyled content on slow links).
 import '../../../static/js/components/styles/PageMain.scss';
 
 import PageStore from '../../../static/js/pages/_PageStore.js';

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -108,6 +108,7 @@ export default defineConfig({
 				signout: 'src/entries/signout.js',
 				toast: 'src/entries/toast.js',
 				tailwinds: 'src/static/css/tailwind.css',
+				styles: 'src/static/css/styles.scss',
 				index: 'src/entries/index.js',
 				search: 'src/entries/search.js',
 				latest: 'src/entries/latest.js',

--- a/templates/root.html
+++ b/templates/root.html
@@ -20,6 +20,13 @@
 
         {% include "common/head-links.html" %}
 
+        {# Global stylesheet as a render-blocking <link> so the page is styled #}
+        {# before React/JS loads. Without this, styles.scss is only pulled in via #}
+        {# JS module imports, which causes a flash of unstyled content on slow #}
+        {# connections. Tailwind utilities load after this (in topimports) so their #}
+        {# important layer keeps precedence. #}
+        <link rel="stylesheet" href="{% vite_asset_url 'src/static/css/styles.scss' %}">
+
         {# Import map — must appear before any <script type="module"> so the browser #}
         {# can resolve the bare "video.js" specifier used in Vite's externalized chunks. #}
         <script type="importmap">


### PR DESCRIPTION
## Description
The global theme stylesheet `frontend/src/static/css/styles.scss` was imported inside React modules (`features/layout/components/AppLayout.jsx` and `features/layout/topbar/LegacyTopbarMount.jsx`), so the theme CSS only reached the browser after the JavaScript bundle executed. On slow connections this produced a flash of unstyled content on modern-track pages.

This change loads `styles.scss` as a render-blocking `<link>` in the document head instead:

- Register `src/static/css/styles.scss` as a Vite build input so it has a manifest entry resolvable by `vite_asset_url`.
- Add the `<link rel="stylesheet">` in `templates/root.html`, before the page JavaScript and before `tailwind.css` so Tailwind utilities keep precedence. Placing it in `root.html` covers every page, including the embed page.
- Remove the in-component `styles.scss` imports so there is a single render-blocking source instead of a JS-injected one.

## Related Issue
Fixes #765

## Motivation and Context
On the modern track, pages loaded without the global theme styles until the JavaScript bundle had executed. On a slow connection the page shell appeared unstyled first, then styling was applied once React/JS loaded. This is poor user experience. The fix makes the theme stylesheet a render-blocking resource that is present before first paint, in both development and production.

## How Has This Been Tested?
Development asset mode (Django runserver with the Vite dev server):
- Confirmed the rendered `<head>` contains the `styles.scss` `<link>` before the `tailwind.css` `<link>`.
- Confirmed the Vite dev server returns `styles.scss` as `Content-Type: text/css` for a real `<link>` request, so it is render-blocking in development.
- Loaded the modern home (`cms/index_revamp.html`, `base_modern`) and the legacy search page (`cms/search.html`, `base.html`) in a browser. Both render fully themed (header, sidebar, buttons, footer). No console errors.

Production build:
- `make frontend-build` succeeds with the new input.
- The manifest contains `src/static/css/styles.scss`, emitted as a single render-blocking CSS file.
- No duplication: no JavaScript chunk references the styles CSS, and the `_helpers` chunk CSS no longer carries `styles.scss`.

Note: a separate, pre-existing local database migration issue (`files_media.comment_count`) affected page data during testing but is unrelated to this change.

## Screenshots (if appropriate):
Verified visually that the modern home and the legacy search page render fully themed before interaction. (Screenshots captured locally during testing.)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):
- [x] I have not imported `flux` in a new component
- [ ] If adding a new feature, I used Modern Track patterns
- [x] New features do not create new SCSS files (use Tailwind instead)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initial page appearance by ensuring styles are applied immediately when the page loads, eliminating visual inconsistencies during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->