### PR TITLE
fix: Resolve issues on single upload media

### DIFF
--- a/files/management_views.py
+++ b/files/management_views.py
@@ -26,7 +26,13 @@ from .models import (
     Topic,
     get_language_choices,
 )
-from .permissions import IsBulkUploadUser, IsFilmImpactManager, IsManageUploadsUser, IsMediacmsEditor
+from .permissions import (
+    IsBulkUploadUser,
+    IsFilmImpactManager,
+    IsManageUploadsUser,
+    IsMediacmsEditor,
+    IsUploadMediaUser,
+)
 from .serializers import CommentSerializer, ManageCommunityImpactSerializer, ManageUploadSerializer, MediaSerializer
 
 VALID_MEDIA_STATES = ["private", "public", "restricted", "unlisted"]
@@ -219,15 +225,26 @@ class MyUploadsBulkState(APIView):
         return Response({"updated": updated}, status=status.HTTP_200_OK)
 
 
+def _normalize_license_field(value):
+    """Maps the model's stored license choice to the values the UI expects.
+
+    The single-upload license chooser matches options by 'yes'/'no'/'sharealike';
+    the model stores 'Partially' for share-alike. Mirrors the upload_media view.
+    """
+    normalized = (value or "").lower()
+    return "sharealike" if normalized == "partially" else (normalized or "no")
+
+
 class BulkUploadOptions(APIView):
-    """Form option lists for the bulk-upload metadata step.
+    """Form option lists for the single- and bulk-upload metadata steps.
 
     Returns ids/codes (not just titles) so the client submits exactly what
     MediaForm expects: M2M PKs for category/topic/content-sensitivity, language
-    and country codes, and license PKs.
+    and country codes, and license PKs. Licenses also carry allowCommercial /
+    allowModifications so the single-upload license chooser can match selections.
     """
 
-    permission_classes = (IsBulkUploadUser,)
+    permission_classes = (IsUploadMediaUser,)
 
     def get(self, request, format=None):
         data = {
@@ -236,7 +253,15 @@ class BulkUploadOptions(APIView):
             "content_sensitivities": list(ContentSensitivity.objects.order_by("title").values("id", "title")),
             "languages": [{"code": code, "title": title} for code, title in get_language_choices()],
             "countries": [{"code": code, "title": title} for code, title in lists.video_countries],
-            "licenses": list(License.objects.order_by("title").values("id", "title")),
+            "licenses": [
+                {
+                    "id": str(lic.id),
+                    "title": lic.title,
+                    "allowCommercial": _normalize_license_field(lic.allow_commercial),
+                    "allowModifications": _normalize_license_field(lic.allow_modifications),
+                }
+                for lic in License.objects.order_by("title")
+            ],
         }
         return Response(data)
 

--- a/files/permissions.py
+++ b/files/permissions.py
@@ -1,6 +1,6 @@
 from rest_framework import permissions
 
-from .methods import can_manage_film_impact, can_manage_uploads, is_mediacms_editor
+from .methods import can_manage_film_impact, can_manage_uploads, can_upload_media, is_mediacms_editor
 
 
 class IsMediacmsEditor(permissions.BasePermission):
@@ -25,6 +25,19 @@ class IsBulkUploadUser(permissions.BasePermission):
         from cms.permissions import user_allowed_to_bulk_upload
 
         return bool(request.user.is_authenticated and user_allowed_to_bulk_upload(request))
+
+
+class IsUploadMediaUser(permissions.BasePermission):
+    """Allows any authenticated user who may upload media (single or bulk).
+
+    Broader than IsBulkUploadUser: single-file-only users must also be able to
+    fetch the shared form option lists for the single-upload page. The options
+    are public taxonomy data (categories, languages, licenses) with no per-user
+    content, so gating on upload capability alone is sufficient.
+    """
+
+    def has_permission(self, request, view):
+        return bool(request.user.is_authenticated and can_upload_media(request.user))
 
 
 class IsFilmImpactManager(permissions.BasePermission):

--- a/files/views.py
+++ b/files/views.py
@@ -661,35 +661,9 @@ def upload_media(request):
     video_extensions = get_allowed_video_extensions()
     context["allowed_extensions"] = video_extensions
 
-    # Media language / country options, sourced from the DB and lists the same
-    # way edit-media does so both pages stay in sync.
-    language_choices = Language.objects.exclude(code__in=["automatic", "automatic-translation"]).values_list(
-        "code", "title"
-    )
-    context["media_languages"] = [{"value": code, "label": title} for code, title in language_choices]
-    context["media_countries"] = [{"value": code, "label": title} for code, title in lists.video_countries]
-
-    # Taxonomy options (Category/Topic/ContentSensitivity), value=pk, label=title,
-    # ordered by title via each model's Meta — same source the edit-media form uses.
-    context["categories"] = [{"value": pk, "label": title} for pk, title in Category.objects.values_list("id", "title")]
-    context["topics"] = [{"value": pk, "label": title} for pk, title in Topic.objects.values_list("id", "title")]
-    context["content_sensitivities"] = [
-        {"value": pk, "label": title} for pk, title in ContentSensitivity.objects.values_list("id", "title")
-    ]
-
-    context["licenses"] = [
-        {
-            "id": str(lic.id),
-            "title": lic.title,
-            "allowCommercial": "sharealike"
-            if (lic.allow_commercial or "").lower() == "partially"
-            else (lic.allow_commercial or "no").lower(),
-            "allowModifications": "sharealike"
-            if (lic.allow_modifications or "").lower() == "partially"
-            else (lic.allow_modifications or "no").lower(),
-        }
-        for lic in License.objects.order_by("id")
-    ]
+    # The single-upload form options (languages, countries, categories, topics,
+    # content sensitivities, licenses) are loaded client-side from the shared
+    # bulk_options endpoint (useTaxonomies), so they are no longer injected here.
 
     return render(request, template, context)
 

--- a/frontend/src/features/add-media/AddMediaPage.jsx
+++ b/frontend/src/features/add-media/AddMediaPage.jsx
@@ -389,7 +389,7 @@ export class AddMediaPage extends Page {
 
 						<TabView
 							tabMode="wrap"
-							triggerClassName="rounded-none py-3 px-size-22 text-neutral-50 aria-selected:text-neutral-50"
+							triggerClassName="rounded-none py-3 px-size-22 text-text-tab-trigger"
 							triggerSelectedColor="bg-bg-section-header"
 							panelClassName="mt-8"
 							aria-label="Upload media type"

--- a/frontend/src/features/add-media/AddMediaPage.jsx
+++ b/frontend/src/features/add-media/AddMediaPage.jsx
@@ -48,19 +48,13 @@ export class AddMediaPage extends Page {
 		};
 	}
 
-	// TODO: Move this to single-upload
 	componentDidMount() {
-		if (this.context.is.anonymous || !this.config.canAdd) {
-			return;
-		}
-
 		if (!window.qq || !window.qq.FineUploader || !this.uploaderRef.current) {
 			console.warn('FineUploader is not available for the add media page.');
 			return;
 		}
 
 		this.uploaderRef.current.addEventListener('click', this.handleUploaderClick);
-
 		this.uploader = new window.qq.FineUploader({
 			debug: false,
 			element: this.uploaderRef.current,
@@ -114,6 +108,12 @@ export class AddMediaPage extends Page {
 					updateUploadItemStatus(id, 'failed', 'Upload failed');
 					console.warn(window.qq.format('Error on file number {} - {}.  Reason: {}', id, name, errorReason));
 				},
+				onCancel: () => {
+					// FineUploader's built-in cancel button removes the item element after
+					// this callback returns, so defer the state sync to the next tick. When
+					// the list empties, reset hasSelectedMedia so the dropzone reappears.
+					window.setTimeout(() => this.syncUploaderState(), 0);
+				},
 				onComplete: (id, _name, response) => {
 					if (!response.success) {
 						updateUploadItemStatus(id, 'failed', 'Upload failed');
@@ -125,7 +125,7 @@ export class AddMediaPage extends Page {
 					const details = getUploadedMediaDetails(response, _name);
 					this.completedTokens[id] = details.friendlyToken;
 
-					if (this.config.uploadMaxFilesNumber === 1) {
+					if (this.config.uploadMaxFilesNumber >= 1) {
 						this.setState({ uploadedMedia: details });
 					}
 				},
@@ -245,8 +245,13 @@ export class AddMediaPage extends Page {
 			itemEl.remove();
 		}
 
-		// When the list empties, reset FineUploader so the dropzone, browse button,
-		// and item-limit counters return to their initial state.
+		this.syncUploaderState();
+	}
+
+	// Reconciles React state with the current upload list. When the list empties,
+	// resets FineUploader so the dropzone, browse button, and item-limit counters
+	// return to their initial state.
+	syncUploaderState() {
 		const listEl = this.uploaderRef.current && this.uploaderRef.current.querySelector('.qq-upload-list-selector');
 		const hasRemainingItems = !!listEl?.children.length;
 
@@ -356,9 +361,9 @@ export class AddMediaPage extends Page {
 		return (
 			<div className="media-uploader-wrap add-media-page-wrap">
 				<main className="add-media-feature mx-4 grid w-auto grid-cols-1 gap-8 py-8 text-text-primary sm:mx-6 lg:mx-10 lg:grid-cols-6 lg:items-start">
-					<aside className="hidden min-w-0 lg:block bg-white" aria-hidden="true">
+					<aside className="hidden min-w-0 lg:block" aria-hidden="true">
 						{/* TODO: Left View (stepper) */}
-						<p>Test</p>
+						Stepper Section
 					</aside>
 
 					<section className="min-w-0 col-span-4">
@@ -384,7 +389,7 @@ export class AddMediaPage extends Page {
 
 						<TabView
 							tabMode="wrap"
-							triggerClassName="rounded-none py-3 px-size-22 text-neutral-50 aria-selected:text-text-primary"
+							triggerClassName="rounded-none py-3 px-size-22 text-neutral-50 aria-selected:text-neutral-50"
 							triggerSelectedColor="bg-bg-section-header"
 							panelClassName="mt-8"
 							aria-label="Upload media type"
@@ -404,12 +409,6 @@ export class AddMediaPage extends Page {
 										canUseAdminSettings={!!this.context.is.admin}
 										csrfToken={this.config.csrfToken}
 										hasUploadedMedia={!!uploadedMedia}
-										mediaLanguages={this.config.mediaLanguages || []}
-										mediaCountries={this.config.mediaCountries || []}
-										categories={this.config.categories || []}
-										topics={this.config.topics || []}
-										contentSensitivities={this.config.contentSensitivities || []}
-										licenses={this.config.licenses || []}
 										onFilesSelected={this.handleFilesSelected}
 										showUploader={hasSelectedMedia || !!uploadedMedia}
 										uploadedMedia={uploadedMedia}
@@ -426,9 +425,9 @@ export class AddMediaPage extends Page {
 						</TabView>
 					</section>
 
-					<aside className="hidden min-w-0 lg:block bg-white" aria-hidden="true">
+					<aside className="hidden min-w-0 lg:block" aria-hidden="true">
 						{/* TODO: Right View (preview) */}
-						<p>Test</p>
+						Quick Preview Section
 					</aside>
 				</main>
 

--- a/frontend/src/features/add-media/single-upload/SingleUploadPage.jsx
+++ b/frontend/src/features/add-media/single-upload/SingleUploadPage.jsx
@@ -1,73 +1,97 @@
+import { useMemo } from 'react';
 import { QueryClientProvider } from '@tanstack/react-query';
+import { useTaxonomies } from '../../shared/components/upload-media';
 import { Card } from '../../shared/components';
 import { MediaDropzone } from '../../shared/components/MediaDropzone';
 import { Text } from '../../shared/components/Text';
 import { MediaDetailsForm } from './components/MediaDetailsForm';
 import singleUploadQueryClient from './queryClient';
 
-export function SingleUploadPage({
+// Language/country use codes; the M2M taxonomies use ids. Mirrors the bulk-upload
+// field mapping so both flows submit exactly what MediaForm expects.
+function toCodeOptions(items = []) {
+	return items.map((item) => ({ value: item.code, label: item.title }));
+}
+
+function toIdOptions(items = []) {
+	return items.map((item) => ({ value: item.id, label: item.title }));
+}
+
+function SingleUploadContent({
 	accept = 'video/*',
 	canPublishDirectly = false,
 	canUseAdminSettings = false,
-	categories = [],
-	contentSensitivities = [],
 	csrfToken = '',
 	hasUploadedMedia = false,
 	maxFiles = 1,
-	licenses = [],
-	mediaCountries = [],
-	mediaLanguages = [],
 	onFilesSelected,
 	showUploader = false,
-	topics = [],
 	uploadedMedia = null,
 	uploader,
 }) {
+	const { options } = useTaxonomies();
+
+	const mediaLanguages = useMemo(() => toCodeOptions(options.languages), [options.languages]);
+	const mediaCountries = useMemo(() => toCodeOptions(options.countries), [options.countries]);
+	const categories = useMemo(() => toIdOptions(options.categories), [options.categories]);
+	const topics = useMemo(() => toIdOptions(options.topics), [options.topics]);
+	const contentSensitivities = useMemo(
+		() => toIdOptions(options.content_sensitivities),
+		[options.content_sensitivities]
+	);
+	const licenses = options.licenses;
+
+	return (
+		<div className="single-upload-page">
+			<Card className="py-8 px-6">
+				<section
+					className="add-media-upload-stage"
+					data-upload-complete={hasUploadedMedia ? 'true' : 'false'}
+					data-uploader-visible={showUploader ? 'true' : 'false'}
+				>
+					<Text variant="h5" as="h2" className="m-0 text-text-strong">
+						Single Media Upload
+					</Text>
+
+					<div className="my-4 border-b border-b-border-divider" />
+
+					{!showUploader ? (
+						<MediaDropzone
+							accept={accept}
+							multiple={maxFiles !== 1}
+							label="Drag & Drop File or"
+							buttonVariant="secondary"
+							buttonLabel="CHOOSE MEDIA"
+							onFilesSelected={onFilesSelected}
+						/>
+					) : null}
+
+					<div hidden={!showUploader}>{uploader}</div>
+				</section>
+			</Card>
+
+			{hasUploadedMedia ? (
+				<MediaDetailsForm
+					canPublishDirectly={canPublishDirectly}
+					canUseAdminSettings={canUseAdminSettings}
+					categories={categories}
+					contentSensitivities={contentSensitivities}
+					csrfToken={csrfToken}
+					editUrl={uploadedMedia?.editUrl ?? ''}
+					licenses={licenses}
+					mediaCountries={mediaCountries}
+					mediaLanguages={mediaLanguages}
+					topics={topics}
+				/>
+			) : null}
+		</div>
+	);
+}
+
+export function SingleUploadPage(props) {
 	return (
 		<QueryClientProvider client={singleUploadQueryClient}>
-			<div className="single-upload-page">
-				<Card className="py-8 px-6">
-					<section
-						className="add-media-upload-stage"
-						data-upload-complete={hasUploadedMedia ? 'true' : 'false'}
-						data-uploader-visible={showUploader ? 'true' : 'false'}
-					>
-						<Text variant="h5" as="h2" className="m-0 text-text-strong">
-							Single Media Upload
-						</Text>
-
-						<div className="my-4 border-b border-b-border-divider" />
-
-						{!showUploader ? (
-							<MediaDropzone
-								accept={accept}
-								multiple={maxFiles !== 1}
-								label="Drag & Drop File or"
-								buttonVariant="secondary"
-								buttonLabel="CHOOSE MEDIA"
-								onFilesSelected={onFilesSelected}
-							/>
-						) : null}
-
-						<div hidden={!showUploader}>{uploader}</div>
-					</section>
-				</Card>
-
-				{hasUploadedMedia ? (
-					<MediaDetailsForm
-						canPublishDirectly={canPublishDirectly}
-						canUseAdminSettings={canUseAdminSettings}
-						categories={categories}
-						contentSensitivities={contentSensitivities}
-						csrfToken={csrfToken}
-						editUrl={uploadedMedia?.editUrl ?? ''}
-						licenses={licenses}
-						mediaCountries={mediaCountries}
-						mediaLanguages={mediaLanguages}
-						topics={topics}
-					/>
-				) : null}
-			</div>
+			<SingleUploadContent {...props} />
 		</QueryClientProvider>
 	);
 }

--- a/frontend/src/features/add-media/single-upload/SingleUploadPage.test.jsx
+++ b/frontend/src/features/add-media/single-upload/SingleUploadPage.test.jsx
@@ -27,20 +27,33 @@ const TEST_LICENSES = [
 	},
 ];
 
+// SingleUploadPage now loads form options from useTaxonomies (GET bulk_options).
+// Mock the hook so the option lists are available synchronously; the API shape
+// uses codes for language/country and ids for the taxonomies/licenses.
+const taxonomyOptions = {
+	categories: [{ id: 'documentary', title: 'Documentary' }],
+	topics: [{ id: 'culture', title: 'Culture' }],
+	content_sensitivities: [],
+	languages: [{ code: 'en', title: 'English' }],
+	countries: [{ code: 'id', title: 'Indonesia' }],
+	licenses: TEST_LICENSES,
+};
+
+vi.mock('../../shared/components/upload-media', async (importOriginal) => {
+	const actual = await importOriginal();
+	return {
+		...actual,
+		useTaxonomies: () => ({ options: taxonomyOptions }),
+	};
+});
+
 describe('SingleUploadPage', () => {
 	beforeEach(() => {
 		useSingleUploadStore.getState().reset();
 	});
 
 	function renderUploadedPage(props = {}) {
-		return render(
-			<SingleUploadPage
-				hasUploadedMedia
-				licenses={TEST_LICENSES}
-				uploadedMedia={{ editUrl: '/media/test/edit' }}
-				{...props}
-			/>
-		);
+		return render(<SingleUploadPage hasUploadedMedia uploadedMedia={{ editUrl: '/media/test/edit' }} {...props} />);
 	}
 
 	afterEach(() => {
@@ -202,13 +215,7 @@ describe('SingleUploadPage', () => {
 		});
 		vi.stubGlobal('fetch', fetchMock);
 
-		renderUploadedPage({
-			canPublishDirectly: true,
-			mediaLanguages: [{ label: 'English', value: 'en' }],
-			mediaCountries: [{ label: 'Indonesia', value: 'id' }],
-			categories: [{ label: 'Documentary', value: 'documentary' }],
-			topics: [{ label: 'Culture', value: 'culture' }],
-		});
+		renderUploadedPage({ canPublishDirectly: true });
 
 		await user.type(screen.getByLabelText('Synopsis'), 'A short synopsis.');
 		await user.type(screen.getByLabelText('Year Produced'), '2024');
@@ -278,12 +285,7 @@ describe('SingleUploadPage', () => {
 		});
 		vi.stubGlobal('fetch', fetchMock);
 
-		renderUploadedPage({
-			mediaLanguages: [{ label: 'English', value: 'en' }],
-			mediaCountries: [{ label: 'Indonesia', value: 'id' }],
-			categories: [{ label: 'Documentary', value: 'documentary' }],
-			topics: [{ label: 'Culture', value: 'culture' }],
-		});
+		renderUploadedPage();
 
 		await user.type(screen.getByLabelText('Synopsis'), 'A short synopsis.');
 		await user.type(screen.getByLabelText('Year Produced'), '2024');

--- a/frontend/src/features/add-media/single-upload/components/ThumbnailImageUpload.jsx
+++ b/frontend/src/features/add-media/single-upload/components/ThumbnailImageUpload.jsx
@@ -27,7 +27,8 @@ export function ThumbnailImageUpload({ lastSelectedThumbnailFile, onFileChanged,
 			<div>
 				<TabView
 					tabMode="wrap"
-					triggerClassName="rounded-none py-3 px-size-22 text-neutral-50 aria-selected:text-text-primary"
+					triggerClassName="rounded-none py-3 px-size-22 text-neutral-50"
+					triggerSelectedColor="cinemata-strait-blue-200"
 					panelClassName="mt-8"
 					aria-label="Upload media type"
 					defaultSelectedTab="upload-thumbnail"

--- a/frontend/src/features/add-media/single-upload/components/ThumbnailImageUpload.jsx
+++ b/frontend/src/features/add-media/single-upload/components/ThumbnailImageUpload.jsx
@@ -27,8 +27,8 @@ export function ThumbnailImageUpload({ lastSelectedThumbnailFile, onFileChanged,
 			<div>
 				<TabView
 					tabMode="wrap"
-					triggerClassName="rounded-none py-3 px-size-22 text-neutral-50"
-					triggerSelectedColor="cinemata-strait-blue-200"
+					triggerClassName="rounded-none py-3 px-size-22 text-text-tab-trigger"
+					triggerSelectedColor="bg-bg-tab-trigger-selected"
 					panelClassName="mt-8"
 					aria-label="Upload media type"
 					defaultSelectedTab="upload-thumbnail"

--- a/frontend/src/features/shared/utils/resolveColor.js
+++ b/frontend/src/features/shared/utils/resolveColor.js
@@ -31,6 +31,7 @@ const SEMANTIC_COLOR_TOKENS = {
 		'control-checked',
 		'chip-active',
 		'chip',
+		'tab-trigger-selected',
 	]),
 	text: new Set([
 		'strong',
@@ -57,6 +58,7 @@ const SEMANTIC_COLOR_TOKENS = {
 		'action-inverse',
 		'panel-heading',
 		'control-checked',
+		'tab-trigger',
 	]),
 	border: new Set([
 		'default',

--- a/frontend/src/static/css/tailwind.css
+++ b/frontend/src/static/css/tailwind.css
@@ -1040,6 +1040,7 @@ body {
 	--bg-control-checked: var(--cinemata-pacific-deep-700);
 	--bg-chip-active: var(--cinemata-sunset-horizon-400p);
 	--bg-chip: var(--cinemata-strait-blue-100);
+	--bg-tab-trigger-selected: var(--cinemata-strait-blue-200);
 
 	/* Text */
 	--text-strong: var(--cinemata-pacific-deep-900);
@@ -1070,6 +1071,7 @@ body {
 	--text-action-inverse: var(--cinemata-strait-blue-100);
 	--text-panel-heading: var(--cinemata-pacific-deep-700);
 	--text-control-checked: var(--cinemata-pacific-deep-100);
+	--text-tab-trigger: var(--cinemata-neutral-50);
 
 	/* Borders */
 	--border-default: var(--cinemata-pacific-deep-200);
@@ -1129,6 +1131,7 @@ body.dark_theme {
 	--bg-control-checked: var(--cinemata-sunset-horizon-400p);
 	--bg-chip-active: var(--cinemata-sunset-horizon-400p);
 	--bg-chip: var(--cinemata-pacific-deep-700);
+	--bg-tab-trigger-selected: var(--cinemata-strait-blue-200);
 
 	--text-strong: var(--cinemata-strait-blue-50);
 	--text-primary: var(--cinemata-strait-blue-50);
@@ -1149,6 +1152,7 @@ body.dark_theme {
 	--text-action-inverse: var(--cinemata-strait-blue-50);
 	--text-panel-heading: var(--cinemata-neutral-50);
 	--text-control-checked: var(--cinemata-pacific-deep-900);
+	--text-tab-trigger: var(--cinemata-neutral-50);
 
 	--border-default: var(--cinemata-pacific-deep-700);
 	--border-subtle: var(--cinemata-pacific-deep-800);
@@ -1215,6 +1219,7 @@ body.dark_theme {
 	--color-bg-control-checked: var(--bg-control-checked);
 	--color-bg-chip-active: var(--bg-chip-active);
 	--color-bg-chip: var(--bg-chip);
+	--color-bg-tab-trigger-selected: var(--bg-tab-trigger-selected);
 
 	/* Text */
 	--color-text-strong: var(--text-strong);
@@ -1245,6 +1250,7 @@ body.dark_theme {
 	--color-text-action-inverse: var(--text-action-inverse);
 	--color-text-panel-heading: var(--text-panel-heading);
 	--color-text-control-checked: var(--text-control-checked);
+	--color-text-tab-trigger: var(--text-tab-trigger);
 
 	/* Borders */
 	--color-border-default: var(--border-default);

--- a/templates/cms/add-media_revamp.html
+++ b/templates/cms/add-media_revamp.html
@@ -22,12 +22,6 @@
 
 {% block content %}
 {{ allowed_extensions|json_script:"add-media-allowed-extensions" }}
-{{ media_languages|json_script:"add-media-languages" }}
-{{ media_countries|json_script:"add-media-countries" }}
-{{ categories|json_script:"add-media-categories" }}
-{{ topics|json_script:"add-media-topics" }}
-{{ content_sensitivities|json_script:"add-media-content-sensitivities" }}
-{{ licenses|json_script:"add-media-licenses" }}
 
 <script>
 	window.MediaCMS = window.MediaCMS || {};
@@ -46,12 +40,6 @@
 		resetPasswordUrl: "{% url 'account_reset_password' %}",
 		csrfToken: "{{ csrf_token|escapejs }}",
 		loginFormHtml: "{{ form.as_p|escapejs }}",
-		mediaLanguages: JSON.parse(document.getElementById('add-media-languages').textContent),
-		mediaCountries: JSON.parse(document.getElementById('add-media-countries').textContent),
-		categories: JSON.parse(document.getElementById('add-media-categories').textContent),
-		topics: JSON.parse(document.getElementById('add-media-topics').textContent),
-		contentSensitivities: JSON.parse(document.getElementById('add-media-content-sensitivities').textContent),
-		licenses: JSON.parse(document.getElementById('add-media-licenses').textContent),
 	};
 </script>
 


### PR DESCRIPTION
## Description

  Two related changes to the single-upload flow:

  1. **Fix cancel-during-upload bug** — clicking **CANCEL** on an in-flight upload aborted the upload but left the uploader hidden, so the dropzone
  never reappeared and the user was stuck. The native FineUploader cancel button was not wired to any React state reset.
  2. **Load form options from the shared API instead of `window.MediaCMS`** — media languages, countries, categories, topics, content sensitivities,
  and licenses are now fetched client-side via `useTaxonomies` (`GET /api/v1/my_uploads/bulk_options`), the same source the bulk-upload flow already
  uses. The server-injected `window.MediaCMS.addMediaPage` config for these lists is removed.
3. Fix user with maxUploadFiles more than 1 cannot open the form

  ## Related Issue

  Fixes #523 

  ## Motivation and Context

  - The cancel bug left users with no way to recover the uploader after cancelling — they had to reload the page.
  - Single- and bulk-upload were sourcing the same taxonomy data two different ways (server-rendered JSON vs. API). Consolidating on `useTaxonomies`
  removes the duplication, keeps both flows in sync, and shrinks the upload page's initial HTML payload.

  ## How Has This Been Tested?

  - **Manual:** Started a single upload, clicked CANCEL mid-upload → upload aborts, list empties, dropzone reappears. Verified delete (completed
  upload) path still works.
  - **Manual:** Confirmed the metadata form populates languages, countries, categories, topics, content sensitivities, and the license chooser from
  the API; license dialog matching (commercial / modifications) works.
  - **Automated:**
    - Frontend: `vitest run src/features/add-media` → 39 passed (includes updated `SingleUploadPage.test.jsx` mocking `useTaxonomies`).
    - Backend: `python manage.py test files.tests.test_bulk_upload.BulkUploadOptionsTests` → 2 passed.

## Screenshots
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/f7185b5e-cf16-4479-8cba-aee786cc9f9a" />
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/22146eea-4c92-43ae-bc90-884815f51db0" />
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/27b9d17c-05b5-4598-9dca-7b4effe2201a" />
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/6ac5b33e-000e-41e6-9be5-fa5593bbbc55" />


  ## Implementation Notes

  **Cancel fix**
  - Added an `onCancel` FineUploader callback that defers a state sync to the next tick (FineUploader removes the item element after the callback
  returns).
  - Extracted the list-empty reset logic into `syncUploaderState()`, shared by both the cancel and delete paths.

  **Taxonomy refactor**
  - `SingleUploadPage` splits into an inner `SingleUploadContent` rendered inside `QueryClientProvider`, which calls `useTaxonomies()` and maps the
  raw API shape to the existing component props (codes for language/country, ids for taxonomies/licenses).
  - New `IsUploadMediaUser` DRF permission: `bulk_options` was gated by `IsBulkUploadUser`, which would 403 single-file-only users. The endpoint
  returns only public taxonomy data, so it is now gated on upload capability alone.
  - `BulkUploadOptions` licenses now include `allowCommercial` / `allowModifications` (normalized, `Partially` → `sharealike`) and a string `id`,
  required by the single-upload license chooser. Harmless to bulk, which only uses id/title.
  - Removed the six taxonomy context vars from the `upload_media` view and the matching `json_script` / `addMediaPage` keys from
  `add-media_revamp.html`.

  ## Types of changes

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Documentation update

  ## Checklist:

  - [x] My code follows the code style of this project.
  - [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
  - [x] I have added tests to cover my changes.
  - [x] All new and existing tests passed.

  ## Modern Track Checklist (for new features):

  - [x] I have not imported `flux` in a new component
  - [x] If adding a new feature, I used Modern Track patterns
  - [x] New features do not create new SCSS files (use Tailwind instead)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * License options now display detailed commercial and modification usage permissions in the media upload form.

* **Improvements**
  * Updated Add Media page styling and layout for better visual organization.
  * Form options now load more efficiently with client-side processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->