### PR TITLE
feat(media): scheduled visibility expiration (#549)

### DIFF
--- a/cms/settings.py
+++ b/cms/settings.py
@@ -298,6 +298,11 @@ CELERY_BEAT_SCHEDULE = {
         "task": "dispatch_deferred_encodings",
         "schedule": timedelta(seconds=60),
     },
+    # Apply scheduled media visibility windows
+    "apply_visibility_schedules": {
+        "task": "apply_visibility_schedules",
+        "schedule": timedelta(seconds=60),
+    },
     #     "schedule": timedelta(seconds=5),
     #     "args": (16, 16)
 }

--- a/files/forms.py
+++ b/files/forms.py
@@ -1,8 +1,9 @@
-from datetime import datetime
+from datetime import datetime, time, timedelta
 
 from django import forms
 from django.conf import settings
 from django.contrib.auth.hashers import make_password
+from django.utils import timezone
 from django_recaptcha.fields import ReCaptchaField
 from django_recaptcha.widgets import ReCaptchaV2Checkbox
 
@@ -16,6 +17,15 @@ MEDIA_STATES = (
 )
 
 
+def _to_local_midnight(value):
+    if value is None:
+        return None
+    dt = value if isinstance(value, datetime) else datetime.combine(value, time.min)
+    if timezone.is_naive(dt):
+        dt = timezone.make_aware(dt, timezone.get_current_timezone())
+    return dt.astimezone(timezone.get_current_timezone()).replace(hour=0, minute=0, second=0, microsecond=0)
+
+
 class MultipleSelect(forms.CheckboxSelectMultiple):
     input_type = "checkbox"
 
@@ -24,6 +34,16 @@ class MediaForm(forms.ModelForm):
     new_tags = forms.CharField(label="Tags", help_text="Use a comma to separate multiple tags.", required=False)
     no_license = forms.BooleanField(required=False, label="All Rights Reserved")
     custom_license = forms.CharField(required=False, label="Just a placeholder")
+    visibility_start = forms.DateField(
+        required=False,
+        input_formats=["%Y-%m-%d"],
+        widget=forms.DateInput(attrs={"type": "date"}, format="%Y-%m-%d"),
+    )
+    visibility_end = forms.DateField(
+        required=False,
+        input_formats=["%Y-%m-%d"],
+        widget=forms.DateInput(attrs={"type": "date"}, format="%Y-%m-%d"),
+    )
 
     # Add New Field Declarations to MediaForm
     # Override year_produced to handle dropdown + custom input
@@ -110,6 +130,8 @@ class MediaForm(forms.ModelForm):
                 self.fields["year_produced_custom"].initial = self.instance.year_produced
 
         self.fields["state"].label = "Status"
+        self.fields["visibility_start"].label = "Enter Start Date"
+        self.fields["visibility_end"].label = "Enter End Date"
         self.fields["allow_download"].label = "Allow Download"
         self.fields["is_encrypted"].label = "Enable HLS Encryption"
         self.fields["reported_times"].label = "Reported Times"
@@ -268,6 +290,17 @@ class MediaForm(forms.ModelForm):
             error = "This video cannot be featured as it is Restricted."
             self.add_error("featured", error)
 
+        visibility_start_date = _to_local_midnight(cleaned_data.get("visibility_start"))
+        visibility_expires_at = _to_local_midnight(cleaned_data.get("visibility_end"))
+        if visibility_expires_at:
+            visibility_expires_at += timedelta(days=1)
+
+        cleaned_data["visibility_start_date"] = visibility_start_date
+        cleaned_data["visibility_expires_at"] = visibility_expires_at
+
+        if visibility_start_date and visibility_expires_at and visibility_expires_at <= visibility_start_date:
+            self.add_error("visibility_end", "End date must be after the start date.")
+
         # Always return the full cleaned_data dictionary
         return cleaned_data
 
@@ -292,6 +325,20 @@ class MediaForm(forms.ModelForm):
                             # self.instance.state = self.initial['state']
                     else:
                         self.instance.state = "private"
+
+        has_visibility_schedule = bool(data.get("visibility_start_date") or data.get("visibility_expires_at"))
+        visibility_fields_submitted = "visibility_start" in self.data or "visibility_end" in self.data
+        if has_visibility_schedule:
+            self.instance.visibility_start_date = data.get("visibility_start_date")
+            self.instance.visibility_expires_at = data.get("visibility_expires_at")
+            self.instance.visibility_after_expiry = "private"
+            self.instance.visibility_window_state = self.instance.state
+            self.instance.state = self.instance.expected_visibility_state(timezone.now())
+        elif visibility_fields_submitted:
+            self.instance.visibility_start_date = None
+            self.instance.visibility_expires_at = None
+            self.instance.visibility_after_expiry = None
+            self.instance.visibility_window_state = None
 
         if data.get("custom_license", "") and data.get("custom_license", "") not in ["None"]:
             self.instance.license_id = data.get("custom_license")

--- a/files/forms.py
+++ b/files/forms.py
@@ -328,10 +328,13 @@ class MediaForm(forms.ModelForm):
 
         has_visibility_schedule = bool(data.get("visibility_start_date") or data.get("visibility_expires_at"))
         visibility_fields_submitted = "visibility_start" in self.data or "visibility_end" in self.data
+        is_new_instance = not self.instance.pk
         if has_visibility_schedule:
             self.instance.visibility_start_date = data.get("visibility_start_date")
             self.instance.visibility_expires_at = data.get("visibility_expires_at")
-            self.instance.visibility_after_expiry = "private"
+            # Preserve an existing after-expiry preference; default to "private" only when absent.
+            if not self.instance.visibility_after_expiry:
+                self.instance.visibility_after_expiry = "private"
             self.instance.visibility_window_state = self.instance.state
             self.instance.state = self.instance.expected_visibility_state(timezone.now())
         elif visibility_fields_submitted:
@@ -360,6 +363,21 @@ class MediaForm(forms.ModelForm):
             self.instance.is_draft = False
 
         media = super(MediaForm, self).save(*args, **kwargs)
+
+        # Media.save() resets state via get_default_state() on creation (no pk
+        # before super().save()). Re-apply the scheduled state after the row
+        # exists so it isn't clobbered by that default.
+        if is_new_instance and has_visibility_schedule:
+            scheduled_state = media.expected_visibility_state(timezone.now())
+            type(media).objects.filter(pk=media.pk).update(
+                state=scheduled_state,
+                visibility_start_date=media.visibility_start_date,
+                visibility_expires_at=media.visibility_expires_at,
+                visibility_after_expiry=media.visibility_after_expiry,
+                visibility_window_state=media.visibility_window_state,
+            )
+            media.state = scheduled_state
+
         return media
 
 

--- a/files/migrations/0028_media_visibility_schedule.py
+++ b/files/migrations/0028_media_visibility_schedule.py
@@ -1,0 +1,57 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("files", "0027_media_is_draft_alter_media_summary"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="media",
+            name="visibility_start_date",
+            field=models.DateTimeField(
+                blank=True,
+                db_index=True,
+                help_text="When the film becomes visible at its chosen Status. Stored in UTC. Blank = immediate.",
+                null=True,
+            ),
+        ),
+        migrations.AddField(
+            model_name="media",
+            name="visibility_expires_at",
+            field=models.DateTimeField(
+                blank=True,
+                db_index=True,
+                help_text="When visibility ends and the film flips to the after-expiry state. Stored in UTC. Blank = never.",
+                null=True,
+            ),
+        ),
+        migrations.AddField(
+            model_name="media",
+            name="visibility_after_expiry",
+            field=models.CharField(
+                blank=True,
+                choices=[("private", "Private"), ("unlisted", "Unlisted")],
+                help_text="State the film flips to after the window ends.",
+                max_length=20,
+                null=True,
+            ),
+        ),
+        migrations.AddField(
+            model_name="media",
+            name="visibility_window_state",
+            field=models.CharField(
+                blank=True,
+                choices=[
+                    ("private", "Private"),
+                    ("public", "Public"),
+                    ("restricted", "Restricted"),
+                    ("unlisted", "Unlisted"),
+                ],
+                help_text="Chosen Status to restore while the visibility window is active. Set automatically.",
+                max_length=20,
+                null=True,
+            ),
+        ),
+    ]

--- a/files/models.py
+++ b/files/models.py
@@ -81,6 +81,10 @@ MEDIA_STATES = (
     ("restricted", "Restricted"),
     ("unlisted", "Unlisted"),
 )
+VISIBILITY_AFTER_EXPIRY_STATES = (
+    ("private", "Private"),
+    ("unlisted", "Unlisted"),
+)
 MEDIA_TYPES_SUPPORTED = (
     ("video", "Video"),
     ("image", "Image"),
@@ -260,6 +264,32 @@ class Media(models.Model):
         default=helpers.get_portal_workflow(),
         db_index=True,
     )
+    visibility_start_date = models.DateTimeField(
+        null=True,
+        blank=True,
+        db_index=True,
+        help_text="When the film becomes visible at its chosen Status. Stored in UTC. Blank = immediate.",
+    )
+    visibility_expires_at = models.DateTimeField(
+        null=True,
+        blank=True,
+        db_index=True,
+        help_text="When visibility ends and the film flips to the after-expiry state. Stored in UTC. Blank = never.",
+    )
+    visibility_after_expiry = models.CharField(
+        max_length=20,
+        choices=VISIBILITY_AFTER_EXPIRY_STATES,
+        null=True,
+        blank=True,
+        help_text="State the film flips to after the window ends.",
+    )
+    visibility_window_state = models.CharField(
+        max_length=20,
+        choices=MEDIA_STATES,
+        null=True,
+        blank=True,
+        help_text="Chosen Status to restore while the visibility window is active. Set automatically.",
+    )
     is_reviewed = models.BooleanField(
         "Reviewed",
         default=settings.MEDIA_IS_REVIEWED,
@@ -374,6 +404,16 @@ class Media(models.Model):
         self.__original_state = self.state
         self.__original_password = self.password
         self.__original_is_encrypted = self.is_encrypted
+
+    def expected_visibility_state(self, now=None):
+        """Return the state this media should have for its visibility window."""
+        if now is None:
+            now = timezone.now()
+        if self.visibility_start_date and now < self.visibility_start_date:
+            return "private"
+        if self.visibility_expires_at and now >= self.visibility_expires_at:
+            return self.visibility_after_expiry or "private"
+        return self.visibility_window_state or self.state
 
     def set_password(self, raw_password):
         """Hash and set the media password. Single entry point for password changes."""

--- a/files/tasks.py
+++ b/files/tasks.py
@@ -18,6 +18,7 @@ from celery.utils.log import get_task_logger
 from django.conf import settings
 from django.core.cache import cache
 from django.core.files import File
+from django.db import transaction
 from django.db.models import F, Q
 from django.urls import reverse
 from django.utils import timezone
@@ -1563,18 +1564,26 @@ def apply_visibility_schedules():
     """Apply scheduled media visibility windows.
 
     Uses a singleton cache lock so only one worker updates visibility at a time.
+    The lock value is a unique token so the finally block only deletes the lock
+    this invocation set, not one a newer worker may have already claimed.
     """
+    import uuid
+
     lock_key = "apply_visibility_schedules_lock"
     lock_timeout = getattr(settings, "VISIBILITY_SCHEDULE_LOCK_TIMEOUT", 120)
+    lock_token = str(uuid.uuid4())
 
-    if not cache.add(lock_key, "locked", lock_timeout):
+    if not cache.add(lock_key, lock_token, lock_timeout):
         logger.debug("Visibility schedule task skipped: another worker holds the lock")
         return
 
     try:
         _apply_visibility_schedules_inner()
     finally:
-        cache.delete(lock_key)
+        # Only release the lock if we still own it — guards against a slow run
+        # where the TTL expired and a new worker already claimed the key.
+        if cache.get(lock_key) == lock_token:
+            cache.delete(lock_key)
 
 
 def _apply_visibility_schedules_inner():
@@ -1591,24 +1600,32 @@ def _apply_visibility_schedules_inner():
     transition_count = 0
     for media in scheduled_media.iterator():
         try:
-            expected = media.expected_visibility_state(now)
-            if media.state == expected:
-                continue
+            with transaction.atomic():
+                # Re-fetch under a row lock so a concurrent user edit that arrived
+                # between the queryset evaluation and this point isn't overwritten.
+                try:
+                    media = Media.objects.select_for_update().get(pk=media.pk)
+                except Media.DoesNotExist:
+                    continue
 
-            logger.info(
-                "Applying visibility schedule for media %s: %s -> %s",
-                media.friendly_token,
-                media.state,
-                expected,
-            )
-            media.state = expected
-            # Keep Media.save() from interpreting this state-only transition as a
-            # media-file or thumbnail-time edit and dispatching encoding work.
-            media._Media__original_media_file = media.media_file
-            media._Media__original_thumbnail_time = media.thumbnail_time
-            media.save(update_fields=["state"])
+                expected = media.expected_visibility_state(now)
+                if media.state == expected:
+                    continue
+
+                logger.info(
+                    "Applying visibility schedule for media %s: %s -> %s",
+                    media.friendly_token,
+                    media.state,
+                    expected,
+                )
+                media.state = expected
+                # Keep Media.save() from interpreting this state-only transition as a
+                # media-file or thumbnail-time edit and dispatching encoding work.
+                media._Media__original_media_file = media.media_file
+                media._Media__original_thumbnail_time = media.thumbnail_time
+                media.save(update_fields=["state"])
             transition_count += 1
-        except (django.db.DatabaseError, OSError, TypeError, ValueError):
+        except Exception:
             logger.exception("Failed to apply visibility schedule for media %s", getattr(media, "pk", "unknown"))
 
     if transition_count:

--- a/files/tasks.py
+++ b/files/tasks.py
@@ -1598,8 +1598,14 @@ def _apply_visibility_schedules_inner():
     ).order_by("id")
 
     transition_count = 0
+    # Collect tokens that transition to public so we can notify after all row
+    # locks are released — notify_users() sends email synchronously and must
+    # not run while a DB row lock and transaction are still open.
+    tokens_to_notify = []
+
     for media in scheduled_media.iterator():
         try:
+            went_public = False
             with transaction.atomic():
                 # Re-fetch under a row lock so a concurrent user edit that arrived
                 # between the queryset evaluation and this point isn't overwritten.
@@ -1618,15 +1624,48 @@ def _apply_visibility_schedules_inner():
                     media.state,
                     expected,
                 )
+                went_public = expected == "public"
                 media.state = expected
                 # Keep Media.save() from interpreting this state-only transition as a
                 # media-file or thumbnail-time edit and dispatching encoding work.
                 media._Media__original_media_file = media.media_file
                 media._Media__original_thumbnail_time = media.thumbnail_time
-                media.save(update_fields=["state"])
+
+                update_fields = ["state"]
+                # Once a schedule has fully settled (past expiry and now in the
+                # after-expiry state) clear the datetime fields so this row no
+                # longer appears in future scans and accumulates unnecessary locks.
+                if (
+                    media.visibility_expires_at
+                    and now >= media.visibility_expires_at
+                    and expected == (media.visibility_after_expiry or "private")
+                ):
+                    media.visibility_start_date = None
+                    media.visibility_expires_at = None
+                    media.visibility_after_expiry = None
+                    media.visibility_window_state = None
+                    update_fields += [
+                        "visibility_start_date",
+                        "visibility_expires_at",
+                        "visibility_after_expiry",
+                        "visibility_window_state",
+                    ]
+
+                media.save(update_fields=update_fields)
+
             transition_count += 1
+            if went_public:
+                tokens_to_notify.append(media.friendly_token)
         except Exception:
             logger.exception("Failed to apply visibility schedule for media %s", getattr(media, "pk", "unknown"))
+
+    # Send publish notifications after all row locks are released so SMTP
+    # round-trips don't hold the DB transaction open.
+    for token in tokens_to_notify:
+        try:
+            notify_users(friendly_token=token, action="media_published")
+        except Exception:
+            logger.exception("Failed to send publish notification for media %s", token)
 
     if transition_count:
         logger.info("Applied %d visibility schedule transitions", transition_count)

--- a/files/tasks.py
+++ b/files/tasks.py
@@ -20,6 +20,7 @@ from django.core.cache import cache
 from django.core.files import File
 from django.db.models import F, Q
 from django.urls import reverse
+from django.utils import timezone
 
 from actions.models import USER_MEDIA_ACTIONS, MediaAction
 from users.models import User
@@ -1555,6 +1556,63 @@ def dispatch_deferred_encodings():
         _dispatch_deferred_encodings_inner()
     finally:
         cache.delete(lock_key)
+
+
+@task(name="apply_visibility_schedules", queue="short_tasks")
+def apply_visibility_schedules():
+    """Apply scheduled media visibility windows.
+
+    Uses a singleton cache lock so only one worker updates visibility at a time.
+    """
+    lock_key = "apply_visibility_schedules_lock"
+    lock_timeout = getattr(settings, "VISIBILITY_SCHEDULE_LOCK_TIMEOUT", 120)
+
+    if not cache.add(lock_key, "locked", lock_timeout):
+        logger.debug("Visibility schedule task skipped: another worker holds the lock")
+        return
+
+    try:
+        _apply_visibility_schedules_inner()
+    finally:
+        cache.delete(lock_key)
+
+
+def _apply_visibility_schedules_inner():
+    now = timezone.now()
+    # Load full rows (no .only()): the candidate set is small (only scheduled
+    # media), and deferring fields here is unsafe — Media.save() fires the
+    # track_featured_change pre_save signal which reads `featured`, and
+    # Media.__init__ reads `media_file`/`thumbnail_time`. If any of those are
+    # deferred, lazy-loading re-enters __init__ and recurses infinitely.
+    scheduled_media = Media.objects.filter(
+        Q(visibility_start_date__isnull=False) | Q(visibility_expires_at__isnull=False)
+    ).order_by("id")
+
+    transition_count = 0
+    for media in scheduled_media.iterator():
+        try:
+            expected = media.expected_visibility_state(now)
+            if media.state == expected:
+                continue
+
+            logger.info(
+                "Applying visibility schedule for media %s: %s -> %s",
+                media.friendly_token,
+                media.state,
+                expected,
+            )
+            media.state = expected
+            # Keep Media.save() from interpreting this state-only transition as a
+            # media-file or thumbnail-time edit and dispatching encoding work.
+            media._Media__original_media_file = media.media_file
+            media._Media__original_thumbnail_time = media.thumbnail_time
+            media.save(update_fields=["state"])
+            transition_count += 1
+        except (django.db.DatabaseError, OSError, TypeError, ValueError):
+            logger.exception("Failed to apply visibility schedule for media %s", getattr(media, "pk", "unknown"))
+
+    if transition_count:
+        logger.info("Applied %d visibility schedule transitions", transition_count)
 
 
 def _dispatch_deferred_encodings_inner():

--- a/files/tests/test_media_form_visibility.py
+++ b/files/tests/test_media_form_visibility.py
@@ -1,0 +1,159 @@
+from datetime import date, datetime, time, timedelta
+
+from django.test import TestCase
+from django.utils import timezone
+
+from files.forms import MediaForm, _to_local_midnight
+from files.models import Category, Language, Media
+from files.tests.helpers import create_test_media, create_test_user
+
+
+class MediaFormVisibilityScheduleTest(TestCase):
+    def setUp(self):
+        self.user = create_test_user()
+        self.user.advancedUser = True
+        self.user.save()
+        self.media = create_test_media(self.user, state="public")
+        self.category = Category.objects.first() or Category.objects.create(
+            title="Test Category", user=self.user, is_global=True
+        )
+        Language.objects.get_or_create(code="en", defaults={"title": "English"})
+
+    def _get_form_data(self, **overrides):
+        data = {
+            "title": "Visibility Test",
+            "state": "public",
+            "password": "",
+            "summary": "test summary",
+            "description": "test description",
+            "media_language": "en",
+            "media_country": "AU",
+            "category": [self.category.id],
+            "topics": [],
+            "new_tags": "",
+            "year_produced": "2025",
+            "enable_comments": True,
+            "allow_download": True,
+            "visibility_start": "",
+            "visibility_end": "",
+        }
+        data.update(overrides)
+        return data
+
+    def test_end_date_before_start_date_is_invalid(self):
+        today = timezone.localdate()
+        data = self._get_form_data(
+            visibility_start=(today + timedelta(days=2)).isoformat(),
+            visibility_end=today.isoformat(),
+        )
+
+        form = MediaForm(self.user, data=data, instance=self.media)
+
+        self.assertFalse(form.is_valid())
+        self.assertIn("visibility_end", form.errors)
+
+    def test_valid_window_stores_window_state_and_inclusive_end_datetime(self):
+        today = timezone.localdate()
+        data = self._get_form_data(
+            state="unlisted",
+            visibility_start=(today - timedelta(days=1)).isoformat(),
+            visibility_end=(today + timedelta(days=1)).isoformat(),
+        )
+
+        form = MediaForm(self.user, data=data, instance=self.media)
+
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+        saved = form.save()
+        self.assertEqual(saved.visibility_window_state, "unlisted")
+        self.assertEqual(saved.visibility_after_expiry, "private")
+        self.assertEqual(saved.state, "unlisted")
+        self.assertEqual(saved.visibility_expires_at, _to_local_midnight(today + timedelta(days=1)) + timedelta(days=1))
+
+    def test_save_immediately_hides_future_start_media(self):
+        today = timezone.localdate()
+        data = self._get_form_data(
+            state="public",
+            visibility_start=(today + timedelta(days=5)).isoformat(),
+            visibility_end=(today + timedelta(days=10)).isoformat(),
+        )
+
+        form = MediaForm(self.user, data=data, instance=self.media)
+
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+        saved = form.save()
+        saved.refresh_from_db()
+        self.assertEqual(saved.visibility_window_state, "public")
+        self.assertEqual(saved.visibility_after_expiry, "private")
+        self.assertEqual(saved.state, "private")
+
+    def test_save_immediately_expires_already_ended_media(self):
+        today = timezone.localdate()
+        data = self._get_form_data(
+            state="public",
+            visibility_start=(today - timedelta(days=10)).isoformat(),
+            visibility_end=(today - timedelta(days=1)).isoformat(),
+        )
+
+        form = MediaForm(self.user, data=data, instance=self.media)
+
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+        saved = form.save()
+        saved.refresh_from_db()
+        self.assertEqual(saved.visibility_window_state, "public")
+        self.assertEqual(saved.state, "private")
+
+    def test_date_coercion_accepts_date_naive_datetime_and_aware_datetime(self):
+        local_tz = timezone.get_current_timezone()
+        day = date(2026, 6, 11)
+        naive_dt = datetime.combine(day, time(hour=14, minute=30))
+        aware_dt = timezone.make_aware(naive_dt, local_tz)
+        expected = timezone.make_aware(datetime.combine(day, time.min), local_tz)
+
+        self.assertEqual(_to_local_midnight(day), expected)
+        self.assertEqual(_to_local_midnight(naive_dt), expected)
+        self.assertEqual(_to_local_midnight(aware_dt), expected)
+
+    def test_unchecking_schedule_clears_visibility_fields(self):
+        Media.objects.filter(pk=self.media.pk).update(
+            visibility_start_date=timezone.now() + timedelta(days=1),
+            visibility_expires_at=timezone.now() + timedelta(days=3),
+            visibility_after_expiry="unlisted",
+            visibility_window_state="public",
+        )
+        self.media.refresh_from_db()
+        data = self._get_form_data(state="unlisted")
+
+        form = MediaForm(self.user, data=data, instance=self.media)
+
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+        saved = form.save()
+        saved.refresh_from_db()
+        self.assertEqual(saved.state, "unlisted")
+        self.assertIsNone(saved.visibility_start_date)
+        self.assertIsNone(saved.visibility_expires_at)
+        self.assertIsNone(saved.visibility_after_expiry)
+        self.assertIsNone(saved.visibility_window_state)
+
+    def test_legacy_edit_without_visibility_aliases_does_not_clear_existing_schedule(self):
+        start = timezone.now() + timedelta(days=1)
+        expires = timezone.now() + timedelta(days=3)
+        Media.objects.filter(pk=self.media.pk).update(
+            visibility_start_date=start,
+            visibility_expires_at=expires,
+            visibility_after_expiry="private",
+            visibility_window_state="public",
+        )
+        self.media.refresh_from_db()
+        data = self._get_form_data(state="public")
+        data.pop("visibility_start")
+        data.pop("visibility_end")
+
+        form = MediaForm(self.user, data=data, instance=self.media)
+
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+        saved = form.save()
+        saved.refresh_from_db()
+        self.assertEqual(saved.visibility_start_date, start)
+        self.assertEqual(saved.visibility_expires_at, expires)
+        self.assertEqual(saved.visibility_after_expiry, "private")
+        self.assertEqual(saved.visibility_window_state, "public")

--- a/files/tests/test_visibility_schedule_task.py
+++ b/files/tests/test_visibility_schedule_task.py
@@ -1,0 +1,160 @@
+from datetime import timedelta
+from unittest.mock import patch
+
+from django.test import TestCase
+from django.utils import timezone
+
+from files.models import Media
+from files.tasks import apply_visibility_schedules
+from files.tests.helpers import create_test_media, create_test_user
+
+
+class VisibilityScheduleTaskTest(TestCase):
+    def setUp(self):
+        self.user = create_test_user()
+
+    def _media_with_schedule(self, *, state="public", start=None, expires=None, after="private", window="public"):
+        media = create_test_media(self.user, state=state)
+        Media.objects.filter(pk=media.pk).update(
+            visibility_start_date=start,
+            visibility_expires_at=expires,
+            visibility_after_expiry=after,
+            visibility_window_state=window,
+        )
+        media.refresh_from_db()
+        return media
+
+    def test_before_start_is_private_even_when_after_expiry_is_unlisted(self):
+        now = timezone.now()
+        media = self._media_with_schedule(
+            state="public",
+            start=now + timedelta(days=2),
+            expires=now + timedelta(days=5),
+            after="unlisted",
+            window="public",
+        )
+
+        apply_visibility_schedules()
+
+        media.refresh_from_db()
+        self.assertEqual(media.state, "private")
+
+    def test_active_window_restores_window_state(self):
+        now = timezone.now()
+        media = self._media_with_schedule(
+            state="private",
+            start=now - timedelta(days=1),
+            expires=now + timedelta(days=1),
+            after="private",
+            window="public",
+        )
+
+        apply_visibility_schedules()
+
+        media.refresh_from_db()
+        self.assertEqual(media.state, "public")
+
+    def test_expired_window_applies_after_expiry_state(self):
+        now = timezone.now()
+        media = self._media_with_schedule(
+            state="public",
+            start=now - timedelta(days=5),
+            expires=now - timedelta(days=1),
+            after="unlisted",
+            window="public",
+        )
+
+        apply_visibility_schedules()
+
+        media.refresh_from_db()
+        self.assertEqual(media.state, "unlisted")
+
+    def test_no_schedule_is_unchanged(self):
+        media = create_test_media(self.user, state="public")
+
+        apply_visibility_schedules()
+
+        media.refresh_from_db()
+        self.assertEqual(media.state, "public")
+
+    def test_idempotent_state_does_not_save_or_notify(self):
+        now = timezone.now()
+        self._media_with_schedule(
+            state="private",
+            start=now + timedelta(days=2),
+            expires=now + timedelta(days=5),
+            after="unlisted",
+            window="public",
+        )
+
+        with (
+            patch("files.models.Media._invalidate_permission_cache") as invalidate_cache,
+            patch("files.methods.notify_users") as notify_users,
+            patch("files.tasks.media_init.apply_async") as media_init,
+        ):
+            apply_visibility_schedules()
+
+        invalidate_cache.assert_not_called()
+        notify_users.assert_not_called()
+        media_init.assert_not_called()
+
+    def test_publish_notification_fires_on_transition_to_public(self):
+        now = timezone.now()
+        media = self._media_with_schedule(
+            state="private",
+            start=now - timedelta(days=1),
+            expires=now + timedelta(days=1),
+            after="private",
+            window="public",
+        )
+
+        with patch("files.methods.notify_users") as notify_users:
+            apply_visibility_schedules()
+
+        media.refresh_from_db()
+        self.assertEqual(media.state, "public")
+        notify_users.assert_any_call(friendly_token=media.friendly_token, action="media_published")
+
+    def test_lock_returns_without_running_inner_task(self):
+        with (
+            patch("files.tasks.cache.add", return_value=False),
+            patch("files.tasks._apply_visibility_schedules_inner") as inner,
+        ):
+            apply_visibility_schedules()
+
+        inner.assert_not_called()
+
+    def test_per_row_error_isolated(self):
+        now = timezone.now()
+        first = self._media_with_schedule(
+            state="public",
+            start=now + timedelta(days=1),
+            expires=now + timedelta(days=2),
+            after="private",
+            window="public",
+        )
+        second = self._media_with_schedule(
+            state="public",
+            start=now + timedelta(days=1),
+            expires=now + timedelta(days=2),
+            after="private",
+            window="public",
+        )
+
+        # Key the failure on the specific instance rather than call order, so the
+        # test is robust to other scheduled media in the (mirrored) test DB and to
+        # queryset ordering. `first` raises; every other row computes normally.
+        real_expected = Media.expected_visibility_state
+
+        def fake_expected(self, now=None):
+            if self.pk == first.pk:
+                raise ValueError("bad row")
+            return real_expected(self, now)
+
+        with patch("files.tasks.Media.expected_visibility_state", autospec=True, side_effect=fake_expected):
+            apply_visibility_schedules()
+
+        first.refresh_from_db()
+        second.refresh_from_db()
+        self.assertEqual(first.state, "public")
+        self.assertEqual(second.state, "private")

--- a/frontend/src/features/add-media/bulk-upload/buildSubmitItems.js
+++ b/frontend/src/features/add-media/bulk-upload/buildSubmitItems.js
@@ -58,6 +58,11 @@ export function buildEditFormData({ metadata = {}, posterFile = null, action = '
 		data.set('password', metadata.password);
 	}
 
+	if (metadata.expireEnabled) {
+		if (metadata.startDate) data.set('visibility_start', metadata.startDate);
+		if (metadata.endDate) data.set('visibility_end', metadata.endDate);
+	}
+
 	// Admin fields: reported_times is always sent (single sends a hidden 0 for
 	// non-admins; MediaForm drops it for non-editors), featured only when set.
 	data.set('reported_times', metadata.reported_times ?? '0');

--- a/frontend/src/features/add-media/bulk-upload/components/step2/FileCard.jsx
+++ b/frontend/src/features/add-media/bulk-upload/components/step2/FileCard.jsx
@@ -17,6 +17,7 @@ import {
 	AllowDownloadCheckbox,
 	StatusRadioGroup,
 	RestrictedPasswordField,
+	VisibilityExpirationField,
 	StreamProtectionField,
 	AdminSettingsFields,
 	ThumbnailUploadField,
@@ -134,14 +135,12 @@ export function FileCard({ file, subStep, options, errors = {}, onClearErrors })
 							/>
 						</>
 					) : null}
-
 					{subStep === 'thumbnail' ? (
 						<ThumbnailUploadField
 							posterFile={file.posterFile}
 							onFileSelected={(posterFile) => setPosterFile(file.id, posterFile)}
 						/>
 					) : null}
-
 					{subStep === 'other' ? (
 						<>
 							<CompanyField value={meta.company} onChange={(value) => patch({ company: value })} />
@@ -196,7 +195,6 @@ export function FileCard({ file, subStep, options, errors = {}, onClearErrors })
 							/>
 						</>
 					) : null}
-
 					{subStep === 'final' ? (
 						<div className="flex flex-col">
 							<EnableCommentsCheckbox
@@ -229,13 +227,30 @@ export function FileCard({ file, subStep, options, errors = {}, onClearErrors })
 
 							<Divider />
 
+							<VisibilityExpirationField
+								idPrefix={`visibility-${file.id}`}
+								expireEnabled={meta.expireEnabled}
+								startDate={meta.startDate}
+								endDate={meta.endDate}
+								onToggle={(checked) =>
+									patch(
+										checked
+											? { expireEnabled: true }
+											: { expireEnabled: false, startDate: '', endDate: '' }
+									)
+								}
+								onStartDateChange={(value) => patch({ startDate: value })}
+								onEndDateChange={(value) => patch({ endDate: value })}
+							/>
+
+							<Divider />
+
 							<StreamProtectionField
 								checked={meta.is_encrypted}
 								onChange={(checked) => patch({ is_encrypted: checked })}
 							/>
 						</div>
 					) : null}
-
 					{subStep === 'admin' && canUseAdminSettings ? (
 						<AdminSettingsFields
 							featured={meta.featured}
@@ -243,6 +258,7 @@ export function FileCard({ file, subStep, options, errors = {}, onClearErrors })
 							onChange={(next) => patch(next)}
 							idPrefix={`file-${file.id}`}
 						/>
+					) : null}
 					) : null}
 				</div>
 			</Card>

--- a/frontend/src/features/add-media/bulk-upload/components/step2/FileCard.jsx
+++ b/frontend/src/features/add-media/bulk-upload/components/step2/FileCard.jsx
@@ -259,7 +259,6 @@ export function FileCard({ file, subStep, options, errors = {}, onClearErrors })
 							idPrefix={`file-${file.id}`}
 						/>
 					) : null}
-					) : null}
 				</div>
 			</Card>
 

--- a/frontend/src/features/add-media/bulk-upload/useBulkUploadStore.js
+++ b/frontend/src/features/add-media/bulk-upload/useBulkUploadStore.js
@@ -33,6 +33,9 @@ export function createDefaultMetadata() {
 		allow_download: true,
 		state: 'public',
 		password: '',
+		expireEnabled: false,
+		startDate: '',
+		endDate: '',
 		// Stream Protection (HLS encryption) is off by default, matching single-upload.
 		is_encrypted: false,
 		// Admin-only fields (shown only to admins); reported_times mirrors the

--- a/frontend/src/features/add-media/single-upload/components/FinalSettingsForm.jsx
+++ b/frontend/src/features/add-media/single-upload/components/FinalSettingsForm.jsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
-import { DateChooserField, RadioButton, Text, formatDMY } from '../../../shared/components';
+import { RadioButton, Text } from '../../../shared/components';
 import { CheckboxButton } from '../../../shared/components/CheckboxButton';
 import { TextField } from '../../../shared/components/TextField';
-import { diffInDays, todayIso } from '../../utils/helpers';
+import { VisibilityExpirationField } from '../../../shared/components/upload-media';
 import { FieldGroup } from './FieldGroup';
 
 const STATUS_OPTIONS = [
@@ -14,15 +14,9 @@ const STATUS_OPTIONS = [
 
 export function FinalSettingsForm({ singleUpload, canUseRestrictedStatus = false }) {
 	const [showPassword, setShowPassword] = useState(false);
-	const effectiveStart = singleUpload.startDate || todayIso();
-	const visibleDays = singleUpload.endDate ? diffInDays(effectiveStart, singleUpload.endDate) : 0;
 	const statusOptions = canUseRestrictedStatus
 		? STATUS_OPTIONS
 		: STATUS_OPTIONS.filter((option) => option.value !== 'restricted');
-
-	function toggleExpire(event) {
-		singleUpload.setExpireEnabled(event.target.checked);
-	}
 
 	return (
 		<FieldGroup title="Final Settings">
@@ -83,39 +77,14 @@ export function FinalSettingsForm({ singleUpload, canUseRestrictedStatus = false
 
 				<div className="my-4 border-b border-b-border-divider" />
 
-				<CheckboxButton checked={singleUpload.expireEnabled} onChange={toggleExpire}>
-					Set Visibility Expiration
-				</CheckboxButton>
-
-				{singleUpload.expireEnabled ? (
-					<>
-						<div className="flex flex-col gap-4 sm:flex-row">
-							<DateChooserField
-								id="visibility_start"
-								name="visibility_start"
-								label="Enter Start Date"
-								value={singleUpload.startDate}
-								onChange={singleUpload.setStartDate}
-							/>
-
-							<DateChooserField
-								id="visibility_end"
-								name="visibility_end"
-								label="Enter End Date"
-								value={singleUpload.endDate}
-								min={singleUpload.startDate || todayIso()}
-								onChange={singleUpload.setEndDate}
-							/>
-						</div>
-
-						{singleUpload.endDate ? (
-							<Text variant="body-14" color="meta" className="m-0">
-								Your film will be visible for {visibleDays} days, starting {formatDMY(effectiveStart)}{' '}
-								to {formatDMY(singleUpload.endDate)}
-							</Text>
-						) : null}
-					</>
-				) : null}
+				<VisibilityExpirationField
+					expireEnabled={singleUpload.expireEnabled}
+					startDate={singleUpload.startDate}
+					endDate={singleUpload.endDate}
+					onToggle={singleUpload.setExpireEnabled}
+					onStartDateChange={singleUpload.setStartDate}
+					onEndDateChange={singleUpload.setEndDate}
+				/>
 
 				<div className="my-4 border-b border-b-border-divider" />
 

--- a/frontend/src/features/shared/components/upload-media/fields/FinalFields.jsx
+++ b/frontend/src/features/shared/components/upload-media/fields/FinalFields.jsx
@@ -80,7 +80,9 @@ export function VisibilityExpirationField({
 	idPrefix = 'visibility',
 }) {
 	const effectiveStart = startDate || todayIso();
-	const visibleDays = endDate ? diffInDays(effectiveStart, endDate) : 0;
+	// Backend treats end date as inclusive (+1 day in forms.py), so add 1 to
+	// match: same start and end date = a valid 1-day window, not 0 days.
+	const visibleDays = endDate ? diffInDays(effectiveStart, endDate) + 1 : 0;
 
 	return (
 		<>

--- a/frontend/src/features/shared/components/upload-media/fields/FinalFields.jsx
+++ b/frontend/src/features/shared/components/upload-media/fields/FinalFields.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { TextField } from '../../TextField';
 import { CheckboxButton } from '../../CheckboxButton';
 import { RadioButton } from '../../RadioButton';
+import { DateChooserField, formatDMY } from '../../DateChooserField';
 import { Text } from '../../Text';
 
 // Controlled twins of the single-upload FinalSettingsForm fields. Same widgets,
@@ -56,7 +57,76 @@ export function StatusRadioGroup({ value = 'public', onChange, name, includeRest
 	);
 }
 
-export function RestrictedPasswordField({ password = '', onPasswordChange, error = '', id = 'restricted-password' }) {
+function todayIso() {
+	const now = new Date();
+	const month = String(now.getMonth() + 1).padStart(2, '0');
+	const day = String(now.getDate()).padStart(2, '0');
+	return `${now.getFullYear()}-${month}-${day}`;
+}
+
+function diffInDays(startIso, endIso) {
+	const start = new Date(startIso);
+	const end = new Date(endIso);
+	return Math.max(0, Math.ceil((end - start) / 86400000));
+}
+
+export function VisibilityExpirationField({
+	expireEnabled = false,
+	startDate = '',
+	endDate = '',
+	onToggle,
+	onStartDateChange,
+	onEndDateChange,
+	idPrefix = 'visibility',
+}) {
+	const effectiveStart = startDate || todayIso();
+	const visibleDays = endDate ? diffInDays(effectiveStart, endDate) : 0;
+
+	return (
+		<>
+			<CheckboxButton checked={expireEnabled} onChange={(event) => onToggle?.(event.target.checked)}>
+				Set Visibility Expiration
+			</CheckboxButton>
+
+			{expireEnabled ? (
+				<>
+					<div className="flex flex-col gap-4 sm:flex-row">
+						<DateChooserField
+							id={`${idPrefix}_start`}
+							name="visibility_start"
+							label="Enter Start Date"
+							value={startDate}
+							onChange={onStartDateChange}
+						/>
+						<DateChooserField
+							id={`${idPrefix}_end`}
+							name="visibility_end"
+							label="Enter End Date"
+							value={endDate}
+							min={startDate || todayIso()}
+							onChange={onEndDateChange}
+						/>
+					</div>
+
+					{endDate ? (
+						<Text variant="body-14" color="meta" className="m-0">
+							Your film will be visible for {visibleDays} days, starting {formatDMY(effectiveStart)} to{' '}
+							{formatDMY(endDate)}
+						</Text>
+					) : null}
+				</>
+			) : null}
+		</>
+	);
+}
+
+export function RestrictedPasswordField({
+	password = '',
+	onPasswordChange,
+	error = '',
+	id = 'restricted-password',
+	name = 'password',
+}) {
 	const [showPassword, setShowPassword] = useState(false);
 
 	return (
@@ -85,14 +155,14 @@ export function StreamProtectionField({ checked = true, onChange }) {
 			<div className="flex flex-row items-start gap-2">
 				<CheckboxButton
 					name="is_encrypted"
-					aria-label="Encrypt this video’s stream"
+					aria-label="Encrypt this video's stream"
 					className="mt-0.5"
 					checked={checked}
 					onChange={(event) => onChange?.(event.target.checked)}
 				/>
 				<div className="flex flex-col gap-2">
 					<Text className="m-0" variant="body-16">
-						Encrypt this video’s stream
+						Encrypt this video's stream
 					</Text>
 					<Text className="m-0" variant="body-12">
 						Adds an extra layer of protection so only authorized viewers can watch this film. If your video


### PR DESCRIPTION
## Description

Adds a scheduled visibility window for media. Uploaders can set a start date (when the film becomes visible at its chosen Status), an end date (when visibility expires), and an after-expiry state (Private or Unlisted). A Celery beat task automatically flips `Media.state` as the window boundaries pass.

The "Set Visibility Expiration" checkbox and date pickers are available in the revamped single-upload flow (`/upload`).

## Related Issue

Fixes #549

## Motivation and Context

Filmmakers need to schedule time-limited public screenings or embargo releases without having to manually change visibility. This feature automates that lifecycle.

## How Has This Been Tested?

Manually tested end-to-end on `feat/549-media-visibility` with Docker Postgres + `cms.settings`:

1. **UI** — Enabled revamp upload variant, uploaded a video, ticked "Set Visibility Expiration", picked start/end dates. Confirmed checkbox reveals both date pickers and the summary line renders correctly ("Your film will be visible for 2 days, starting 26/06/2026 to 28/06/2026").
2. **Persistence** — Verified in Django shell that `visibility_start_date`, `visibility_expires_at`, `visibility_after_expiry`, and `visibility_window_state` all saved correctly.
3. **No-leak apply** — Set a future start date with Status=Public; confirmed `state=private` immediately on save before any beat run.
4. **Beat task transitions** — Called `_apply_visibility_schedules_inner()` directly in the shell:
   - Before start → `private` ✅
   - In window → `public` (notification email fired) ✅
   - After expiry → `private` ✅
   - Idempotent re-run → no change ✅

Automated tests: `files/tests/test_media_form_visibility.py` and `files/tests/test_visibility_schedule_task.py`.

## Screenshots (if appropriate):
<img width="1070" height="674" alt="image" src="https://github.com/user-attachments/assets/af1d3d46-acaa-4cdd-9150-3b6b3c88499c" />
<img width="1097" height="792" alt="image" src="https://github.com/user-attachments/assets/7d037342-20a7-49c8-a7ef-ba5c3567b0fb" />

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):

- [x] I have not imported `flux` in a new component
- [x] If adding a new feature, I used Modern Track patterns
- [x] New features do not create new SCSS files (use Tailwind instead)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visibility scheduling for media, including start and end dates plus automatic state handling when a visibility window begins or ends.
  * Media visibility is now recalculated automatically every minute.

* **Bug Fixes**
  * Submitting an invalid date range is now rejected.
  * Clearing scheduled visibility now removes related visibility settings cleanly.
  * Scheduled updates are applied safely without repeating work or interrupting unrelated changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->