### PR TITLE
fix: Single Upload Revamp Issues

### DIFF
--- a/files/management_views.py
+++ b/files/management_views.py
@@ -24,6 +24,7 @@ from .models import (
     get_language_choices,
 )
 from .permissions import (
+    IsBulkUploadUser,
     IsFilmImpactManager,
     IsManageUploadsUser,
     IsMediacmsEditor,

--- a/files/management_views.py
+++ b/files/management_views.py
@@ -24,7 +24,6 @@ from .models import (
     get_language_choices,
 )
 from .permissions import (
-    IsBulkUploadUser,
     IsFilmImpactManager,
     IsManageUploadsUser,
     IsMediacmsEditor,

--- a/files/tests/test_bulk_upload.py
+++ b/files/tests/test_bulk_upload.py
@@ -50,12 +50,12 @@ class BulkUploadOptionsTests(TestCase):
         Language.objects.get_or_create(code="en", defaults={"title": "English"})
 
     def test_anonymous_forbidden(self):
-        response = self.client.get("/api/v1/my_uploads/bulk_options")
+        response = self.client.get("/api/v1/my_uploads/upload_options")
         self.assertEqual(response.status_code, 403)
 
     def test_regular_user_gets_options(self):
         self.client.login(username="reg", password="pw")
-        response = self.client.get("/api/v1/my_uploads/bulk_options")
+        response = self.client.get("/api/v1/my_uploads/upload_options")
         self.assertEqual(response.status_code, 200)
         data = response.json()
         for key in ("categories", "topics", "content_sensitivities", "languages", "countries", "licenses"):
@@ -65,16 +65,16 @@ class BulkUploadOptionsTests(TestCase):
 
     def test_licenses_expose_creative_commons_fields(self):
         # The shared CC license chooser resolves a license from the commercial /
-        # modifications selection, so bulk_options must expose those fields (same
+        # modifications selection, so upload_options must expose those fields (same
         # shape the single-upload page injects via window.MediaCMS.addMediaPage).
         License.objects.get_or_create(
             title="Test License",
             defaults={"allow_commercial": "yes", "allow_modifications": "yes"},
         )
         self.client.login(username="reg", password="pw")
-        response = self.client.get("/api/v1/my_uploads/bulk_options")
+        response = self.client.get("/api/v1/my_uploads/upload_options")
         licenses = response.json()["licenses"]
-        self.assertTrue(licenses, "expected at least one license in bulk_options")
+        self.assertTrue(licenses, "expected at least one license in upload_options")
         for key in ("id", "title", "allowCommercial", "allowModifications"):
             self.assertIn(key, licenses[0])
 

--- a/files/urls.py
+++ b/files/urls.py
@@ -124,7 +124,7 @@ urlpatterns = [
     # USER MANAGE UPLOADS
     path("api/v1/my_uploads", management_views.MyUploadsList.as_view()),
     path("api/v1/my_uploads/bulk_state", management_views.MyUploadsBulkState.as_view()),
-    path("api/v1/my_uploads/bulk_options", management_views.BulkUploadOptions.as_view()),
+    path("api/v1/my_uploads/upload_options", management_views.BulkUploadOptions.as_view()),
     path("manage/uploads", views.manage_uploads, name="manage_uploads"),
     path("manage/users/export", views.export_users, name="export_users"),
     path("api/v1/encode_profiles/", views.EncodeProfileList.as_view()),

--- a/files/views.py
+++ b/files/views.py
@@ -675,7 +675,7 @@ def upload_media(request):
 
     # The single-upload form options (languages, countries, categories, topics,
     # content sensitivities, licenses) are loaded client-side from the shared
-    # bulk_options endpoint (useTaxonomies), so they are no longer injected here.
+    # upload_options endpoint (useTaxonomies), so they are no longer injected here.
 
     return render(request, template, context)
 

--- a/frontend/src/entries/add-media.js
+++ b/frontend/src/entries/add-media.js
@@ -1,4 +1,8 @@
 import { renderPage } from '../static/js/_helpers.js';
-import { AddMediaPage } from '../features/add-media';
+import { AddMediaPage as AddMediaPageRevamp } from '../features/add-media';
+import { AddMediaPage as AddMediaPageLegacy } from '../static/js/pages/AddMediaPage';
 
-renderPage('page-add-media', AddMediaPage);
+const isRevamp = document.body?.dataset.uiVariant === 'revamp' && document.getElementById('app-root') !== null;
+const PageComponent = isRevamp ? AddMediaPageRevamp : AddMediaPageLegacy;
+
+renderPage('page-add-media', PageComponent);

--- a/frontend/src/features/add-media/AddMediaPage.jsx
+++ b/frontend/src/features/add-media/AddMediaPage.jsx
@@ -588,10 +588,17 @@ export class AddMediaPage extends Page {
 						    form and never bleeds into the Quick Preview column; the stepper
 						    rail (left) lines up with its top. */}
 						<header className="flex items-start justify-between gap-4 @4xl/page:col-start-2 @4xl/page:row-start-1">
-							<div className="min-w-0">
-								<Text variant="h4" as="h1" className="m-0 text-text-strong">
-									{headerTitle}
-								</Text>
+							<div className="w-full">
+								<div className="flex flex-row items-center">
+									<Text variant="h4" as="h1" className="m-0 text-text-strong flex-1">
+										{headerTitle}
+									</Text>
+
+									<span className="body-body-12-regular shrink-0 text-text-title-required">
+										* Required
+									</span>
+								</div>
+
 								<Text variant="body-16" color="description" className="m-0 mt-4 max-w-[720px]">
 									Please check our&nbsp;
 									<a
@@ -605,7 +612,6 @@ export class AddMediaPage extends Page {
 									Any media that does not comply with the policy will be deleted from Cinemata.org.
 								</Text>
 							</div>
-							<span className="body-body-12-regular shrink-0 text-text-accent">* Required</span>
 						</header>
 
 						{/* Left rail — the bulk wizard stepper; spans from the header row so it

--- a/frontend/src/features/add-media/AddMediaPage.jsx
+++ b/frontend/src/features/add-media/AddMediaPage.jsx
@@ -58,6 +58,9 @@ export class AddMediaPage extends Page {
 	}
 
 	componentDidMount() {
+		// Build the bulk config now that context is settled. Set once and never
+		// rebuilt, so the reference stays stable across re-renders — recreating it
+		// would re-run useBulkUpload's effect and cancel an in-progress upload.
 		this.setState({
 			bulkConfig: {
 				isTrustedUser: !!this.config.isTrustedUser,
@@ -137,6 +140,9 @@ export class AddMediaPage extends Page {
 					console.warn(window.qq.format('Error on file number {} - {}.  Reason: {}', id, name, errorReason));
 				},
 				onCancel: () => {
+					// FineUploader's built-in cancel button removes the item element after
+					// this callback returns, so defer the state sync to the next tick. When
+					// the list empties, reset hasSelectedMedia so the dropzone reappears.
 					window.setTimeout(() => this.syncUploaderState(), 0);
 				},
 				onComplete: (id, _name, response) => {
@@ -458,6 +464,8 @@ export class AddMediaPage extends Page {
 			return;
 		}
 
+		// Guard against out-of-order responses: only the most recently requested
+		// token may write the preview, so a slow earlier fetch can't clobber it.
 		this.latestPreviewToken = friendlyToken;
 
 		fetch(`${mediaApiUrl}/${friendlyToken}`, { credentials: 'same-origin' })

--- a/frontend/src/features/add-media/AddMediaPage.jsx
+++ b/frontend/src/features/add-media/AddMediaPage.jsx
@@ -39,8 +39,6 @@ export class AddMediaPage extends Page {
 		this.uploaderRef = React.createRef();
 		this.uploader = null;
 		this.pendingReplaceId = null;
-		// Maps FineUploader file id -> server friendly_token once the upload
-		// completes, so a later delete can remove the real Media object.
 		this.completedTokens = {};
 		this.state = {
 			confirmBulkUploadOpen: false,
@@ -52,26 +50,14 @@ export class AddMediaPage extends Page {
 			pendingDeleteName: '',
 			selectedTab: 'single-film-upload',
 			uploadedMedia: null,
-			// Set when a bulk file is moved into the single tab (one file left): the
-			// media is already uploaded, so single shows its edit form (no re-upload).
 			externalMedia: null,
-			// Live data for the single-upload Quick Preview, reported up from the
-			// form so it can render in the shared right-hand slot (below).
 			singlePreview: { ...EMPTY_SINGLE_PREVIEW },
-			// Config for the Bulk Upload tab; built once in componentDidMount (after
-			// UserContext has settled) so canUseAdminSettings reflects the real admin
-			// flag rather than a first-render snapshot. Kept stable thereafter.
 			bulkConfig: null,
-			// Mirrors the bulk wizard's current step so the Single/Bulk tab switcher
-			// can hide itself on steps 2 and 3 (matching the Figma).
 			bulkStep: 1,
 		};
 	}
 
 	componentDidMount() {
-		// Build the bulk config now that context is settled. Set once and never
-		// rebuilt, so the reference stays stable across re-renders — recreating it
-		// would re-run useBulkUpload's effect and cancel an in-progress upload.
 		this.setState({
 			bulkConfig: {
 				isTrustedUser: !!this.config.isTrustedUser,
@@ -83,8 +69,6 @@ export class AddMediaPage extends Page {
 			},
 		});
 
-		// Track the bulk wizard step so the Single/Bulk tab switcher can hide on
-		// steps 2 and 3 (only update on actual step changes to avoid extra renders).
 		this.lastBulkStep = 1;
 		this.unsubscribeBulkStep = useBulkUploadStore.subscribe((state) => {
 			if (state.currentStep !== this.lastBulkStep) {
@@ -153,9 +137,6 @@ export class AddMediaPage extends Page {
 					console.warn(window.qq.format('Error on file number {} - {}.  Reason: {}', id, name, errorReason));
 				},
 				onCancel: () => {
-					// FineUploader's built-in cancel button removes the item element after
-					// this callback returns, so defer the state sync to the next tick. When
-					// the list empties, reset hasSelectedMedia so the dropzone reappears.
 					window.setTimeout(() => this.syncUploaderState(), 0);
 				},
 				onComplete: (id, _name, response) => {
@@ -198,8 +179,6 @@ export class AddMediaPage extends Page {
 	}
 
 	openFilePicker() {
-		// This page adds files manually (MediaDropzone -> addFiles) and has no
-		// FineUploader browse button, so spin up a transient file input instead.
 		const input = document.createElement('input');
 		input.type = 'file';
 		input.accept = 'video/*';
@@ -211,7 +190,6 @@ export class AddMediaPage extends Page {
 			const files = Array.from(input.files || []);
 
 			if (files.length) {
-				// Check for multi-file selection before deleting the original
 				if (files.length > 1) {
 					this.pendingReplaceId = null;
 					this.setState({ confirmBulkUploadOpen: true });
@@ -219,8 +197,6 @@ export class AddMediaPage extends Page {
 					return;
 				}
 
-				// Replace = delete the old media first (frees the item-limit slot and
-				// removes the old server-side Media), then upload the new one.
 				if (this.pendingReplaceId != null) {
 					this.removeUploadItem(this.pendingReplaceId);
 					this.pendingReplaceId = null;
@@ -234,7 +210,6 @@ export class AddMediaPage extends Page {
 			cleanup();
 		});
 
-		// Picker dismissed without choosing: keep the original media untouched.
 		input.addEventListener('cancel', () => {
 			this.pendingReplaceId = null;
 			cleanup();
@@ -244,8 +219,6 @@ export class AddMediaPage extends Page {
 		input.click();
 	}
 
-	// Delete a Media row created by a finished upload. Best-effort and fire-and-
-	// forget: a failed cleanup is logged but never blocks the UI.
 	deleteMediaByToken(friendlyToken) {
 		if (!friendlyToken) {
 			return;
@@ -269,8 +242,6 @@ export class AddMediaPage extends Page {
 
 	deleteUploadedMedia(id) {
 		const friendlyToken = this.completedTokens[id];
-
-		// Only completed uploads exist server-side; in-flight ones are handled by cancel().
 		if (!friendlyToken) {
 			return;
 		}
@@ -284,8 +255,6 @@ export class AddMediaPage extends Page {
 			return;
 		}
 
-		// FineUploader.cancel() only aborts in-flight uploads; a finished upload has
-		// already created a Media row, so delete it on the server too.
 		this.deleteUploadedMedia(id);
 
 		try {
@@ -303,9 +272,6 @@ export class AddMediaPage extends Page {
 		this.syncUploaderState();
 	}
 
-	// Reconciles React state with the current upload list. When the list empties,
-	// resets FineUploader so the dropzone, browse button, and item-limit counters
-	// return to their initial state.
 	syncUploaderState() {
 		const listEl = this.uploaderRef.current && this.uploaderRef.current.querySelector('.qq-upload-list-selector');
 		const hasRemainingItems = !!listEl?.children.length;
@@ -326,8 +292,6 @@ export class AddMediaPage extends Page {
 
 		if (reuploadButton) {
 			event.preventDefault();
-			// Defer removing the existing item until the user actually picks a new
-			// file (onSubmitted). Canceling the picker keeps the original in place.
 			this.pendingReplaceId = this.getFileIdFromElement(reuploadButton);
 			this.openFilePicker();
 			return;
@@ -375,32 +339,25 @@ export class AddMediaPage extends Page {
 		this.setState({ confirmBulkUploadOpen: false, selectedTab: 'bulk-upload' });
 	};
 
-	// Stable reference so the single-upload form's preview effect doesn't loop.
-	// Merge so the upload's thumbnail (set on complete) isn't clobbered by the
-	// form's title/company/country/category updates.
 	handleSinglePreviewChange = (preview) => {
 		this.setState((state) => ({ singlePreview: { ...state.singlePreview, ...preview } }));
 	};
 
-	// True when there's work that switching tabs would discard: a single-upload
-	// selection/upload, or any files in the bulk wizard.
 	hasUploadInProgress = () => {
 		let bulkFileCount = 0;
+
 		try {
 			bulkFileCount = useBulkUploadStore.getState().files.length;
 		} catch {
 			bulkFileCount = 0;
 		}
+
 		return this.state.hasSelectedMedia || !!this.state.uploadedMedia || bulkFileCount > 0;
 	};
 
-	// Clears both flows and switches; called directly when nothing's in progress,
-	// or after the user confirms the switch dialog.
 	doTabSwitch = (nextTab) => {
-		// Discarding in-progress work also removes any media already created on the
-		// server — single completed uploads plus bulk files — so switching tabs
-		// never leaves orphan drafts behind.
 		Object.values(this.completedTokens).forEach((token) => this.deleteMediaByToken(token));
+
 		try {
 			useBulkUploadStore.getState().files.forEach((file) => {
 				if (file.friendlyToken) {
@@ -410,17 +367,21 @@ export class AddMediaPage extends Page {
 		} catch (error) {
 			console.warn('Unable to read bulk upload files on tab change', error);
 		}
+
 		this.completedTokens = {};
+
 		try {
 			this.uploader?.reset();
 		} catch (error) {
 			console.warn('Unable to reset uploader on tab change', error);
 		}
+
 		try {
 			useBulkUploadStore.getState().reset();
 		} catch (error) {
 			console.warn('Unable to reset bulk upload store on tab change', error);
 		}
+
 		this.setState({
 			selectedTab: nextTab,
 			hasSelectedMedia: false,
@@ -432,20 +393,20 @@ export class AddMediaPage extends Page {
 		});
 	};
 
-	// Bulk -> single when only one file remains (decision D2): the media is already
-	// uploaded, so move it into the single tab's edit form instead of discarding it
-	// (no re-upload needed). The bulk wizard is cleared.
 	moveBulkMediaToSingle = (file) => {
 		if (!file?.friendlyToken) {
 			return;
 		}
+
 		const token = file.friendlyToken;
 		this.completedTokens = {};
+
 		try {
 			useBulkUploadStore.getState().reset();
 		} catch (error) {
 			console.warn('Unable to reset bulk upload store on move-to-single', error);
 		}
+
 		this.setState({
 			selectedTab: 'single-film-upload',
 			hasSelectedMedia: true,
@@ -460,6 +421,7 @@ export class AddMediaPage extends Page {
 			confirmTabSwitchOpen: false,
 			pendingTab: null,
 		});
+
 		this.fetchSinglePreviewThumbnail(token);
 	};
 
@@ -467,11 +429,12 @@ export class AddMediaPage extends Page {
 		if (nextTab === this.state.selectedTab) {
 			return;
 		}
-		// Confirm before discarding in-progress work; otherwise switch immediately.
+
 		if (this.hasUploadInProgress()) {
 			this.setState({ confirmTabSwitchOpen: true, pendingTab: nextTab });
 			return;
 		}
+
 		this.doTabSwitch(nextTab);
 	};
 
@@ -485,18 +448,18 @@ export class AddMediaPage extends Page {
 		}
 	};
 
-	// Pull the uploaded media's poster so the Quick Preview shows a real image.
 	fetchSinglePreviewThumbnail = (friendlyToken) => {
 		if (!friendlyToken) {
 			return;
 		}
+
 		const mediaApiUrl = mediacmsConfig(window.MediaCMS).api.media;
 		if (!mediaApiUrl) {
 			return;
 		}
-		// Guard against out-of-order responses: only the most recently requested
-		// token may write the preview, so a slow earlier fetch can't clobber it.
+
 		this.latestPreviewToken = friendlyToken;
+
 		fetch(`${mediaApiUrl}/${friendlyToken}`, { credentials: 'same-origin' })
 			.then((response) => (response.ok ? response.json() : null))
 			.then((data) => {
@@ -534,10 +497,6 @@ export class AddMediaPage extends Page {
 	};
 
 	pageContent() {
-		// Anonymous users never reach this React app: the upload_media view redirects
-		// them to the (redesigned) allauth sign-in page before the page is served.
-		// If that guard is ever bypassed, canAdd is false for them, so they fall
-		// through to CannotUploadMessage below.
 		if (!this.config.canAdd) {
 			return <CannotUploadMessage config={this.config} />;
 		}
@@ -560,13 +519,8 @@ export class AddMediaPage extends Page {
 
 		const isBulk = selectedTab === 'bulk-upload';
 		const bulkConfig = this.state.bulkConfig;
-		// On bulk steps 2 & 3 the Single/Bulk tab switcher is hidden (matching the
-		// Figma), so the panel's top margin (which normally separates it from the
-		// tabs) is dropped to avoid a large gap under the header.
 		const tabsHidden = isBulk && bulkStep > 1;
 
-		// The header title tracks the bulk wizard step (matching the Figma); single
-		// keeps a single title. The description stays the same across steps.
 		const headerTitle = !isBulk
 			? 'Upload Media to Cinemata'
 			: bulkStep === 2
@@ -577,16 +531,8 @@ export class AddMediaPage extends Page {
 
 		return (
 			<div className="media-uploader-wrap add-media-page-wrap">
-				{/* Shared 3-column shell: left stepper rail, centre form, right Quick
-				    Preview. The single tab uses these slots directly; the bulk tab
-				    renders its own stepper/per-file preview, so it spans full width and
-				    the side slots are hidden. Container queries respond to the real
-				    content width (shrinks when the app sidebar is open). */}
 				<main className="add-media-feature @container/page mx-4 py-8 text-text-primary sm:mx-6 lg:mx-10">
 					<div className="grid grid-cols-1 gap-8 @4xl/page:grid-cols-[220px_minmax(0,1fr)_340px] @4xl/page:items-start">
-						{/* Header — lives in the centre column (row 1) so it aligns with the
-						    form and never bleeds into the Quick Preview column; the stepper
-						    rail (left) lines up with its top. */}
 						<header className="flex items-start justify-between gap-4 @4xl/page:col-start-2 @4xl/page:row-start-1">
 							<div className="w-full">
 								<div className="flex flex-row items-center">
@@ -614,9 +560,6 @@ export class AddMediaPage extends Page {
 							</div>
 						</header>
 
-						{/* Left rail — the bulk wizard stepper; spans from the header row so it
-						    sits flush at the top and stays pinned while scrolling. Empty
-						    (reserved) on the single tab so the centre card stays aligned. */}
 						<aside className="hidden min-w-0 @4xl/page:block @4xl/page:col-start-1 @4xl/page:row-start-1 @4xl/page:row-span-2 @4xl/page:sticky @4xl/page:top-[calc(var(--header-height)+1rem)] @4xl/page:self-start">
 							{isBulk ? <BulkStepperSlot /> : null}
 						</aside>
@@ -674,15 +617,9 @@ export class AddMediaPage extends Page {
 							</TabView>
 						</section>
 
-						{/* Right slot — live Quick Preview for the single tab, shown once a
-						    file has been uploaded. The column stays reserved before then so
-						    the form doesn't shift. Hidden for bulk (per-file preview lives
-						    inside each card). */}
 						<aside
 							className={cn(
 								'hidden min-w-0 @4xl/page:block @4xl/page:col-start-3 @4xl/page:row-start-2 @4xl/page:sticky @4xl/page:top-[calc(var(--header-height)+1rem)] @4xl/page:self-start',
-								// Offset down so the Quick Preview lines up with the form's first
-								// card (clears the tab bar ~44px + the panel's mt-8 = 76px).
 								'@4xl/page:mt-[76px]',
 								isBulk && '@4xl/page:hidden'
 							)}

--- a/frontend/src/features/add-media/bulk-upload/bulkUploadConfig.js
+++ b/frontend/src/features/add-media/bulk-upload/bulkUploadConfig.js
@@ -8,7 +8,7 @@ import { createContext, useContext } from 'react';
 export const BULK_UPLOAD_CONFIG_DEFAULTS = {
 	uploadEndpoint: '/fu/upload/',
 	chunksDoneParam: 'done',
-	optionsEndpoint: '/api/v1/my_uploads/bulk_options',
+	optionsEndpoint: '/api/v1/my_uploads/upload_options',
 	singleUploadUrl: '/upload',
 	postSubmitUrl: '/',
 	maxFiles: 2,

--- a/frontend/src/features/add-media/single-upload/SingleUploadPage.jsx
+++ b/frontend/src/features/add-media/single-upload/SingleUploadPage.jsx
@@ -1,27 +1,13 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { useTaxonomies } from '../../shared/components/upload-media';
-import { Card, Icon, TextAlert } from '../../shared/components';
+import { Card, Icon } from '../../shared/components';
 import { MediaDropzone } from '../../shared/components/MediaDropzone';
 import { Text } from '../../shared/components/Text';
 import { MediaDetailsForm } from './components/MediaDetailsForm';
 import singleUploadQueryClient from './queryClient';
 import { AlertOwnershipMedia } from './components/AlertOwnershipMedia';
-
-function toCodeOptions(items = []) {
-	return items.map((item) => ({ value: item.code, label: item.title }));
-}
-
-function toIdOptions(items = []) {
-	return items.map((item) => ({ value: item.id, label: item.title }));
-}
-
-const EMPTY_PREVIEW = { title: '', company: '', media_country: '', category: '' };
-
-function findLabel(options = [], value) {
-	const option = options.find((item) => String(item.value ?? item.code) === String(value));
-	return option?.label || option?.title || '';
-}
+import { EMPTY_PREVIEW, findLabel, toCodeOptions, toIdOptions } from '../utils/helpers';
 
 function SingleUploadContent({
 	accept = 'video/*',
@@ -39,6 +25,7 @@ function SingleUploadContent({
 }) {
 	const { options } = useTaxonomies();
 
+	// Form Options
 	const mediaLanguages = useMemo(() => toCodeOptions(options.languages), [options.languages]);
 	const mediaCountries = useMemo(() => toCodeOptions(options.countries), [options.countries]);
 	const categories = useMemo(() => toIdOptions(options.categories), [options.categories]);
@@ -49,14 +36,10 @@ function SingleUploadContent({
 	);
 	const licenses = options.licenses;
 
-	// Raw values reported by the (uncontrolled) form, resolved to display labels
-	// and pushed up so the host can render the Quick Preview in its shared slot.
+	// Preview
 	const [preview, setPreview] = useState(EMPTY_PREVIEW);
 	const countryLabel = findLabel(mediaCountries, preview.media_country);
 	const categoryLabel = findLabel(categories, preview.category);
-
-	// Stable so the form's thumbnail effect (which creates/revokes an object URL on
-	// change) doesn't re-run every render and revoke the preview blob early.
 	const handleFormPreviewChange = useCallback((partial) => setPreview((prev) => ({ ...prev, ...partial })), []);
 
 	useEffect(() => {
@@ -66,11 +49,11 @@ function SingleUploadContent({
 			country: countryLabel,
 			category: categoryLabel ? { title: categoryLabel } : null,
 		};
-		// Only forward a chosen-thumbnail preview when one exists, so it doesn't wipe
-		// the uploaded media's auto thumbnail that the host fetched on upload.
+
 		if (preview.thumbnailUrl) {
 			next.thumbnailUrl = preview.thumbnailUrl;
 		}
+
 		onPreviewChange?.(next);
 	}, [onPreviewChange, preview.title, preview.company, countryLabel, categoryLabel, preview.thumbnailUrl]);
 
@@ -89,8 +72,6 @@ function SingleUploadContent({
 					<div className="my-4 border-b border-b-border-divider" />
 
 					{externalMedia ? (
-						/* A file moved here from the bulk tab — already uploaded, so show a
-						   "ready" row instead of the dropzone/uploader (no re-upload). */
 						<div className="flex items-center gap-3 rounded-ds-4 bg-bg-surface-muted px-4 py-3">
 							<Icon name="check" size={20} decorative className="text-text-success" />
 							<span className="body-body-14-medium text-text-strong">

--- a/frontend/src/features/add-media/single-upload/SingleUploadPage.jsx
+++ b/frontend/src/features/add-media/single-upload/SingleUploadPage.jsx
@@ -1,14 +1,13 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { useTaxonomies } from '../../shared/components/upload-media';
-import { Card, Icon } from '../../shared/components';
+import { Card, Icon, TextAlert } from '../../shared/components';
 import { MediaDropzone } from '../../shared/components/MediaDropzone';
 import { Text } from '../../shared/components/Text';
 import { MediaDetailsForm } from './components/MediaDetailsForm';
 import singleUploadQueryClient from './queryClient';
+import { AlertOwnershipMedia } from './components/AlertOwnershipMedia';
 
-// Language/country use codes; the M2M taxonomies use ids. Mirrors the bulk-upload
-// field mapping so both flows submit exactly what MediaForm expects.
 function toCodeOptions(items = []) {
 	return items.map((item) => ({ value: item.code, label: item.title }));
 }
@@ -117,6 +116,8 @@ function SingleUploadContent({
 					)}
 				</section>
 			</Card>
+
+			{!showUploader && <AlertOwnershipMedia className="mt-8" />}
 
 			{hasUploadedMedia ? (
 				<MediaDetailsForm

--- a/frontend/src/features/add-media/single-upload/SingleUploadPage.test.jsx
+++ b/frontend/src/features/add-media/single-upload/SingleUploadPage.test.jsx
@@ -217,6 +217,7 @@ describe('SingleUploadPage', () => {
 
 		renderUploadedPage({ canPublishDirectly: true });
 
+		await user.type(screen.getByLabelText('Title'), 'A short title.');
 		await user.type(screen.getByLabelText('Synopsis'), 'A short synopsis.');
 		await user.click(screen.getByRole('button', { name: 'Choose' }));
 		await user.click(screen.getByRole('button', { name: '2024' }));
@@ -288,6 +289,7 @@ describe('SingleUploadPage', () => {
 
 		renderUploadedPage();
 
+		await user.type(screen.getByLabelText('Title'), 'A short title.');
 		await user.type(screen.getByLabelText('Synopsis'), 'A short synopsis.');
 		await user.click(screen.getByRole('button', { name: 'Choose' }));
 		await user.click(screen.getByRole('button', { name: '2024' }));

--- a/frontend/src/features/add-media/single-upload/SingleUploadPage.test.jsx
+++ b/frontend/src/features/add-media/single-upload/SingleUploadPage.test.jsx
@@ -27,7 +27,7 @@ const TEST_LICENSES = [
 	},
 ];
 
-// SingleUploadPage now loads form options from useTaxonomies (GET bulk_options).
+// SingleUploadPage now loads form options from useTaxonomies (GET upload_options).
 // Mock the hook so the option lists are available synchronously; the API shape
 // uses codes for language/country and ids for the taxonomies/licenses.
 const taxonomyOptions = {
@@ -109,15 +109,16 @@ describe('SingleUploadPage', () => {
 		expect(screen.getByText('CC BY-NC-SA 4.0 - Attribution-NonCommercial-ShareAlike')).toBeInTheDocument();
 	});
 
-	it('limits year produced to four characters', async () => {
+	it('selects a year from the popover picker', async () => {
 		const user = userEvent.setup();
 		renderUploadedPage();
 
-		const yearInput = screen.getByLabelText('Year Produced');
+		await user.click(screen.getByRole('button', { name: 'Choose' }));
 
-		await user.type(yearInput, '20245');
+		const yearButton = screen.getByRole('button', { name: '2024' });
+		await user.click(yearButton);
 
-		expect(yearInput).toHaveValue('2024');
+		expect(document.querySelector('input[name="year_produced"]')).toHaveValue('2024');
 	});
 
 	it('enables comments and downloads by default', () => {
@@ -175,14 +176,12 @@ describe('SingleUploadPage', () => {
 		expect(submittedBody.get('reported_times')).toBe('3');
 	});
 
-	it('submits stream protection as the HLS encryption field', () => {
+	it('renders the stream protection checkbox unchecked by default', () => {
 		renderUploadedPage();
 
-		const streamProtection = document.querySelector('input[name="is_encrypted"]');
+		const encryptionCheckbox = screen.getByRole('checkbox', { name: /Encrypt this video/ });
 
-		expect(screen.getByText('Stream Protection')).toBeInTheDocument();
-		// HLS encryption is opt-in: the checkbox is present but off by default.
-		expect(streamProtection).not.toBeChecked();
+		expect(encryptionCheckbox).not.toBeChecked();
 	});
 
 	it('shows a password field with visibility toggle for restricted status', async () => {
@@ -219,7 +218,8 @@ describe('SingleUploadPage', () => {
 		renderUploadedPage({ canPublishDirectly: true });
 
 		await user.type(screen.getByLabelText('Synopsis'), 'A short synopsis.');
-		await user.type(screen.getByLabelText('Year Produced'), '2024');
+		await user.click(screen.getByRole('button', { name: 'Choose' }));
+		await user.click(screen.getByRole('button', { name: '2024' }));
 
 		await user.click(screen.getByRole('button', { name: 'Select media language' }));
 		await user.click(screen.getByRole('menuitemradio', { name: 'English' }));
@@ -289,7 +289,8 @@ describe('SingleUploadPage', () => {
 		renderUploadedPage();
 
 		await user.type(screen.getByLabelText('Synopsis'), 'A short synopsis.');
-		await user.type(screen.getByLabelText('Year Produced'), '2024');
+		await user.click(screen.getByRole('button', { name: 'Choose' }));
+		await user.click(screen.getByRole('button', { name: '2024' }));
 
 		await user.click(screen.getByRole('button', { name: 'Select media language' }));
 		await user.click(screen.getByRole('menuitemradio', { name: 'English' }));

--- a/frontend/src/features/add-media/single-upload/components/AdminSettingsForm.jsx
+++ b/frontend/src/features/add-media/single-upload/components/AdminSettingsForm.jsx
@@ -2,11 +2,17 @@ import { CheckboxButton } from '../../../shared/components/CheckboxButton';
 import { TextField } from '../../../shared/components/TextField';
 import { FieldGroup } from './FieldGroup';
 
-export function AdminSettingsForm() {
+export function AdminSettingsForm({ singleUpload }) {
 	return (
 		<FieldGroup title="Admin Settings">
 			<div className="flex flex-col gap-5">
-				<CheckboxButton name="featured">Featured</CheckboxButton>
+				<CheckboxButton
+					name="featured"
+					checked={singleUpload.featured}
+					onChange={(event) => singleUpload.setFeatured(event.target.checked)}
+				>
+					Featured
+				</CheckboxButton>
 
 				<TextField
 					className="w-full max-w-sm"
@@ -14,7 +20,8 @@ export function AdminSettingsForm() {
 					name="reported_times"
 					type="number"
 					label="Reported Times"
-					defaultValue="0"
+					value={singleUpload.reportedTimes}
+					onChange={(event) => singleUpload.setReportedTimes(event.target.value)}
 					min="0"
 					step="1"
 					required

--- a/frontend/src/features/add-media/single-upload/components/AlertOwnershipMedia.jsx
+++ b/frontend/src/features/add-media/single-upload/components/AlertOwnershipMedia.jsx
@@ -1,0 +1,10 @@
+import { TextAlert } from '../../../shared/components';
+
+export function AlertOwnershipMedia({ className }) {
+	return (
+		<TextAlert className={className}>
+			Uploading to Cinemata does not transfer ownership. <br />
+			You keep full rights and control over how your film is shared.
+		</TextAlert>
+	);
+}

--- a/frontend/src/features/add-media/single-upload/components/BasicDetailsForm.jsx
+++ b/frontend/src/features/add-media/single-upload/components/BasicDetailsForm.jsx
@@ -17,11 +17,13 @@ export function BasicDetailsForm({ singleUpload }) {
 				id="title"
 				name="title"
 				label="Title"
+				required
 				placeholder="Write here..."
 				value={singleUpload.title}
 				onChange={(event) => singleUpload.setTitle(event.target.value)}
 				helperText={errors.title}
 				invalid={!!errors.title}
+				validate={[required()]}
 			/>
 
 			<EditorField
@@ -34,7 +36,7 @@ export function BasicDetailsForm({ singleUpload }) {
 				enableCounter
 				maxWordsLength={80}
 				value={singleUpload.summary}
-				onChange={singleUpload.setSummary}
+				onChange={(event) => singleUpload.setSummary(event.target.value)}
 				helperText={errors.summary || 'Maximum 80 Words'}
 				invalid={!!errors.summary}
 				validate={[required(), maxWords(80)]}
@@ -47,7 +49,7 @@ export function BasicDetailsForm({ singleUpload }) {
 				label="More Information and Credits"
 				placeholder="Write here..."
 				value={singleUpload.description}
-				onChange={singleUpload.setDescription}
+				onChange={(event) => singleUpload.setDescription(event.target.value)}
 				helperText={errors.description}
 				invalid={!!errors.description}
 			/>

--- a/frontend/src/features/add-media/single-upload/components/BasicDetailsForm.jsx
+++ b/frontend/src/features/add-media/single-upload/components/BasicDetailsForm.jsx
@@ -1,9 +1,12 @@
 import { EditorField } from '../../../shared/components/EditorField';
 import { TextField } from '../../../shared/components/TextField';
+import { YearChooserField } from '../../../shared/components/YearChooserField';
 import { maxWords, required } from '../../../shared/utils/validators';
 import { FieldGroup } from './FieldGroup';
 
-export function BasicDetailsForm({ errors }) {
+export function BasicDetailsForm({ singleUpload }) {
+	const { errors } = singleUpload;
+
 	return (
 		<FieldGroup
 			title="Basic Details"
@@ -15,6 +18,8 @@ export function BasicDetailsForm({ errors }) {
 				name="title"
 				label="Title"
 				placeholder="Write here..."
+				value={singleUpload.title}
+				onChange={(event) => singleUpload.setTitle(event.target.value)}
 				helperText={errors.title}
 				invalid={!!errors.title}
 			/>
@@ -28,6 +33,8 @@ export function BasicDetailsForm({ errors }) {
 				placeholder="Write here..."
 				enableCounter
 				maxWordsLength={80}
+				value={singleUpload.summary}
+				onChange={singleUpload.setSummary}
 				helperText={errors.summary || 'Maximum 80 Words'}
 				invalid={!!errors.summary}
 				validate={[required(), maxWords(80)]}
@@ -39,21 +46,21 @@ export function BasicDetailsForm({ errors }) {
 				name="description"
 				label="More Information and Credits"
 				placeholder="Write here..."
+				value={singleUpload.description}
+				onChange={singleUpload.setDescription}
 				helperText={errors.description}
 				invalid={!!errors.description}
 			/>
 
-			<TextField
+			<YearChooserField
 				className="w-full"
-				id="year_produced"
 				name="year_produced"
 				label="Year Produced"
-				placeholder="Write here..."
-				helperText={errors.year_produced}
-				invalid={!!errors.year_produced}
 				required
-				validate={[required()]}
-				maxLength={4}
+				value={singleUpload.yearProduced}
+				onChange={singleUpload.setYearProduced}
+				error={errors.year_produced}
+				minYear={2000}
 			/>
 		</FieldGroup>
 	);

--- a/frontend/src/features/add-media/single-upload/components/BasicDetailsForm.jsx
+++ b/frontend/src/features/add-media/single-upload/components/BasicDetailsForm.jsx
@@ -10,7 +10,7 @@ export function BasicDetailsForm({ singleUpload }) {
 	return (
 		<FieldGroup
 			title="Basic Details"
-			description="Add the information viewers and editors need before this media is published."
+			description="What viewers and curators will see when they find your film on Cinemata."
 		>
 			<TextField
 				className="w-full"

--- a/frontend/src/features/add-media/single-upload/components/FinalSettingsForm.jsx
+++ b/frontend/src/features/add-media/single-upload/components/FinalSettingsForm.jsx
@@ -55,14 +55,6 @@ export function FinalSettingsForm({ singleUpload, canUseRestrictedStatus = false
 					Allow Download
 				</CheckboxButton>
 
-				<CheckboxButton
-					name="is_encrypted"
-					checked={singleUpload.isEncrypted}
-					onChange={(event) => singleUpload.setIsEncrypted(event.target.checked)}
-				>
-					Encrypt this video&rsquo;s stream
-				</CheckboxButton>
-
 				<div className="my-4 border-b border-b-border-divider" />
 
 				<fieldset className="m-0 border-0 p-0">
@@ -138,6 +130,29 @@ export function FinalSettingsForm({ singleUpload, canUseRestrictedStatus = false
 				) : null}
 
 				<div className="my-4 border-b border-b-border-divider" />
+
+				<div>
+					<span className="body-body-16-regular mb-2 block text-text-muted">Stream Protection</span>
+					<div className="flex flex-row items-start gap-2">
+						<CheckboxButton
+							name="is_encrypted"
+							className="mt-0.5"
+							aria-label="Encrypt this video&rsquo;s stream"
+							checked={singleUpload.isEncrypted}
+							onChange={(event) => singleUpload.setIsEncrypted(event.target.checked)}
+						/>
+						<div className="flex flex-col gap-2">
+							<Text className="m-0" variant="body-16">
+								Encrypt this video&rsquo;s stream
+							</Text>
+							<Text className="m-0" variant="body-12">
+								Adds an extra layer of protection so only authorized viewers can watch this film. If your
+								video has already been processed, enabling this will trigger a re-encoding, which may take
+								a few minutes.
+							</Text>
+						</div>
+					</div>
+				</div>
 			</div>
 		</FieldGroup>
 	);

--- a/frontend/src/features/add-media/single-upload/components/FinalSettingsForm.jsx
+++ b/frontend/src/features/add-media/single-upload/components/FinalSettingsForm.jsx
@@ -134,9 +134,9 @@ export function FinalSettingsForm({ singleUpload, canUseRestrictedStatus = false
 								Encrypt this video&rsquo;s stream
 							</Text>
 							<Text className="m-0" variant="body-12">
-								Adds an extra layer of protection so only authorized viewers can watch this film. If your
-								video has already been processed, enabling this will trigger a re-encoding, which may take
-								a few minutes.
+								Adds an extra layer of protection so only authorized viewers can watch this film. If
+								your video has already been processed, enabling this will trigger a re-encoding, which
+								may take a few minutes.
 							</Text>
 						</div>
 					</div>

--- a/frontend/src/features/add-media/single-upload/components/FinalSettingsForm.jsx
+++ b/frontend/src/features/add-media/single-upload/components/FinalSettingsForm.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { DateChooserField, RadioButton, Text, formatDMY } from '../../../shared/components';
 import { CheckboxButton } from '../../../shared/components/CheckboxButton';
 import { TextField } from '../../../shared/components/TextField';
+import { diffInDays, todayIso } from '../../utils/helpers';
 import { FieldGroup } from './FieldGroup';
 
 const STATUS_OPTIONS = [
@@ -10,19 +11,6 @@ const STATUS_OPTIONS = [
 	{ value: 'restricted', label: 'Restricted' },
 	{ value: 'unlisted', label: 'Unlisted' },
 ];
-
-function todayIso() {
-	const now = new Date();
-	const month = String(now.getMonth() + 1).padStart(2, '0');
-	const day = String(now.getDate()).padStart(2, '0');
-	return `${now.getFullYear()}-${month}-${day}`;
-}
-
-function diffInDays(startIso, endIso) {
-	const start = new Date(startIso);
-	const end = new Date(endIso);
-	return Math.max(0, Math.ceil((end - start) / 86400000));
-}
 
 export function FinalSettingsForm({ singleUpload, canUseRestrictedStatus = false }) {
 	const [showPassword, setShowPassword] = useState(false);

--- a/frontend/src/features/add-media/single-upload/components/FinalSettingsForm.jsx
+++ b/frontend/src/features/add-media/single-upload/components/FinalSettingsForm.jsx
@@ -39,7 +39,11 @@ export function FinalSettingsForm({ singleUpload, canUseRestrictedStatus = false
 	return (
 		<FieldGroup title="Final Settings">
 			<div className="flex flex-col">
-				<CheckboxButton name="enable_comments" defaultChecked>
+				<CheckboxButton
+					name="enable_comments"
+					checked={singleUpload.enableComments}
+					onChange={(event) => singleUpload.setEnableComments(event.target.checked)}
+				>
 					Enable Comments
 				</CheckboxButton>
 
@@ -49,6 +53,14 @@ export function FinalSettingsForm({ singleUpload, canUseRestrictedStatus = false
 					onChange={(event) => singleUpload.setAllowDownload(event.target.checked)}
 				>
 					Allow Download
+				</CheckboxButton>
+
+				<CheckboxButton
+					name="is_encrypted"
+					checked={singleUpload.isEncrypted}
+					onChange={(event) => singleUpload.setIsEncrypted(event.target.checked)}
+				>
+					Encrypt this video&rsquo;s stream
 				</CheckboxButton>
 
 				<div className="my-4 border-b border-b-border-divider" />
@@ -126,23 +138,6 @@ export function FinalSettingsForm({ singleUpload, canUseRestrictedStatus = false
 				) : null}
 
 				<div className="my-4 border-b border-b-border-divider" />
-
-				<legend className="body-body-16-regular mb-2 text-text-muted">Stream Protection</legend>
-
-				<div className="flex flex-row items-start gap-2">
-					<CheckboxButton name="is_encrypted" className="mt-0.5" aria-label="Encrypt this video’s stream" />
-
-					<div className="flex flex-col gap-2">
-						<Text className="m-0" variant="body-16">
-							Encrypt this video’s stream
-						</Text>
-						<Text className="m-0" variant="body-12">
-							Adds an extra layer of protection so only authorized viewers can watch this film. If your
-							video has already been processed, enabling this will trigger a re-encoding, which may take a
-							few minutes.
-						</Text>
-					</div>
-				</div>
 			</div>
 		</FieldGroup>
 	);

--- a/frontend/src/features/add-media/single-upload/components/MediaDetailsForm.jsx
+++ b/frontend/src/features/add-media/single-upload/components/MediaDetailsForm.jsx
@@ -30,7 +30,6 @@ export function MediaDetailsForm({
 
 	useEffect(() => singleUpload.reset, [singleUpload.reset]);
 
-	// Reflect a chosen thumbnail in the live Quick Preview right away.
 	const selectedThumbnailFile = singleUpload.selectedThumbnailFile;
 	useEffect(() => {
 		if (

--- a/frontend/src/features/add-media/single-upload/components/MediaDetailsForm.jsx
+++ b/frontend/src/features/add-media/single-upload/components/MediaDetailsForm.jsx
@@ -46,20 +46,17 @@ export function MediaDetailsForm({
 		return () => URL.revokeObjectURL(url);
 	}, [selectedThumbnailFile, onPreviewChange]);
 
-	// Feed the live Quick Preview from the (uncontrolled) form on every edit.
-	function reportPreview() {
-		const form = formRef.current;
-		if (!form || !onPreviewChange) {
+	useEffect(() => {
+		if (!onPreviewChange) {
 			return;
 		}
-		const data = new FormData(form);
 		onPreviewChange({
-			title: data.get('title') || '',
-			company: data.get('company') || '',
-			media_country: data.get('media_country') || '',
-			category: data.getAll('category')[0] ?? '',
+			title: singleUpload.title,
+			company: singleUpload.company,
+			media_country: singleUpload.mediaCountry,
+			category: singleUpload.category[0] ?? '',
 		});
-	}
+	}, [onPreviewChange, singleUpload.title, singleUpload.company, singleUpload.mediaCountry, singleUpload.category]);
 
 	function onFileChanged(files) {
 		const [file] = files;
@@ -67,45 +64,37 @@ export function MediaDetailsForm({
 	}
 
 	function validateForm() {
-		const form = formRef.current;
-
-		if (!form) {
-			return {};
-		}
-
-		const data = new FormData(form);
 		const nextErrors = {};
 
-		const summaryError = runValidators([required(), maxWords(80)], data.get('summary'));
+		const summaryError = runValidators([required(), maxWords(80)], singleUpload.summary);
 		if (summaryError) {
 			nextErrors.summary = summaryError;
 		}
 
-		const year = String(data.get('year_produced') ?? '').trim();
+		const year = String(singleUpload.yearProduced).trim();
 		if (!year) {
 			nextErrors.year_produced = 'This field is required';
 		} else if (!/^\d+$/.test(year) || Number(year) < 2000 || Number(year) > CURRENT_YEAR) {
 			nextErrors.year_produced = `Enter a year between 2000 and ${CURRENT_YEAR}`;
 		}
 
-		const website = String(data.get('website') ?? '').trim();
-		if (website && !website.startsWith('https://')) {
+		if (singleUpload.website && !singleUpload.website.startsWith('https://')) {
 			nextErrors.website = 'Website should start with https://';
 		}
 
-		if (!String(data.get('media_language') ?? '').trim()) {
+		if (!singleUpload.mediaLanguage) {
 			nextErrors.media_language = 'Select a media language';
 		}
 
-		if (!String(data.get('media_country') ?? '').trim()) {
+		if (!singleUpload.mediaCountry) {
 			nextErrors.media_country = 'Select a media country';
 		}
 
-		if (data.getAll('category').length === 0) {
+		if (singleUpload.category.length === 0) {
 			nextErrors.category = 'Select at least one category';
 		}
 
-		if (data.get('state') === 'restricted' && !String(data.get('password') ?? '').trim()) {
+		if (singleUpload.mediaStatus === 'restricted' && !singleUpload.password) {
 			nextErrors.password = 'Password has to be set when state is Restricted.';
 		}
 
@@ -201,13 +190,11 @@ export function MediaDetailsForm({
 			encType="multipart/form-data"
 			className="mt-10 flex flex-col gap-8"
 			data-single-upload-form
-			onInput={reportPreview}
-			onChange={reportPreview}
 		>
 			<input type="hidden" name="csrfmiddlewaretoken" value={csrfToken} />
 			{canUseAdminSettings ? null : <input type="hidden" name="reported_times" value="0" />}
 
-			<BasicDetailsForm errors={singleUpload.errors} />
+			<BasicDetailsForm singleUpload={singleUpload} />
 
 			<ThumbnailImageUpload
 				lastSelectedThumbnailFile={singleUpload.lastSelectedThumbnailFile}
@@ -227,7 +214,7 @@ export function MediaDetailsForm({
 
 			<FinalSettingsForm canUseRestrictedStatus={canPublishDirectly} singleUpload={singleUpload} />
 
-			{canUseAdminSettings ? <AdminSettingsForm /> : null}
+			{canUseAdminSettings ? <AdminSettingsForm singleUpload={singleUpload} /> : null}
 
 			<SubmitSection
 				onSaveDraft={handleSaveDraftClick}

--- a/frontend/src/features/add-media/single-upload/components/MediaDetailsForm.jsx
+++ b/frontend/src/features/add-media/single-upload/components/MediaDetailsForm.jsx
@@ -65,6 +65,11 @@ export function MediaDetailsForm({
 	function validateForm() {
 		const nextErrors = {};
 
+		const titleError = runValidators([required()], singleUpload.title);
+		if (titleError) {
+			nextErrors.title = titleError;
+		}
+
 		const summaryError = runValidators([required(), maxWords(80)], singleUpload.summary);
 		if (summaryError) {
 			nextErrors.summary = summaryError;
@@ -91,6 +96,10 @@ export function MediaDetailsForm({
 
 		if (singleUpload.category.length === 0) {
 			nextErrors.category = 'Select at least one category';
+		}
+
+		if (singleUpload.topics.length === 0) {
+			nextErrors.topics = 'Select at least one topic';
 		}
 
 		if (singleUpload.mediaStatus === 'restricted' && !singleUpload.password) {

--- a/frontend/src/features/add-media/single-upload/components/OtherDetailsForm.jsx
+++ b/frontend/src/features/add-media/single-upload/components/OtherDetailsForm.jsx
@@ -204,6 +204,8 @@ export function OtherDetailsForm({
 				name="company"
 				label="Production Company"
 				placeholder="Write here..."
+				value={singleUpload.company}
+				onChange={(event) => singleUpload.setCompany(event.target.value)}
 			/>
 
 			<TextField
@@ -212,6 +214,8 @@ export function OtherDetailsForm({
 				name="website"
 				label="Website"
 				placeholder="Write here..."
+				value={singleUpload.website}
+				onChange={(event) => singleUpload.setWebsite(event.target.value)}
 				helperText={singleUpload.errors.website}
 				invalid={!!singleUpload.errors.website}
 			/>
@@ -223,6 +227,8 @@ export function OtherDetailsForm({
 				label="Media Language"
 				required
 				options={mediaLanguages}
+				value={singleUpload.mediaLanguage}
+				onChange={(value) => singleUpload.setMediaLanguage(value)}
 				invalid={!!singleUpload.errors.media_language}
 				helperText={singleUpload.errors.media_language}
 			/>
@@ -234,6 +240,8 @@ export function OtherDetailsForm({
 				label="Media Country"
 				required
 				options={mediaCountries}
+				value={singleUpload.mediaCountry}
+				onChange={(value) => singleUpload.setMediaCountry(value)}
 				invalid={!!singleUpload.errors.media_country}
 				helperText={singleUpload.errors.media_country}
 			/>
@@ -245,6 +253,8 @@ export function OtherDetailsForm({
 					name="category"
 					required
 					options={categories}
+					value={singleUpload.category}
+					onChange={singleUpload.setCategory}
 					error={singleUpload.errors.category}
 				/>
 
@@ -253,6 +263,8 @@ export function OtherDetailsForm({
 					label="Content Sensitivity"
 					name="content_sensitivity"
 					options={contentSensitivities}
+					value={singleUpload.contentSensitivity}
+					onChange={singleUpload.setContentSensitivity}
 				/>
 			</div>
 
@@ -262,6 +274,8 @@ export function OtherDetailsForm({
 					label="Topics"
 					name="topics"
 					options={topics}
+					value={singleUpload.topics}
+					onChange={singleUpload.setTopics}
 					listClassName="grid grid-cols-1 md:grid-cols-3 max-h-50 overflow-y-scroll [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar]:[-webkit-appearance:none] [&::-webkit-scrollbar-track]:bg-bg-surface-muted [&::-webkit-scrollbar-thumb]:bg-text-dialog-accent [&::-webkit-scrollbar-thumb]:rounded-full"
 				/>
 			</div>
@@ -272,6 +286,8 @@ export function OtherDetailsForm({
 				name="new_tags"
 				label="Tags"
 				placeholder="Write here..."
+				value={singleUpload.tags}
+				onChange={(event) => singleUpload.setTags(event.target.value)}
 				helperText="Use a comma to separate multiple tags (eq. first,second)"
 			/>
 

--- a/frontend/src/features/add-media/single-upload/components/OtherDetailsForm.jsx
+++ b/frontend/src/features/add-media/single-upload/components/OtherDetailsForm.jsx
@@ -275,9 +275,11 @@ export function OtherDetailsForm({
 					className="flex flex-col flex-1"
 					label="Topics"
 					name="topics"
+					required
 					options={topics}
 					value={singleUpload.topics}
 					onChange={singleUpload.setTopics}
+					error={singleUpload.errors.topics}
 					listClassName="grid grid-cols-1 md:grid-cols-3 max-h-50 overflow-y-scroll [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar]:[-webkit-appearance:none] [&::-webkit-scrollbar-track]:bg-bg-surface-muted [&::-webkit-scrollbar-thumb]:bg-text-dialog-accent [&::-webkit-scrollbar-thumb]:rounded-full"
 				/>
 			</div>

--- a/frontend/src/features/add-media/single-upload/components/OtherDetailsForm.jsx
+++ b/frontend/src/features/add-media/single-upload/components/OtherDetailsForm.jsx
@@ -4,6 +4,7 @@ import { CheckboxButton } from '../../../shared/components/CheckboxButton';
 import { CheckboxGroup } from '../../../shared/components/CheckboxGroup';
 import { Text } from '../../../shared/components/Text';
 import { TextField } from '../../../shared/components/TextField';
+import { pattern } from '../../../shared/utils/validators';
 import { FieldGroup } from './FieldGroup';
 
 const DEFAULT_LICENSES = [];
@@ -218,6 +219,7 @@ export function OtherDetailsForm({
 				onChange={(event) => singleUpload.setWebsite(event.target.value)}
 				helperText={singleUpload.errors.website}
 				invalid={!!singleUpload.errors.website}
+				validate={[pattern(/^https:\/\//, 'Website should start with https://')]}
 			/>
 
 			<Dropdown

--- a/frontend/src/features/add-media/single-upload/components/SubmitSection.jsx
+++ b/frontend/src/features/add-media/single-upload/components/SubmitSection.jsx
@@ -1,6 +1,7 @@
-import { ConfirmationDialogContent, Dialog, TextAlert } from '../../../shared/components';
+import { ConfirmationDialogContent, Dialog } from '../../../shared/components';
 import { Button } from '../../../shared/components/Button';
 import { Text } from '../../../shared/components/Text';
+import { AlertOwnershipMedia } from './AlertOwnershipMedia';
 
 export function SubmitSection({
 	onSaveDraft,
@@ -12,10 +13,7 @@ export function SubmitSection({
 }) {
 	return (
 		<>
-			<TextAlert>
-				Uploading to Cinemata does not transfer ownership. <br />
-				You keep full rights and control over how your film is shared.
-			</TextAlert>
+			<AlertOwnershipMedia />
 
 			{singleUpload.submitError || Object.keys(singleUpload.errors).length > 0 ? (
 				<div

--- a/frontend/src/features/add-media/single-upload/useSingleUploadStore.js
+++ b/frontend/src/features/add-media/single-upload/useSingleUploadStore.js
@@ -104,7 +104,11 @@ const useSingleUploadStore = create((set) => ({
 	setEnableComments: (enableComments) => set({ enableComments }),
 	setIsEncrypted: (isEncrypted) => set({ isEncrypted }),
 	setMediaStatus: (mediaStatus) =>
-		set((state) => ({ mediaStatus, password: mediaStatus === 'restricted' ? state.password : '' })),
+		set((state) => ({
+			mediaStatus,
+			password: mediaStatus === 'restricted' ? state.password : '',
+			errors: mediaStatus === 'restricted' ? state.errors : withoutError(state.errors, 'password'),
+		})),
 	setPassword: (password) => set((state) => ({ password, errors: withoutError(state.errors, 'password') })),
 	setExpireEnabled: (expireEnabled) =>
 		set(expireEnabled ? { expireEnabled } : { expireEnabled, startDate: '', endDate: '' }),

--- a/frontend/src/features/add-media/single-upload/useSingleUploadStore.js
+++ b/frontend/src/features/add-media/single-upload/useSingleUploadStore.js
@@ -1,5 +1,16 @@
 import { create } from 'zustand';
 
+// Drops a single field error so live validation can take over after submit.
+function withoutError(errors, field) {
+	if (!(field in errors)) {
+		return errors;
+	}
+
+	const next = { ...errors };
+	delete next[field];
+	return next;
+}
+
 export function createDefaultSingleUploadState() {
 	return {
 		// Basic details
@@ -56,19 +67,22 @@ const useSingleUploadStore = create((set) => ({
 	...createDefaultSingleUploadState(),
 
 	// Basic details
-	setTitle: (title) => set({ title }),
-	setSummary: (summary) => set({ summary }),
+	setTitle: (title) => set((state) => ({ title, errors: withoutError(state.errors, 'title') })),
+	setSummary: (summary) => set((state) => ({ summary, errors: withoutError(state.errors, 'summary') })),
 	setDescription: (description) => set({ description }),
-	setYearProduced: (yearProduced) => set({ yearProduced }),
+	setYearProduced: (yearProduced) =>
+		set((state) => ({ yearProduced, errors: withoutError(state.errors, 'year_produced') })),
 
 	// Other details
 	setCompany: (company) => set({ company }),
-	setWebsite: (website) => set({ website }),
-	setMediaLanguage: (mediaLanguage) => set({ mediaLanguage }),
-	setMediaCountry: (mediaCountry) => set({ mediaCountry }),
-	setCategory: (category) => set({ category }),
+	setWebsite: (website) => set((state) => ({ website, errors: withoutError(state.errors, 'website') })),
+	setMediaLanguage: (mediaLanguage) =>
+		set((state) => ({ mediaLanguage, errors: withoutError(state.errors, 'media_language') })),
+	setMediaCountry: (mediaCountry) =>
+		set((state) => ({ mediaCountry, errors: withoutError(state.errors, 'media_country') })),
+	setCategory: (category) => set((state) => ({ category, errors: withoutError(state.errors, 'category') })),
 	setContentSensitivity: (contentSensitivity) => set({ contentSensitivity }),
-	setTopics: (topics) => set({ topics }),
+	setTopics: (topics) => set((state) => ({ topics, errors: withoutError(state.errors, 'topics') })),
 	setTags: (tags) => set({ tags }),
 
 	// License
@@ -91,7 +105,7 @@ const useSingleUploadStore = create((set) => ({
 	setIsEncrypted: (isEncrypted) => set({ isEncrypted }),
 	setMediaStatus: (mediaStatus) =>
 		set((state) => ({ mediaStatus, password: mediaStatus === 'restricted' ? state.password : '' })),
-	setPassword: (password) => set({ password }),
+	setPassword: (password) => set((state) => ({ password, errors: withoutError(state.errors, 'password') })),
 	setExpireEnabled: (expireEnabled) =>
 		set(expireEnabled ? { expireEnabled } : { expireEnabled, startDate: '', endDate: '' }),
 	setStartDate: (startDate) => set({ startDate }),

--- a/frontend/src/features/add-media/single-upload/useSingleUploadStore.js
+++ b/frontend/src/features/add-media/single-upload/useSingleUploadStore.js
@@ -2,17 +2,23 @@ import { create } from 'zustand';
 
 export function createDefaultSingleUploadState() {
 	return {
-		allowDownload: true,
-		errors: {},
-		submitError: '',
-		shareStage: null,
-		selectedThumbnailFile: null,
-		lastSelectedThumbnailFile: '',
-		mediaStatus: 'public',
-		password: '',
-		expireEnabled: false,
-		startDate: '',
-		endDate: '',
+		// Basic details
+		title: '',
+		summary: '',
+		description: '',
+		yearProduced: '',
+
+		// Other details
+		company: '',
+		website: '',
+		mediaLanguage: '',
+		mediaCountry: '',
+		category: [],
+		contentSensitivity: [],
+		topics: [],
+		tags: '',
+
+		// License
 		licenseDialogOpen: false,
 		noLicense: true,
 		selectedLicenseId: '1',
@@ -20,27 +26,52 @@ export function createDefaultSingleUploadState() {
 			commercial: 'yes',
 			derivatives: 'yes',
 		},
+
+		// Final settings
+		allowDownload: true,
+		enableComments: true,
+		isEncrypted: false,
+		mediaStatus: 'public',
+		password: '',
+		expireEnabled: false,
+		startDate: '',
+		endDate: '',
+
+		// Admin settings
+		featured: false,
+		reportedTimes: '0',
+
+		// Thumbnail
+		selectedThumbnailFile: null,
+		lastSelectedThumbnailFile: '',
+
+		// Form state
+		errors: {},
+		submitError: '',
+		shareStage: null,
 	};
 }
 
 const useSingleUploadStore = create((set) => ({
 	...createDefaultSingleUploadState(),
 
-	setAllowDownload: (allowDownload) => set({ allowDownload }),
-	setErrors: (errors) => set({ errors }),
-	setSubmitError: (submitError) => set({ submitError }),
-	setShareStage: (shareStage) => set({ shareStage }),
-	setSelectedThumbnailFile: (selectedThumbnailFile) =>
-		set({ selectedThumbnailFile, lastSelectedThumbnailFile: selectedThumbnailFile?.name ?? '' }),
-	setMediaStatus: (mediaStatus) =>
-		set((state) => ({ mediaStatus, password: mediaStatus === 'restricted' ? state.password : '' })),
-	setPassword: (password) => set({ password }),
+	// Basic details
+	setTitle: (title) => set({ title }),
+	setSummary: (summary) => set({ summary }),
+	setDescription: (description) => set({ description }),
+	setYearProduced: (yearProduced) => set({ yearProduced }),
 
-	setExpireEnabled: (expireEnabled) =>
-		set(expireEnabled ? { expireEnabled } : { expireEnabled, startDate: '', endDate: '' }),
-	setStartDate: (startDate) => set({ startDate }),
-	setEndDate: (endDate) => set({ endDate }),
+	// Other details
+	setCompany: (company) => set({ company }),
+	setWebsite: (website) => set({ website }),
+	setMediaLanguage: (mediaLanguage) => set({ mediaLanguage }),
+	setMediaCountry: (mediaCountry) => set({ mediaCountry }),
+	setCategory: (category) => set({ category }),
+	setContentSensitivity: (contentSensitivity) => set({ contentSensitivity }),
+	setTopics: (topics) => set({ topics }),
+	setTags: (tags) => set({ tags }),
 
+	// License
 	setLicenseDialogOpen: (licenseDialogOpen) => set({ licenseDialogOpen }),
 	setNoLicense: (noLicense) => set({ noLicense }),
 	setSelectedLicenseField: (field, value) =>
@@ -53,6 +84,31 @@ const useSingleUploadStore = create((set) => ({
 			noLicense: false,
 			licenseDialogOpen: false,
 		}),
+
+	// Final settings
+	setAllowDownload: (allowDownload) => set({ allowDownload }),
+	setEnableComments: (enableComments) => set({ enableComments }),
+	setIsEncrypted: (isEncrypted) => set({ isEncrypted }),
+	setMediaStatus: (mediaStatus) =>
+		set((state) => ({ mediaStatus, password: mediaStatus === 'restricted' ? state.password : '' })),
+	setPassword: (password) => set({ password }),
+	setExpireEnabled: (expireEnabled) =>
+		set(expireEnabled ? { expireEnabled } : { expireEnabled, startDate: '', endDate: '' }),
+	setStartDate: (startDate) => set({ startDate }),
+	setEndDate: (endDate) => set({ endDate }),
+
+	// Admin settings
+	setFeatured: (featured) => set({ featured }),
+	setReportedTimes: (reportedTimes) => set({ reportedTimes }),
+
+	// Thumbnail
+	setSelectedThumbnailFile: (selectedThumbnailFile) =>
+		set({ selectedThumbnailFile, lastSelectedThumbnailFile: selectedThumbnailFile?.name ?? '' }),
+
+	// Form state
+	setErrors: (errors) => set({ errors }),
+	setSubmitError: (submitError) => set({ submitError }),
+	setShareStage: (shareStage) => set({ shareStage }),
 
 	reset: () => set(createDefaultSingleUploadState()),
 }));

--- a/frontend/src/features/add-media/utils/helpers.js
+++ b/frontend/src/features/add-media/utils/helpers.js
@@ -1,5 +1,18 @@
 export const EMPTY_PREVIEW = { title: '', company: '', media_country: '', category: '' };
 
+export function todayIso() {
+	const now = new Date();
+	const month = String(now.getMonth() + 1).padStart(2, '0');
+	const day = String(now.getDate()).padStart(2, '0');
+	return `${now.getFullYear()}-${month}-${day}`;
+}
+
+export function diffInDays(startIso, endIso) {
+	const start = new Date(startIso);
+	const end = new Date(endIso);
+	return Math.max(0, Math.ceil((end - start) / 86400000));
+}
+
 export function findLabel(options = [], value) {
 	const option = options.find((item) => String(item.value ?? item.code) === String(value));
 	return option?.label || option?.title || '';

--- a/frontend/src/features/add-media/utils/helpers.js
+++ b/frontend/src/features/add-media/utils/helpers.js
@@ -1,3 +1,18 @@
+export const EMPTY_PREVIEW = { title: '', company: '', media_country: '', category: '' };
+
+export function findLabel(options = [], value) {
+	const option = options.find((item) => String(item.value ?? item.code) === String(value));
+	return option?.label || option?.title || '';
+}
+
+export function toCodeOptions(items = []) {
+	return items.map((item) => ({ value: item.code, label: item.title }));
+}
+
+export function toIdOptions(items = []) {
+	return items.map((item) => ({ value: item.id, label: item.title }));
+}
+
 export function getAddMediaConfig() {
 	return (window.MediaCMS && window.MediaCMS.addMediaPage) || {};
 }

--- a/frontend/src/features/shared/components/EditorField/EditorField.jsx
+++ b/frontend/src/features/shared/components/EditorField/EditorField.jsx
@@ -293,11 +293,9 @@ export function EditorField({
 						if (value === undefined) {
 							setHasValue(hasTextValue(nextValue));
 						}
-						// Re-run validators live only once an error is already showing,
-						// so the message clears/updates as the user fixes the field.
-						if (validationError) {
-							setValidationError(runValidators(validate, nextValue));
-						}
+						// Validate live on every keystroke, but only after the user
+						// has started typing in this field.
+						setValidationError(runValidators(validate, nextValue));
 						onChange?.(event);
 					}}
 					className={cn(

--- a/frontend/src/features/shared/components/TextField/TextField.jsx
+++ b/frontend/src/features/shared/components/TextField/TextField.jsx
@@ -188,11 +188,9 @@ export function TextField({
 							if (value === undefined) {
 								setHasValue(hasTextValue(event.target.value));
 							}
-							// Re-run validators live only once an error is already showing,
-							// so the message clears/updates as the user fixes the field.
-							if (validationError) {
-								setValidationError(runValidators(validate, event.target.value));
-							}
+							// Validate live on every keystroke, but only after the user
+							// has started typing in this field.
+							setValidationError(runValidators(validate, event.target.value));
 							onChange?.(event);
 						}}
 						className={cn(

--- a/frontend/src/features/shared/components/UploadMediaItem/UploadMediaItem.jsx
+++ b/frontend/src/features/shared/components/UploadMediaItem/UploadMediaItem.jsx
@@ -20,6 +20,7 @@ const STATUS_CONFIG = {
 	processing: {
 		statusText: 'Processing...',
 		statusClassName: 'text-text-muted',
+		progressClassName: 'bg-cinemata-coral-reef-400p',
 		showProgress: false,
 		actions: [{ key: 'cancel', label: 'Cancel', iconName: 'cancel', type: 'danger' }],
 	},

--- a/frontend/src/features/shared/components/upload-media/hooks/useTaxonomies.js
+++ b/frontend/src/features/shared/components/upload-media/hooks/useTaxonomies.js
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { apiFetch } from '../../../utils/api';
 
-const DEFAULT_OPTIONS_ENDPOINT = '/api/v1/my_uploads/bulk_options';
+const DEFAULT_OPTIONS_ENDPOINT = '/api/v1/my_uploads/upload_options';
 
 const EMPTY_OPTIONS = {
 	categories: [],

--- a/frontend/src/static/css/tailwind.css
+++ b/frontend/src/static/css/tailwind.css
@@ -1251,6 +1251,7 @@ body.dark_theme {
 	--color-text-panel-heading: var(--text-panel-heading);
 	--color-text-control-checked: var(--text-control-checked);
 	--color-text-tab-trigger: var(--text-tab-trigger);
+	--color-text-title-required: var(--cinemata-red-400);
 
 	/* Borders */
 	--color-border-default: var(--border-default);

--- a/frontend/src/static/js/pages/AddMediaPage/index.js
+++ b/frontend/src/static/js/pages/AddMediaPage/index.js
@@ -1,0 +1,494 @@
+import React from 'react';
+import { UploadMediaItem } from '../../../../features/shared/components/UploadMediaItem';
+import { Button } from '../../../../features/shared/components/Button';
+import { Dialog } from '../../../../features/shared/components/Dialog';
+import { ConfirmationDialogContent } from '../../../../features/shared/components/ConfirmationDialog';
+import UserContext from '../../contexts/UserContext';
+import { Page } from '../_Page';
+
+import '../../static_pages/styles/AddMediaPage.scss';
+import { Text } from '../../../../features/shared/components';
+
+function getAddMediaConfig() {
+	return (window.MediaCMS && window.MediaCMS.addMediaPage) || {};
+}
+
+function getCSRFToken() {
+	let cookieVal = null;
+
+	if (document.cookie && '' !== document.cookie) {
+		const cookies = document.cookie.split(';');
+		let i = 0;
+
+		while (i < cookies.length) {
+			const cookie = cookies[i].trim();
+
+			if ('csrftoken=' === cookie.substring(0, 10)) {
+				cookieVal = decodeURIComponent(cookie.substring(10));
+				break;
+			}
+
+			i += 1;
+		}
+	}
+
+	return cookieVal;
+}
+
+function getUploadStatus(status) {
+	const qqStatus = window.qq && window.qq.status;
+
+	if (!qqStatus) {
+		return 'uploading';
+	}
+
+	switch (status) {
+		case qqStatus.UPLOAD_SUCCESSFUL:
+			return 'complete';
+		case qqStatus.UPLOAD_FAILED:
+		case qqStatus.REJECTED:
+			return 'failed';
+		case qqStatus.PAUSED:
+			return 'paused';
+		default:
+			return 'uploading';
+	}
+}
+
+function getStatusLabel(status) {
+	switch (status) {
+		case 'complete':
+			return 'Complete';
+		case 'failed':
+			return 'Upload failed';
+		case 'paused':
+			return 'Paused';
+		default:
+			return 'Uploading';
+	}
+}
+
+function updateUploadItemStatus(id, status, statusText) {
+	const listEl = document.querySelector('.qq-file-id-' + id);
+	const itemEl = listEl ? listEl.querySelector('.upload-media-item') : null;
+
+	if (!itemEl) {
+		return;
+	}
+
+	itemEl.setAttribute('data-upload-status', status);
+
+	if (statusText) {
+		const statusEl = itemEl.querySelector('.qq-upload-status-text-selector');
+
+		if (statusEl) {
+			statusEl.textContent = statusText;
+		}
+	}
+}
+
+function AddMediaUploadTemplate() {
+	return (
+		<div id="qq-template" style={{ display: 'none' }}>
+			<div className="media-uploader-bottom-wrap qq-uploader-selector">
+				<div className="media-uploader-bottom-left-wrap">
+					<div className="media-drag-drop-wrap">
+						<div className="media-drag-drop-inner" qq-drop-area-text="Drop files here">
+							<div className="media-drag-drop-content">
+								<div className="media-drag-drop-content-inner">
+									<span>
+										<i className="material-icons">cloud_upload</i>
+									</span>
+									<span>Drag and drop files</span>
+									<span>or</span>
+									<span className="browse-files-btn-wrap">
+										<span className="qq-upload-button-selector">Browse your files</span>
+									</span>
+									<div className="qq-upload-drop-area-selector media-dropzone" qq-hide-dropzone="">
+										<span className="qq-upload-drop-area-text-selector"></span>
+									</div>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+
+				<div className="media-uploader-bottom-right-wrap">
+					<ul className="media-upload-items-list qq-upload-list-selector" style={{ minHeight: 320 }}>
+						<li>
+							<UploadMediaItem
+								className="media-upload-item-main p-4"
+								includeFineUploaderSelectors={true}
+							/>
+						</li>
+					</ul>
+
+					<dialog style={{ backgroundColor: 'white' }} className="qq-alert-dialog-selector">
+						<div className="qq-dialog-message-selector"></div>
+						<div className="qq-dialog-buttons">
+							<button type="button" className="qq-cancel-button-selector">
+								CLOSE
+							</button>
+						</div>
+					</dialog>
+
+					<dialog className="qq-confirm-dialog-selector">
+						<div className="qq-dialog-message-selector"></div>
+						<div className="qq-dialog-buttons">
+							<button type="button" className="qq-cancel-button-selector">
+								NO
+							</button>
+							<button type="button" className="qq-ok-button-selector">
+								YES
+							</button>
+						</div>
+					</dialog>
+
+					<dialog className="qq-prompt-dialog-selector">
+						<div className="qq-dialog-message-selector"></div>
+						<input type="text" />
+						<div className="qq-dialog-buttons">
+							<button type="button" className="qq-cancel-button-selector">
+								CANCEL
+							</button>
+							<button type="button" className="qq-ok-button-selector">
+								OK
+							</button>
+						</div>
+					</dialog>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function LoginForm({ config }) {
+	const redirectUrl = config.uploadMediaUrl || '/upload';
+	const signupUrl = (config.signupUrl || '/accounts/signup/') + '?next=' + encodeURIComponent(redirectUrl);
+	const loginUrl = config.loginUrl || '/accounts/login/';
+	const resetPasswordUrl = config.resetPasswordUrl || '/accounts/password/reset/';
+
+	return (
+		<div className="user-action-form-wrap">
+			<div className="user-action-form-inner">
+				<h1>Sign In</h1>
+				<p>Please log in or register before uploading a video.</p>
+				<p>
+					If you have not created an account yet, then please <a href={signupUrl}>sign up</a> first.
+				</p>
+
+				<form className="login" method="POST" action={loginUrl}>
+					<input type="hidden" name="csrfmiddlewaretoken" value={config.csrfToken || ''} />
+					<div dangerouslySetInnerHTML={{ __html: config.loginFormHtml || '' }}></div>
+					<input type="hidden" name="next" value={redirectUrl} />
+
+					<a className="button secondaryAction" href={resetPasswordUrl}>
+						Forgot Password?
+					</a>
+
+					<button className="primaryAction" type="submit">
+						Sign In
+					</button>
+				</form>
+			</div>
+		</div>
+	);
+}
+
+function CannotUploadMessage({ config }) {
+	return (
+		<React.Fragment>
+			{config.canUploadMessage || null}
+			<br />
+			<a href="/contact">Contact</a> the admin owners for more information.
+		</React.Fragment>
+	);
+}
+
+export class AddMediaPage extends Page {
+	static contextType = UserContext;
+
+	constructor(props) {
+		super(props, 'add-media');
+		this.config = getAddMediaConfig();
+		this.uploaderRef = React.createRef();
+		this.uploader = null;
+		this.pendingReplaceId = null;
+		this.state = {
+			confirmDeleteOpen: false,
+			pendingDeleteId: null,
+			pendingDeleteName: '',
+		};
+	}
+
+	componentDidMount() {
+		if (this.context.is.anonymous || !this.config.canAdd) {
+			return;
+		}
+
+		if (!window.qq || !window.qq.FineUploader || !this.uploaderRef.current) {
+			console.warn('FineUploader is not available for the add media page.');
+			return;
+		}
+
+		this.uploaderRef.current.addEventListener('click', this.handleUploaderClick);
+
+		this.uploader = new window.qq.FineUploader({
+			debug: false,
+			element: this.uploaderRef.current,
+			classes: {
+				hide: 'hidden',
+			},
+			request: {
+				endpoint: this.config.uploadEndpoint,
+				customHeaders: {
+					'X-CSRFToken': getCSRFToken(),
+				},
+			},
+			retry: {
+				enableAuto: true,
+				maxAutoAttempts: 2,
+			},
+			messages: {
+				tooManyItemsError:
+					"You've attempted to upload {netItems} files, which exceeds your limit. Non-trusted users can only upload one video at a time.",
+			},
+			text: {
+				formatProgress: '{percent}% ({total_size})',
+				failUpload: 'Upload failed',
+				waitingForResponse: 'Processing...',
+				paused: 'Paused',
+			},
+			validation: {
+				itemLimit: this.config.uploadMaxFilesNumber,
+				sizeLimit: this.config.uploadMaxSize,
+				allowedExtensions: this.config.allowedExtensions || [],
+				acceptFiles: 'video/*',
+			},
+			chunking: {
+				enabled: true,
+				concurrent: {
+					enabled: true,
+				},
+				success: {
+					endpoint: this.config.uploadCompleteEndpoint,
+				},
+			},
+			callbacks: {
+				onStatusChange: function (id, _oldStatus, newStatus) {
+					const status = getUploadStatus(newStatus);
+					updateUploadItemStatus(id, status, getStatusLabel(status));
+				},
+				onSubmitted: (id) => {
+					// A reupload only replaces the original once the new file is in.
+					if (this.pendingReplaceId != null && this.pendingReplaceId !== id) {
+						this.removeUploadItem(this.pendingReplaceId);
+						this.pendingReplaceId = null;
+					}
+				},
+				onError: function (id, name, errorReason) {
+					updateUploadItemStatus(id, 'failed', 'Upload failed');
+					console.warn(window.qq.format('Error on file number {} - {}.  Reason: {}', id, name, errorReason));
+				},
+				onComplete: (id, _name, response) => {
+					if (!response.success) {
+						updateUploadItemStatus(id, 'failed', 'Upload failed');
+						return;
+					}
+
+					updateUploadItemStatus(id, 'complete', 'Complete');
+
+					if (this.config.uploadMaxFilesNumber === 1) {
+						// setTimeout(function(){ window.location.href = response.media_url; }, 500);
+						window.location.href = response.media_url.replace('/view?', '/edit?');
+						return;
+					}
+				},
+			},
+		});
+	}
+
+	componentWillUnmount() {
+		if (this.uploaderRef.current) {
+			this.uploaderRef.current.removeEventListener('click', this.handleUploaderClick);
+		}
+	}
+
+	getFileIdFromElement(element) {
+		const item = element.closest('[class*="qq-file-id-"]');
+
+		if (!item) {
+			return null;
+		}
+
+		const match = item.className.match(/qq-file-id-(\d+)/);
+
+		return match ? Number(match[1]) : null;
+	}
+
+	openFilePicker() {
+		const root = this.uploaderRef.current;
+
+		if (!root) {
+			return;
+		}
+
+		const fileInput = root.querySelector('.qq-upload-button-selector input[type="file"]');
+
+		if (fileInput) {
+			fileInput.click();
+			return;
+		}
+
+		const browseButton = root.querySelector('.qq-upload-button-selector');
+
+		if (browseButton) {
+			browseButton.click();
+		}
+	}
+
+	removeUploadItem(id) {
+		if (id == null) {
+			return;
+		}
+
+		try {
+			this.uploader.cancel(id);
+		} catch (error) {
+			console.warn('Unable to cancel upload ' + id, error);
+		}
+
+		const itemEl = document.querySelector('.qq-file-id-' + id);
+
+		if (itemEl) {
+			itemEl.remove();
+		}
+
+		// When the list empties, reset FineUploader so the dropzone, browse button,
+		// and item-limit counters return to their initial state.
+		const listEl = this.uploaderRef.current && this.uploaderRef.current.querySelector('.qq-upload-list-selector');
+
+		if (listEl && 0 === listEl.children.length) {
+			try {
+				this.uploader.reset();
+			} catch (error) {
+				console.warn('Unable to reset uploader', error);
+			}
+		}
+	}
+
+	handleUploaderClick = (event) => {
+		const reuploadButton = event.target.closest('.reupload-media-upload-item');
+
+		if (reuploadButton) {
+			event.preventDefault();
+			// Defer removing the existing item until the user actually picks a new
+			// file (onSubmitted). Canceling the picker keeps the original in place.
+			this.pendingReplaceId = this.getFileIdFromElement(reuploadButton);
+			this.openFilePicker();
+			return;
+		}
+
+		const deleteButton = event.target.closest('.qq-upload-delete-selector');
+
+		if (deleteButton) {
+			event.preventDefault();
+			event.stopPropagation();
+
+			const id = this.getFileIdFromElement(deleteButton);
+
+			if (id == null) {
+				return;
+			}
+
+			const nameEl = document.querySelector('.qq-file-id-' + id + ' .qq-upload-file-selector');
+
+			this.setState({
+				confirmDeleteOpen: true,
+				pendingDeleteId: id,
+				pendingDeleteName: nameEl ? nameEl.textContent.trim() : '',
+			});
+		}
+	};
+
+	closeDeleteDialog = () => {
+		this.setState({ confirmDeleteOpen: false, pendingDeleteId: null, pendingDeleteName: '' });
+	};
+
+	confirmDelete = () => {
+		const id = this.state.pendingDeleteId;
+		this.closeDeleteDialog();
+		this.removeUploadItem(id);
+	};
+
+	pageContent() {
+		if (this.context.is.anonymous) {
+			return <LoginForm config={this.config} />;
+		}
+
+		if (!this.config.canAdd) {
+			return <CannotUploadMessage config={this.config} />;
+		}
+
+		const { confirmDeleteOpen, pendingDeleteName } = this.state;
+
+		return (
+			<div className="media-uploader-wrap p-6">
+				<div className="media-uploader-top-wrap">
+					<div className="media-uploader-top-left-wrap">
+						<h1>Upload media files</h1>
+					</div>
+					<div className="media-uploader-top-right-wrap"> </div>
+				</div>
+
+				<AddMediaUploadTemplate />
+
+				<div className="media-uploader" ref={this.uploaderRef}></div>
+
+				<Text variant="body-16" color="description" className="m-0 mt-4 text-center w-full">
+					Please check our&nbsp;
+					<a
+						href="/editorial-policy"
+						className="text-text-accent no-underline underline-offset-2 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring-focus"
+					>
+						Editorial Policy
+					</a>
+					&nbsp;before uploading media.
+					<br />
+					Any media that does not comply with the policy will be deleted from Cinemata.org.
+					<br />
+					Trusted Users may upload up to 10 media files.{' '}
+					<a
+						href="/contact"
+						className="text-text-accent no-underline underline-offset-2 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring-focus"
+					>
+						Contact Us
+					</a>{' '}
+					to apply for Trusted User status
+				</Text>
+
+				<Dialog open={confirmDeleteOpen} onOpenChange={(open) => !open && this.closeDeleteDialog()}>
+					<ConfirmationDialogContent
+						title="Delete this media?"
+						subtitle={
+							pendingDeleteName
+								? `“${pendingDeleteName}” will be removed from the upload list.`
+								: 'This file will be removed from the upload list.'
+						}
+						aria-label="Delete media confirmation"
+						actions={
+							<>
+								<Button variant="secondary-outline" onClick={this.closeDeleteDialog}>
+									Cancel
+								</Button>
+								<Button variant="primary" onClick={this.confirmDelete}>
+									Delete
+								</Button>
+							</>
+						}
+					/>
+				</Dialog>
+			</div>
+		);
+	}
+}


### PR DESCRIPTION
## Description

Single upload improvements addressing feedback from #771. Tightens form
validation (Title, Topics now required), updates copy, restores the legacy
edit flow, and fixes the Topics/Categories scroll handle on light mode.

- Updated Basic Details helper text to "What viewers and curators will see
  when they find your film on Cinemata."
- Year Produced uses the dropdown/year-picker (`YearChooserField`) matching
  the old UI, with edge cases (range, custom values) handled.
- **Topics** is now required â added the `required` indicator + inline error,
  wired into `validateForm()` and the shared metadata schema.
- **Title** now surfaces a required error on Share Media (previously silent,
  unlike Synopsis).
- Fixed the scroll handle for Topics/Categories not showing in Light Mode on
  Chrome / iPad OS.
- Restored the legacy Edit Media UI so clicking Edit Media no longer dead-ends.
- Extracted `todayIso` / `diffInDays` date helpers into `add-media/utils/helpers.js`.

## Related Issue

Fixes #771

## Motivation and Context

The new single-upload flow shipped with several UX gaps: missing required-field
validation (Title and Topics could be submitted empty), outdated helper copy,
a free-text year field instead of the dropdown, a scroll handle invisible in
light mode on iPad Chrome, and an Edit Media link that routed users back to the
old UI. This PR closes those gaps so the modern upload experience matches the
intended design and validates before a server round-trip.

## How Has This Been Tested?

- `make lint` â all pre-commit hooks pass (ruff, ruff format, django-upgrade,
  prettier).
- `npm run test:run` (frontend) â 479/479 tests pass across 83 files.
- Updated `SingleUploadPage.test.jsx` to fill the now-required Title field and
  cover the Topics-required path.
- Manual: verified Share Media surfaces inline errors for empty Title and
  Topics, year dropdown selection, and the light-mode scroll handle on Chrome.

## Screenshots (if appropriate):

<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/ff9efe81-832d-49d3-a80b-4ef15ad141bf" />
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/64b28324-524d-416b-81b7-1477822d67e7" />
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/c29a0dbd-d2b4-467f-a5c4-cda4396e84b0" />
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/fa83f963-99c1-4607-bd8b-00fe5c7d094b" />
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/1f36cbfb-6363-4d82-b9ec-98fb29b07475" />
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/e622036c-b83e-40a2-8b42-75c9733985f6" />
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/af2dd0ca-2102-4a19-9d5e-e4f818a7b40b" />

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):

- [x] I have not imported `flux` in a new component
- [x] If adding a new feature, I used Modern Track patterns
- [x] New features do not create new SCSS files (use Tailwind instead)

Note: confirm screenshots before posting. Restored legacy AddMediaPage/index.js is a .js file â verify it predates Modern Track so the SCSS/flux checkboxes hold.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rolled out a refreshed add-media experience with revamp/legacy selection, improved single-upload forms, year picker, and live “Quick Preview” updates.
  * Added an ownership/rights notice during upload and enhanced “upload options” support.
* **Bug Fixes**
  * Improved validation responsiveness so errors update immediately as users type.
  * Updated upload-options routing to use the new endpoint path and aligned the UI accordingly.
* **Tests**
  * Updated authorization and single-upload flow tests to match the new endpoint behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->