### PR TITLE
fix: upload Quick Preview, validation and mobile feedback (single + b…

### DIFF
--- a/frontend/src/features/add-media/AddMediaPage.jsx
+++ b/frontend/src/features/add-media/AddMediaPage.jsx
@@ -84,7 +84,8 @@ export class AddMediaPage extends Page {
 		// the viewport — so it stays in sync with the grid even when the app sidebar
 		// changes the available width. Guarded for non-browser/test environments.
 		if (typeof ResizeObserver !== 'undefined' && this.pageRef.current) {
-			const FOUR_XL_PX = 56 * 16; // @4xl/page container width (56rem)
+			// Keep in sync with Tailwind's @4xl/page container breakpoint.
+			const FOUR_XL_PX = 56 * 16;
 			this.pageObserver = new ResizeObserver((entries) => {
 				const width = entries[0]?.contentRect?.width ?? 0;
 				const narrow = width > 0 && width < FOUR_XL_PX;

--- a/frontend/src/features/add-media/AddMediaPage.jsx
+++ b/frontend/src/features/add-media/AddMediaPage.jsx
@@ -54,6 +54,9 @@ export class AddMediaPage extends Page {
 			singlePreview: { ...EMPTY_SINGLE_PREVIEW },
 			bulkConfig: null,
 			bulkStep: 1,
+			// Bulk upload needs the desktop layout; below this the Single/Bulk switcher
+			// is hidden and only single upload is shown (mobile + tablet).
+			isNarrow: false,
 		};
 	}
 
@@ -68,9 +71,19 @@ export class AddMediaPage extends Page {
 				maxFiles: this.config.maxBulkFiles,
 				uploadEndpoint: this.config.uploadEndpoint || undefined,
 				chunksDoneParam: this.config.chunksDoneParam || undefined,
+				userName: this.config.userName || '',
 				onMoveSingle: this.moveBulkMediaToSingle,
 			},
 		});
+
+		// Hide the Single/Bulk switcher on mobile + tablet (bulk needs the desktop
+		// layout); track the breakpoint so the tab is forced to single below it.
+		if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+			this.narrowQuery = window.matchMedia('(max-width: 1023px)');
+			this.handleNarrowChange = (event) => this.setState({ isNarrow: event.matches });
+			this.setState({ isNarrow: this.narrowQuery.matches });
+			this.narrowQuery.addEventListener('change', this.handleNarrowChange);
+		}
 
 		this.lastBulkStep = 1;
 		this.unsubscribeBulkStep = useBulkUploadStore.subscribe((state) => {
@@ -170,6 +183,7 @@ export class AddMediaPage extends Page {
 			this.uploaderRef.current.removeEventListener('click', this.handleUploaderClick);
 		}
 		this.unsubscribeBulkStep?.();
+		this.narrowQuery?.removeEventListener('change', this.handleNarrowChange);
 	}
 
 	getFileIdFromElement(element) {
@@ -516,6 +530,7 @@ export class AddMediaPage extends Page {
 			confirmTabSwitchOpen,
 			externalMedia,
 			hasSelectedMedia,
+			isNarrow,
 			pendingDeleteName,
 			pendingTab,
 			selectedTab,
@@ -525,9 +540,12 @@ export class AddMediaPage extends Page {
 
 		const pendingTabLabel = pendingTab === 'bulk-upload' ? 'Bulk Upload' : 'Single Film Upload';
 
-		const isBulk = selectedTab === 'bulk-upload';
+		// Bulk needs the desktop layout, so on mobile/tablet the switcher is hidden
+		// and the tab is forced to single.
+		const effectiveTab = isNarrow ? 'single-film-upload' : selectedTab;
+		const isBulk = effectiveTab === 'bulk-upload';
 		const bulkConfig = this.state.bulkConfig;
-		const tabsHidden = isBulk && bulkStep > 1;
+		const tabsHidden = isNarrow || (isBulk && bulkStep > 1);
 
 		const headerTitle = !isBulk
 			? 'Upload Media to Cinemata'
@@ -588,7 +606,7 @@ export class AddMediaPage extends Page {
 								hideTabList={tabsHidden}
 								aria-label="Upload media type"
 								defaultSelectedTab="single-film-upload"
-								selectedTab={selectedTab}
+								selectedTab={effectiveTab}
 								onSelectedTabChange={this.handleTabChange}
 								className="add-media-tabs"
 								keepMounted
@@ -635,10 +653,11 @@ export class AddMediaPage extends Page {
 							{!isBulk && uploadedMedia ? (
 								<QuickPreview
 									title={singlePreview.title}
-									subtitle={singlePreview.company}
+									subtitle={this.config.userName}
 									country={singlePreview.country}
 									category={singlePreview.category}
 									thumbnailUrl={singlePreview.thumbnailUrl}
+									views={0}
 									className="min-w-0"
 								/>
 							) : null}

--- a/frontend/src/features/add-media/AddMediaPage.jsx
+++ b/frontend/src/features/add-media/AddMediaPage.jsx
@@ -37,6 +37,9 @@ export class AddMediaPage extends Page {
 		super(props, 'add-media');
 		this.config = getAddMediaConfig();
 		this.uploaderRef = React.createRef();
+		// The @container/page element; its width drives the bulk layout, so we watch
+		// it to gate bulk availability on the same threshold as the grid (@4xl/page).
+		this.pageRef = React.createRef();
 		this.uploader = null;
 		this.pendingReplaceId = null;
 		this.completedTokens = {};
@@ -76,13 +79,18 @@ export class AddMediaPage extends Page {
 			},
 		});
 
-		// Hide the Single/Bulk switcher on mobile + tablet (bulk needs the desktop
-		// layout); track the breakpoint so the tab is forced to single below it.
-		if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
-			this.narrowQuery = window.matchMedia('(max-width: 1023px)');
-			this.handleNarrowChange = (event) => this.setState({ isNarrow: event.matches });
-			this.setState({ isNarrow: this.narrowQuery.matches });
-			this.narrowQuery.addEventListener('change', this.handleNarrowChange);
+		// Bulk needs the desktop grid, so gate it on the same threshold the layout
+		// uses (@4xl/page = 56rem container). Watch the @container/page width — not
+		// the viewport — so it stays in sync with the grid even when the app sidebar
+		// changes the available width. Guarded for non-browser/test environments.
+		if (typeof ResizeObserver !== 'undefined' && this.pageRef.current) {
+			const FOUR_XL_PX = 56 * 16; // @4xl/page container width (56rem)
+			this.pageObserver = new ResizeObserver((entries) => {
+				const width = entries[0]?.contentRect?.width ?? 0;
+				const narrow = width > 0 && width < FOUR_XL_PX;
+				this.setState((state) => (state.isNarrow === narrow ? null : { isNarrow: narrow }));
+			});
+			this.pageObserver.observe(this.pageRef.current);
 		}
 
 		this.lastBulkStep = 1;
@@ -183,7 +191,7 @@ export class AddMediaPage extends Page {
 			this.uploaderRef.current.removeEventListener('click', this.handleUploaderClick);
 		}
 		this.unsubscribeBulkStep?.();
-		this.narrowQuery?.removeEventListener('change', this.handleNarrowChange);
+		this.pageObserver?.disconnect();
 	}
 
 	getFileIdFromElement(element) {
@@ -557,7 +565,10 @@ export class AddMediaPage extends Page {
 
 		return (
 			<div className="media-uploader-wrap add-media-page-wrap">
-				<main className="add-media-feature @container/page mx-4 py-8 text-text-primary sm:mx-6 lg:mx-10">
+				<main
+					ref={this.pageRef}
+					className="add-media-feature @container/page mx-4 py-8 text-text-primary sm:mx-6 lg:mx-10"
+				>
 					<div className="grid grid-cols-1 gap-8 @4xl/page:grid-cols-[220px_minmax(0,1fr)_340px] @4xl/page:items-start">
 						<header className="flex items-start justify-between gap-4 @4xl/page:col-start-2 @4xl/page:row-start-1">
 							<div className="w-full">
@@ -653,7 +664,7 @@ export class AddMediaPage extends Page {
 							{!isBulk && uploadedMedia ? (
 								<QuickPreview
 									title={singlePreview.title}
-									subtitle={this.config.userName}
+									subtitle={this.config.userName || ''}
 									country={singlePreview.country}
 									category={singlePreview.category}
 									thumbnailUrl={singlePreview.thumbnailUrl}

--- a/frontend/src/features/add-media/bulk-upload/bulkUploadConfig.js
+++ b/frontend/src/features/add-media/bulk-upload/bulkUploadConfig.js
@@ -15,6 +15,8 @@ export const BULK_UPLOAD_CONFIG_DEFAULTS = {
 	maxSizeBytes: 0,
 	allowedExtensions: [],
 	isTrustedUser: false,
+	// Logged-in user's full name, shown as the uploader in each file's Quick Preview.
+	userName: '',
 	// Admin-only "Admin Settings" section (Featured / Reported Times). Provided by
 	// the host add-media page; defaults off otherwise.
 	canUseAdminSettings: false,

--- a/frontend/src/features/add-media/bulk-upload/components/FileQuickPreview.jsx
+++ b/frontend/src/features/add-media/bulk-upload/components/FileQuickPreview.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { QuickPreview } from '../../../upload-quick-preview';
+import { useBulkUploadConfig } from '../bulkUploadConfig';
 
 // Per-file Quick Preview shared by the Enter-Details cards (step 2) and the
 // Preview & Submit summary (step 3), so both show the same thing: a chosen
@@ -7,6 +8,7 @@ import { QuickPreview } from '../../../upload-quick-preview';
 // media's auto thumbnail.
 export function FileQuickPreview({ file, options = {}, className = '' }) {
 	const meta = file.metadata || {};
+	const { userName } = useBulkUploadConfig();
 
 	const [posterPreviewUrl, setPosterPreviewUrl] = useState('');
 	useEffect(() => {
@@ -28,9 +30,10 @@ export function FileQuickPreview({ file, options = {}, className = '' }) {
 		<QuickPreview
 			title={meta.title}
 			thumbnailUrl={posterPreviewUrl || file.thumbnailUrl || ''}
-			subtitle={meta.company}
+			subtitle={userName || ''}
 			country={countryLabel}
 			category={previewCategory}
+			views={0}
 			className={className}
 		/>
 	);

--- a/frontend/src/features/add-media/bulk-upload/components/step2/FileCard.jsx
+++ b/frontend/src/features/add-media/bulk-upload/components/step2/FileCard.jsx
@@ -26,6 +26,7 @@ import useBulkUploadStore from '../../useBulkUploadStore';
 import { useBulkUploadConfig } from '../../bulkUploadConfig';
 import { useBulkUploadActions } from '../../BulkUploadActionsContext';
 import { formatFileSize } from '../../utils/formatSize';
+import { required } from '../../../../shared/utils/validators';
 
 function Divider() {
 	return <div className="my-4 border-b border-b-border-divider" />;
@@ -116,6 +117,7 @@ export function FileCard({ file, subStep, options, errors = {}, onClearErrors })
 							<TitleField
 								value={meta.title}
 								onChange={(value) => patch({ title: value })}
+								validate={[required()]}
 								error={errors.title}
 							/>
 							<SynopsisField

--- a/frontend/src/features/shared/components/ConfirmationDialog/ConfirmationDialogContent.jsx
+++ b/frontend/src/features/shared/components/ConfirmationDialog/ConfirmationDialogContent.jsx
@@ -27,7 +27,9 @@ export function ConfirmationDialogContent({
 						width={320}
 						height={320}
 						aria-hidden={decorationAlt ? undefined : 'true'}
-						className="pointer-events-none absolute right-0 bottom-0 w-[160px] max-w-[52%] object-contain"
+						// The corner ripple art is light-toned (made for the dark dialog). Invert
+						// it in light mode so it stays visible there too; keep it as-is in dark.
+						className="pointer-events-none absolute right-0 bottom-0 w-[160px] max-w-[52%] object-contain invert dark:invert-0"
 						loading="lazy"
 						decoding="async"
 					/>

--- a/frontend/src/features/shared/components/upload-media/fields/BasicFields.jsx
+++ b/frontend/src/features/shared/components/upload-media/fields/BasicFields.jsx
@@ -12,6 +12,7 @@ export function TitleField({ value = '', onChange, error = '' }) {
 		<TextField
 			className="w-full"
 			label="Title"
+			required
 			placeholder="Write here..."
 			value={value}
 			onChange={(event) => onChange?.(event.target.value)}

--- a/frontend/src/features/shared/components/upload-media/fields/BasicFields.jsx
+++ b/frontend/src/features/shared/components/upload-media/fields/BasicFields.jsx
@@ -7,7 +7,7 @@ import { SYNOPSIS_MAX_WORDS } from '../schema/mediaMetadataSchema';
 // identical: same labels, placeholders, widgets and helper text), driven by
 // per-file metadata so the bulk wizard can render one set per file.
 
-export function TitleField({ value = '', onChange, error = '' }) {
+export function TitleField({ value = '', onChange, error = '', validate }) {
 	return (
 		<TextField
 			className="w-full"
@@ -16,6 +16,7 @@ export function TitleField({ value = '', onChange, error = '' }) {
 			placeholder="Write here..."
 			value={value}
 			onChange={(event) => onChange?.(event.target.value)}
+			validate={validate}
 			invalid={Boolean(error)}
 			helperText={error}
 		/>

--- a/frontend/src/features/shared/components/upload-media/fields/OtherFields.jsx
+++ b/frontend/src/features/shared/components/upload-media/fields/OtherFields.jsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import { pattern } from '../../../utils/validators';
 import { TextField } from '../../TextField';
 import { Dropdown } from '../../Dropdown';
 import { CheckboxButton } from '../../CheckboxButton';
@@ -38,6 +39,7 @@ export function WebsiteField({ value = '', onChange, error = '' }) {
 			placeholder="Write here..."
 			value={value}
 			onChange={(event) => onChange?.(event.target.value)}
+			validate={[pattern(/^https:\/\//, 'Website should start with https://')]}
 			invalid={Boolean(error)}
 			helperText={error}
 		/>

--- a/frontend/src/features/shared/components/upload-media/schema/mediaMetadataSchema.js
+++ b/frontend/src/features/shared/components/upload-media/schema/mediaMetadataSchema.js
@@ -36,6 +36,10 @@ export function validateMetadata(metadata = {}) {
 	const errors = {};
 	const currentYear = new Date().getFullYear();
 
+	if (isBlank(metadata.title)) {
+		errors.title = 'This field is required';
+	}
+
 	if (isBlank(metadata.summary)) {
 		errors.summary = 'This field is required';
 	} else if (countSynopsisWords(metadata.summary) > SYNOPSIS_MAX_WORDS) {

--- a/frontend/src/features/shared/components/upload-media/schema/mediaMetadataSchema.test.js
+++ b/frontend/src/features/shared/components/upload-media/schema/mediaMetadataSchema.test.js
@@ -7,6 +7,7 @@ import {
 } from './mediaMetadataSchema';
 
 const validMetadata = {
+	title: 'My Film',
 	summary: 'A short synopsis.',
 	year_produced: '2021',
 	category: [1],
@@ -36,6 +37,7 @@ describe('validateMetadata', () => {
 
 	it('flags the required fields when empty', () => {
 		const errors = validateMetadata({});
+		expect(errors.title).toBeTruthy();
 		expect(errors.summary).toBeTruthy();
 		expect(errors.year_produced).toBeTruthy();
 		expect(errors.category).toBeTruthy();

--- a/templates/cms/add-media_revamp.html
+++ b/templates/cms/add-media_revamp.html
@@ -35,6 +35,7 @@
 		maxBulkFiles: {{ max_bulk_files }},
 		chunksDoneParam: "{{ chunks_done_param|escapejs }}",
 		isTrustedUser: {% if is_trusted_user %}true{% else %}false{% endif %},
+		userName: "{{ request.user.name|default:request.user.username|escapejs }}",
 		allowedExtensions: JSON.parse(document.getElementById('add-media-allowed-extensions').textContent),
 		canUploadMessage: "{{ can_upload_exp|escapejs }}",
 		csrfToken: "{{ csrf_token|escapejs }}",


### PR DESCRIPTION
## Description

Follow-up review feedback on the revamped upload flow, applied to **both** the
single-upload and bulk-upload tabs so they stay in parity.

**Quick Preview**
- Subtitle now shows the logged-in user's full name (the uploader) instead of the
  typed production company. The name is injected into the page config
  (`request.user.name`, falling back to the username) and consumed by the single
  preview and the per-file preview in bulk.
- Shows `0 views` (single + bulk) instead of omitting the views row.

**Validation (bulk — already done in single via #773)**
- Title is now required: added to the bulk metadata validation and marked required
  on the field, so it blocks submit and surfaces on the Basic Details sub-step.
- Website validates `https://` live on every keystroke (shared `TextField`
  `validate` prop) instead of only on submit.

**Mobile / tablet**
- Bulk needs the wide desktop layout, so on mobile and tablet (`< 1024px`) the
  Single/Bulk switcher is hidden entirely and only single upload is shown. Tracked
  with `matchMedia` (guarded for non-browser/test environments).

**Theming**
- The confirmation dialog's decorative corner "ripple" art is light-toned (made for
  the dark dialog) and was invisible in light mode. It is now inverted in light mode
  (`invert dark:invert-0`) so the decoration is consistent across themes for every
  confirmation dialog.

## Related Issue
Follow-up review feedback on the upload revamp — relates to #523 (bulk upload) and
#771 (single upload revamp issues). References PR #773 (single-upload fixes) for the
title/website parity.

## Motivation and Context
Reviewer feedback after the single/bulk upload revamp: the Quick Preview showed the
wrong subtitle and no view count, Title wasn't enforced, Website validation only ran
on submit, the bulk wizard was unusable on mobile/tablet, and the confirmation
dialog decoration only rendered in dark mode. These align the bulk tab with the
single tab and fix the cross-theme inconsistency.

## How Has This Been Tested?
- `npm run lint:modern`, `npm run test:run` (479 passed), `npm run build`
- `uv run pre-commit run`
- `python manage.py check`, `python manage.py makemigrations --check` (no changes),
  `python manage.py test` (CI settings)
- Manual: single + bulk Quick Preview (uploader name, 0 views, chosen thumbnail);
  required Title and live Website validation; mobile/tablet shows single only;
  confirmation dialog ripple visible in both light and dark.

## Screenshots (if appropriate):
<img width="2854" height="1462" alt="image" src="https://github.com/user-attachments/assets/fd6a6db5-c400-4261-af2d-872397ca3dac" />
<img width="640" height="1286" alt="image" src="https://github.com/user-attachments/assets/f3d76b09-b94b-4759-a084-6d5b97e8f249" />


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):
- [x] I have not imported `flux` in a new component
- [x] If adding a new feature, I used Modern Track patterns
- [x] New features do not create new SCSS files (use Tailwind instead)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved the add-media experience on smaller screens by automatically simplifying the upload tab shown and keeping the selected tab in sync with the layout.
  * Display the current user’s name in upload previews.

* **Bug Fixes**
  * Added validation to require a title for media uploads.
  * Enforced secure website URLs by requiring `https://`.
  * Updated confirmation dialog styling for improved light-mode appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->