### PR TITLE
feat(media): "choose from video" thumbnail selector in single & bulk upload (#541)

### DIFF
--- a/cms/dev_settings.py
+++ b/cms/dev_settings.py
@@ -234,6 +234,7 @@ HLS_DIR = os.path.join(MEDIA_ROOT, "hls/")
 
 FFMPEG_COMMAND = "ffmpeg"  # this is the path
 FFPROBE_COMMAND = "ffprobe"  # this is the path
+IMAGEMAGICK_COMMAND = None  # optional path/name for ImageMagick; auto-detects convert or magick when unset
 MP4HLS = "mp4hls"
 
 ALLOW_ANONYMOUS_ACTIONS = ["report", "like", "dislike", "watch"]  # need be a list

--- a/cms/settings.py
+++ b/cms/settings.py
@@ -387,6 +387,7 @@ HLS_DIR = os.path.join(MEDIA_ROOT, "hls/")
 
 FFMPEG_COMMAND = "ffmpeg"  # this is the path
 FFPROBE_COMMAND = "ffprobe"  # this is the path
+IMAGEMAGICK_COMMAND = None  # optional path/name for ImageMagick; auto-detects convert or magick when unset
 MP4HLS = "mp4hls"
 
 ALLOW_ANONYMOUS_ACTIONS = ["watch"]  # need be a list - only watching allowed for anonymous users

--- a/docs/admin-guides/video-sprite-backfill.md
+++ b/docs/admin-guides/video-sprite-backfill.md
@@ -1,0 +1,51 @@
+# Video Sprite Backfill
+
+The edit-media thumbnail selector uses each video's generated sprite sheet to show
+selectable frames. Older videos, or videos whose sprite generation failed, can have an
+empty `sprites` value and will keep showing the loading state until a sprite is generated.
+
+Use the `backfill_video_sprites` management command to enqueue sprite generation for
+existing videos:
+
+```bash
+python manage.py backfill_video_sprites --dry-run
+python manage.py backfill_video_sprites --limit 100 --sleep 1
+```
+
+By default, the command targets videos that:
+
+- have finished encoding (`encoding_status = "success"`),
+- have an empty `sprites` value, and
+- are at least 60 minutes old.
+
+The encoding-status filter is the primary guard: sprite generation normally runs right after
+encoding, so a video that has not finished encoding either has that step still pending or
+failed encoding outright (no usable source). The age guard is an extra safety margin against
+racing fresh uploads. The command also skips rows whose original `media_file` is missing,
+because there is no source video to extract frames from.
+
+Useful flags:
+
+- `--dry-run`: report how many videos would be targeted without enqueueing jobs.
+- `--limit N`: cap the total number of videos targeted in one run.
+- `--batch-size N`: DB fetch/log cadence (does not change how many jobs run).
+- `--sleep SECONDS`: pause between every job (Celery enqueue or inline run) to keep load on
+  `long_tasks` and CPU smooth.
+- `--user-id ID`: target one user's videos.
+- `--inline`: generate sprites in the management command process for local or staging
+  debugging.
+- `--force`: regenerate sprites even when a sprite value already exists.
+- `--repair-missing-files`: also target videos whose `sprites` database value is set but
+  the sprite file is missing on disk.
+- `--min-age-minutes N`: override the default age guard (`0` disables it).
+- `--include-unencoded`: also target videos that have not finished encoding. Off by default;
+  use only when you knowingly want to (re)generate sprites for non-`success` videos.
+
+Sprite generation requires FFmpeg and ImageMagick. `FFMPEG_COMMAND` controls the FFmpeg
+binary. `IMAGEMAGICK_COMMAND` can pin an ImageMagick binary; when unset, CinemataCMS
+auto-detects `convert` first and then `magick`.
+
+For production, run the command off-peak in small passes and watch `long_tasks` queue depth,
+encoding latency, and temporary disk usage between passes. The command is resumable:
+videos that already have sprite files are skipped unless `--force` or
+`--repair-missing-files` applies.

--- a/files/forms.py
+++ b/files/forms.py
@@ -73,6 +73,7 @@ class MediaForm(forms.ModelForm):
             "year_produced_custom",
             "media_file",
             "uploaded_poster",
+            "thumbnail_time",
             "allow_whisper_transcribe_and_translate",
             "add_date",
             "company",

--- a/files/management/commands/backfill_video_sprites.py
+++ b/files/management/commands/backfill_video_sprites.py
@@ -79,9 +79,9 @@ class Command(BaseCommand):
             "--include-unencoded",
             action="store_true",
             help=(
-                "Also target videos that have not finished encoding "
-                "(encoding_status != 'success'). Off by default so the backfill never "
-                "races a video whose normal post-encoding sprite step has not run yet."
+                "Also target videos still in 'pending' encoding state. "
+                "Off by default so the backfill does not race fresh uploads "
+                "whose normal post-encoding sprite step has not run yet."
             ),
         )
 
@@ -107,14 +107,16 @@ class Command(BaseCommand):
         if user_id:
             queryset = queryset.filter(user_id=user_id)
 
-        # Primary race guard: only touch videos that finished encoding. Sprite
-        # generation normally runs post-encoding, so a non-"success" video either
-        # hasn't reached that step yet or failed encoding (no usable source) —
-        # backfilling it would either duplicate pending work or fail anyway.
+        # Race guard: skip videos that are still being encoded so the backfill
+        # doesn't race the normal post-encoding sprite step. Once the age floor
+        # passes the upload is old enough that any in-progress encoding has
+        # either finished or failed — at that point a usable media_file and
+        # duration are the only real prerequisites (checked per-row below).
         if not options["include_unencoded"]:
-            queryset = queryset.filter(encoding_status="success")
+            queryset = queryset.exclude(encoding_status="pending")
 
-        # Belt-and-suspenders time floor on top of the encoding_status guard.
+        # Time floor keeps us clear of uploads that haven't had time to finish
+        # their encoding + sprite pipeline yet.
         if min_age_minutes:
             queryset = queryset.filter(add_date__lte=timezone.now() - timedelta(minutes=min_age_minutes))
 

--- a/files/management/commands/backfill_video_sprites.py
+++ b/files/management/commands/backfill_video_sprites.py
@@ -79,9 +79,9 @@ class Command(BaseCommand):
             "--include-unencoded",
             action="store_true",
             help=(
-                "Also target videos still in 'pending' encoding state. "
-                "Off by default so the backfill does not race fresh uploads "
-                "whose normal post-encoding sprite step has not run yet."
+                "Also target videos that have not finished encoding "
+                "(encoding_status != 'success'). Off by default so the backfill never "
+                "races a video whose normal post-encoding sprite step has not run yet."
             ),
         )
 
@@ -107,16 +107,14 @@ class Command(BaseCommand):
         if user_id:
             queryset = queryset.filter(user_id=user_id)
 
-        # Race guard: skip videos that are still being encoded so the backfill
-        # doesn't race the normal post-encoding sprite step. Once the age floor
-        # passes the upload is old enough that any in-progress encoding has
-        # either finished or failed — at that point a usable media_file and
-        # duration are the only real prerequisites (checked per-row below).
+        # Primary race guard: only touch videos that finished encoding. Sprite
+        # generation normally runs post-encoding, so a non-"success" video either
+        # hasn't reached that step yet or failed encoding (no usable source) —
+        # backfilling it would either duplicate pending work or fail anyway.
         if not options["include_unencoded"]:
-            queryset = queryset.exclude(encoding_status="pending")
+            queryset = queryset.filter(encoding_status="success")
 
-        # Time floor keeps us clear of uploads that haven't had time to finish
-        # their encoding + sprite pipeline yet.
+        # Belt-and-suspenders time floor on top of the encoding_status guard.
         if min_age_minutes:
             queryset = queryset.filter(add_date__lte=timezone.now() - timedelta(minutes=min_age_minutes))
 

--- a/files/management/commands/backfill_video_sprites.py
+++ b/files/management/commands/backfill_video_sprites.py
@@ -1,0 +1,207 @@
+import os
+import time
+from datetime import timedelta
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db.models import Q
+from django.utils import timezone
+
+from files.models import Media
+from files.sprites import generate_sprite_for_media
+from files.tasks import produce_sprite_from_video
+
+
+def _file_field_exists(field_file):
+    if not field_file:
+        return False
+    try:
+        return field_file.storage.exists(field_file.name)
+    except (NotImplementedError, OSError, ValueError):
+        try:
+            return os.path.exists(field_file.path)
+        except (NotImplementedError, OSError, ValueError):
+            return False
+
+
+class Command(BaseCommand):
+    help = "Backfill missing sprite sheets for existing video media"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--batch-size",
+            type=int,
+            default=50,
+            help="Number of media rows to fetch per DB batch (default: 50)",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Report matching media without enqueueing or generating sprites",
+        )
+        parser.add_argument(
+            "--limit",
+            type=int,
+            help="Maximum number of sprite jobs to enqueue or run",
+        )
+        parser.add_argument(
+            "--user-id",
+            type=int,
+            help="Only backfill media owned by this user ID",
+        )
+        parser.add_argument(
+            "--sleep",
+            type=float,
+            default=1.0,
+            help="Seconds to sleep between enqueueing jobs (default: 1.0)",
+        )
+        parser.add_argument(
+            "--inline",
+            action="store_true",
+            help="Generate sprites synchronously in this process instead of enqueueing Celery tasks",
+        )
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            help="Regenerate sprites even when a sprite value already exists",
+        )
+        parser.add_argument(
+            "--repair-missing-files",
+            action="store_true",
+            help="Also target rows whose sprites field is set but the sprite file is missing on disk",
+        )
+        parser.add_argument(
+            "--min-age-minutes",
+            type=int,
+            default=60,
+            help="Only target videos at least this old, to avoid racing fresh uploads (default: 60)",
+        )
+        parser.add_argument(
+            "--include-unencoded",
+            action="store_true",
+            help=(
+                "Also target videos that have not finished encoding "
+                "(encoding_status != 'success'). Off by default so the backfill never "
+                "races a video whose normal post-encoding sprite step has not run yet."
+            ),
+        )
+
+    def handle(self, *args, **options):
+        batch_size = options["batch_size"]
+        if batch_size <= 0:
+            raise CommandError("Invalid --batch-size: must be a positive integer")
+
+        limit = options.get("limit")
+        if limit is not None and limit <= 0:
+            raise CommandError("Invalid --limit: must be a positive integer")
+
+        sleep_seconds = options["sleep"]
+        if sleep_seconds < 0:
+            raise CommandError("Invalid --sleep: must be zero or a positive number")
+
+        min_age_minutes = options["min_age_minutes"]
+        if min_age_minutes < 0:
+            raise CommandError("Invalid --min-age-minutes: must be zero or a positive integer")
+
+        queryset = Media.objects.filter(media_type="video").order_by("id")
+        user_id = options.get("user_id")
+        if user_id:
+            queryset = queryset.filter(user_id=user_id)
+
+        # Primary race guard: only touch videos that finished encoding. Sprite
+        # generation normally runs post-encoding, so a non-"success" video either
+        # hasn't reached that step yet or failed encoding (no usable source) —
+        # backfilling it would either duplicate pending work or fail anyway.
+        if not options["include_unencoded"]:
+            queryset = queryset.filter(encoding_status="success")
+
+        # Belt-and-suspenders time floor on top of the encoding_status guard.
+        if min_age_minutes:
+            queryset = queryset.filter(add_date__lte=timezone.now() - timedelta(minutes=min_age_minutes))
+
+        force = options["force"]
+        repair_missing_files = options["repair_missing_files"]
+        if not force and not repair_missing_files:
+            queryset = queryset.filter(Q(sprites="") | Q(sprites__isnull=True))
+
+        dry_run = options["dry_run"]
+        inline = options["inline"]
+        processed = 0
+        targeted = 0
+        enqueued = 0
+        succeeded = 0
+        failed = 0
+        skipped_missing_media_file = 0
+        skipped_existing_sprite = 0
+
+        if dry_run:
+            self.stdout.write(self.style.WARNING("DRY RUN: no sprite jobs will be enqueued or run"))
+
+        for media in queryset.iterator(chunk_size=batch_size):
+            processed += 1
+
+            if not _file_field_exists(media.media_file):
+                skipped_missing_media_file += 1
+                continue
+
+            sprite_exists = _file_field_exists(media.sprites)
+            if not force and repair_missing_files and media.sprites and sprite_exists:
+                skipped_existing_sprite += 1
+                continue
+
+            if limit is not None and targeted >= limit:
+                break
+
+            targeted += 1
+            if dry_run:
+                continue
+
+            if inline:
+                result = generate_sprite_for_media(media)
+                if result["ok"]:
+                    succeeded += 1
+                else:
+                    failed += 1
+                    self.stdout.write(
+                        self.style.WARNING(
+                            f"Failed {media.friendly_token}: {result['reason']}"
+                            + (f" ({result['error']})" if result.get("error") else "")
+                        )
+                    )
+            else:
+                produce_sprite_from_video.delay(media.friendly_token)
+                enqueued += 1
+
+            # Pause between every job (enqueue or inline run) to keep load on the
+            # shared long_tasks queue / CPU smooth and predictable.
+            if sleep_seconds:
+                time.sleep(sleep_seconds)
+
+        if dry_run:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    "Video sprite backfill dry run complete: "
+                    f"processed={processed}, would_target={targeted}, "
+                    f"skipped_missing_media_file={skipped_missing_media_file}, "
+                    f"skipped_existing_sprite={skipped_existing_sprite}"
+                )
+            )
+            return
+
+        if inline:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    "Video sprite backfill complete: "
+                    f"processed={processed}, targeted={targeted}, succeeded={succeeded}, failed={failed}, "
+                    f"skipped_missing_media_file={skipped_missing_media_file}, "
+                    f"skipped_existing_sprite={skipped_existing_sprite}"
+                )
+            )
+        else:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    "Video sprite backfill enqueue complete: "
+                    f"processed={processed}, targeted={targeted}, enqueued={enqueued}, "
+                    f"skipped_missing_media_file={skipped_missing_media_file}, "
+                    f"skipped_existing_sprite={skipped_existing_sprite}"
+                )
+            )

--- a/files/models.py
+++ b/files/models.py
@@ -436,7 +436,7 @@ class Media(models.Model):
         for item in strip_text_items:
             setattr(self, item, strip_tags(getattr(self, item, None)))
         self.title = self.title[:99]
-        if self.thumbnail_time:
+        if self.thumbnail_time is not None:
             self.thumbnail_time = round(self.thumbnail_time, 1)
         if not self.add_date:
             self.add_date = timezone.now()
@@ -459,9 +459,18 @@ class Media(models.Model):
                 from . import tasks
 
                 tasks.media_init.apply_async(args=[self.friendly_token], countdown=5)
-            if self.thumbnail_time != self.__original_thumbnail_time:
+            thumbnail_time_changed = self.thumbnail_time != self.__original_thumbnail_time
+            uploaded_poster_changed = self.uploaded_poster != self.__original_uploaded_poster
+            if thumbnail_time_changed and self.thumbnail_time is not None and not uploaded_poster_changed:
+                if self.uploaded_thumbnail:
+                    self.uploaded_thumbnail.delete(save=False)
+                if self.uploaded_poster:
+                    self.uploaded_poster.delete(save=False)
+                self.__original_uploaded_poster = self.uploaded_poster
                 self.__original_thumbnail_time = self.thumbnail_time
                 self.set_thumbnail(force=True)
+            elif thumbnail_time_changed:
+                self.__original_thumbnail_time = self.thumbnail_time
         else:
             self.state = helpers.get_default_state(user=self.user)
             self.license = License.objects.filter(id=10).first()
@@ -703,7 +712,7 @@ class Media(models.Model):
     def produce_thumbnails_from_video(self):
         if self.media_type != "video":
             return False
-        if self.thumbnail_time and 0 <= self.thumbnail_time < self.duration:
+        if self.thumbnail_time is not None and 0 <= self.thumbnail_time < self.duration:
             thumbnail_time = self.thumbnail_time
         else:
             thumbnail_time = round(random.uniform(0, self.duration - 0.1), 1)
@@ -992,10 +1001,10 @@ class Media(models.Model):
     def media_version(self):
         """Get media version based on edit_date timestamp for URL versioning"""
         if self.edit_date:
-            return int(self.edit_date.timestamp())
+            return int(self.edit_date.timestamp() * 1000)
         # Fallback to add_date if edit_date is not available
         if self.add_date:
-            return int(self.add_date.timestamp())
+            return int(self.add_date.timestamp() * 1000)
         # Final fallback: use hash of uid to ensure uniqueness
         return hash(str(self.uid)) & 0x7FFFFFFF  # Ensure positive 32-bit integer
 

--- a/files/serializers.py
+++ b/files/serializers.py
@@ -296,9 +296,19 @@ class SingleMediaSerializer(serializers.ModelSerializer):
     user_has_liked = serializers.SerializerMethodField()
     user_has_disliked = serializers.SerializerMethodField()
     community_impacts = serializers.SerializerMethodField()
+    sprite_num_secs = serializers.SerializerMethodField()
 
     def get_url(self, obj):
         return self.context["request"].build_absolute_uri(obj.get_absolute_url())
+
+    def get_sprite_num_secs(self, obj):
+        # Seconds between consecutive sprite-sheet frames. The thumbnail selector needs
+        # this to map a chosen tile back to its exact timestamp (tile i -> i * value),
+        # which must match how files/sprites.py extracts the tiles. Exposed instead of
+        # hardcoding 10 on the client so the two never drift if the setting changes.
+        from django.conf import settings
+
+        return getattr(settings, "SPRITE_NUM_SECS", 10)
 
     def get_user_has_liked(self, obj):
         request = self.context.get("request")
@@ -367,6 +377,7 @@ class SingleMediaSerializer(serializers.ModelSerializer):
             "thumbnail_time",
             "url",
             "sprites_url",
+            "sprite_num_secs",
             "preview_url",
             "author_name",
             "author_profile",

--- a/files/sprites.py
+++ b/files/sprites.py
@@ -1,0 +1,154 @@
+import os
+import shutil
+import tempfile
+
+from django.conf import settings
+from django.core.files import File
+
+from .helpers import get_file_name, get_file_type, run_command
+
+SPRITE_WIDTH = 160
+SPRITE_HEIGHT = 90
+
+
+def _command_exists(command):
+    if os.path.sep in command:
+        return os.path.isfile(command) and os.access(command, os.X_OK)
+    return shutil.which(command) is not None
+
+
+def resolve_imagemagick_command():
+    configured_command = getattr(settings, "IMAGEMAGICK_COMMAND", None)
+    if configured_command:
+        if _command_exists(configured_command):
+            return [configured_command]
+        return None
+
+    convert_command = shutil.which("convert")
+    if convert_command:
+        return [convert_command]
+
+    magick_command = shutil.which("magick")
+    if magick_command:
+        return [magick_command]
+
+    return None
+
+
+def _media_file_path(media):
+    try:
+        if not media.media_file:
+            return None
+        return media.media_file.path
+    except (NotImplementedError, ValueError):
+        return None
+
+
+def _failure(media, reason, error=None):
+    result = {
+        "ok": False,
+        "reason": reason,
+        "friendly_token": getattr(media, "friendly_token", None),
+    }
+    if error:
+        result["error"] = error
+    return result
+
+
+def generate_sprite_for_media(media):
+    if media.media_type != "video":
+        return _failure(media, "not_video")
+
+    ffmpeg_command = getattr(settings, "FFMPEG_COMMAND", None)
+    if not ffmpeg_command or not _command_exists(ffmpeg_command):
+        return _failure(media, "missing_ffmpeg")
+
+    imagemagick_command = resolve_imagemagick_command()
+    if not imagemagick_command:
+        return _failure(media, "missing_imagemagick")
+
+    temp_directory = getattr(settings, "TEMP_DIRECTORY", None)
+    if not temp_directory or not os.path.isdir(temp_directory) or not os.access(temp_directory, os.W_OK):
+        return _failure(media, "missing_temp_directory")
+
+    media_file_path = _media_file_path(media)
+    if not media_file_path or not os.path.exists(media_file_path):
+        return _failure(media, "missing_media_file")
+
+    with tempfile.TemporaryDirectory(dir=temp_directory) as tmpdirname:
+        output_name = os.path.join(tmpdirname, "sprites.jpg")
+
+        sprite_num_secs = getattr(settings, "SPRITE_NUM_SECS", 10)
+
+        # Extract each sprite tile at an EXACT timestamp (i * sprite_num_secs) using the
+        # same `-ss <time> -i <file> -vframes 1` input-seek mechanism the poster uses in
+        # Media.produce_thumbnails_from_video(). The previous `fps=1/N` approach decoded
+        # frames on a different seek model than the poster's input-seek (which snaps to the
+        # nearest keyframe), so the tile a user clicked and the poster generated for that
+        # same second could be different frames. Extracting both the same way guarantees
+        # that selecting tile `i` (time i*sprite_num_secs) yields exactly that poster.
+        duration = int(getattr(media, "duration", 0) or 0)
+        if duration <= 0:
+            return _failure(media, "missing_duration")
+
+        timestamps = list(range(0, duration, sprite_num_secs))
+        if not timestamps:
+            timestamps = [0]
+
+        last_ffmpeg_error = None
+        image_files = []
+        for index, timestamp in enumerate(timestamps):
+            frame_path = os.path.join(tmpdirname, f"img{index:03d}.jpg")
+            ffmpeg_cmd = [
+                ffmpeg_command,
+                "-threads",
+                "1",
+                "-ss",
+                str(timestamp),  # input seek: -ss before -i, matching the poster command
+                "-i",
+                media_file_path,
+                "-vframes",
+                "1",
+                "-vf",
+                f"scale={SPRITE_WIDTH}:{SPRITE_HEIGHT}",
+                "-y",
+                frame_path,
+            ]
+            ffmpeg_result = run_command(ffmpeg_cmd)
+            if os.path.exists(frame_path):
+                image_files.append(frame_path)
+            else:
+                last_ffmpeg_error = ffmpeg_result.get("error")
+                return _failure(media, "ffmpeg_missing_frame", last_ffmpeg_error)
+
+        if not image_files:
+            return _failure(media, "ffmpeg_no_frames", last_ffmpeg_error)
+
+        convert_cmd = [
+            *imagemagick_command,
+            *image_files,
+            "-append",
+            output_name,
+        ]
+        convert_result = run_command(convert_cmd)
+
+        if not os.path.exists(output_name):
+            return _failure(media, "imagemagick_no_output", convert_result.get("error"))
+        if get_file_type(output_name) != "image":
+            return _failure(media, "invalid_sprite_output")
+
+        with open(output_name, "rb") as sprite_file:
+            media.sprites.save(
+                content=File(sprite_file),
+                name=get_file_name(media_file_path) + "sprites.jpg",
+            )
+
+    if not media.sprites:
+        return _failure(media, "sprite_not_saved")
+
+    return {
+        "ok": True,
+        "reason": None,
+        "friendly_token": media.friendly_token,
+        "sprites": media.sprites.name,
+    }

--- a/files/tasks.py
+++ b/files/tasks.py
@@ -54,6 +54,7 @@ from .models import (
     TranscriptionRequest,
 )
 from .query_cache import invalidate_media_cache
+from .sprites import generate_sprite_for_media
 from .storage_usage import schedule_refresh_media_storage_usage
 
 logger = get_task_logger(__name__)
@@ -725,51 +726,19 @@ def produce_sprite_from_video(friendly_token):
 
     try:
         media = Media.objects.get(friendly_token=friendly_token)
-    except BaseException:
+    except Media.DoesNotExist:
         logger.info("failed to get media with friendly_token %s" % friendly_token)
-        return False
+        return {"ok": False, "reason": "media_not_found", "friendly_token": friendly_token}
 
-    with tempfile.TemporaryDirectory(dir=settings.TEMP_DIRECTORY) as tmpdirname:
-        try:
-            tmpdir_image_files = tmpdirname + "/img%03d.jpg"
-            output_name = tmpdirname + "/sprites.jpg"
-
-            fps = getattr(settings, "SPRITE_NUM_SECS", 10)
-            ffmpeg_cmd = [
-                settings.FFMPEG_COMMAND,
-                "-threads",
-                "1",
-                "-i",
-                media.media_file.path,
-                "-f",
-                "image2",
-                "-vf",
-                f"fps=1/{fps}, scale=160:90",
-                tmpdir_image_files,
-            ]
-            run_command(ffmpeg_cmd)
-            image_files = [f for f in os.listdir(tmpdirname) if f.startswith("img") and f.endswith(".jpg")]
-            image_files = sorted(image_files, key=lambda x: int(re.search(r"\d+", x).group()))
-            image_files = [os.path.join(tmpdirname, f) for f in image_files]
-            cmd_convert = [
-                "convert",
-                *image_files,  # image files, unpacked into the list
-                "-append",
-                output_name,
-            ]
-
-            run_command(cmd_convert)
-
-            if os.path.exists(output_name) and get_file_type(output_name) == "image":
-                with open(output_name, "rb") as f:
-                    myfile = File(f)
-                    media.sprites.save(
-                        content=myfile,
-                        name=get_file_name(media.media_file.path) + "sprites.jpg",
-                    )
-        except BaseException:
-            pass
-    return True
+    result = generate_sprite_for_media(media)
+    if not result["ok"]:
+        logger.error(
+            "Failed to generate sprite for media %s: %s%s",
+            friendly_token,
+            result["reason"],
+            f" ({result['error']})" if result.get("error") else "",
+        )
+    return result
 
 
 @task(name="create_hls", queue="long_tasks")

--- a/files/tests/test_edit_media_thumbnail_selector.py
+++ b/files/tests/test_edit_media_thumbnail_selector.py
@@ -1,0 +1,72 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from files.forms import MediaForm
+from files.models import Category, Language, Media
+from files.tests.helpers import create_test_media, create_test_user
+
+
+class EditMediaThumbnailSelectorTests(TestCase):
+    def setUp(self):
+        self.user = create_test_user()
+        self.user.advancedUser = True
+        self.user.save()
+        self.category = Category.objects.first() or Category.objects.create(
+            title="Test Category", user=self.user, is_global=True
+        )
+        Language.objects.get_or_create(code="en", defaults={"title": "English"})
+
+    def test_media_form_includes_thumbnail_time_for_video(self):
+        media = create_test_media(self.user, media_type="video")
+
+        form = MediaForm(self.user, instance=media)
+
+        self.assertIn("thumbnail_time", form.fields)
+
+    def test_media_form_excludes_thumbnail_time_for_non_video(self):
+        media = create_test_media(self.user, media_type="image")
+
+        form = MediaForm(self.user, instance=media)
+
+        self.assertNotIn("thumbnail_time", form.fields)
+
+    def test_zero_thumbnail_time_is_used_as_selected_frame(self):
+        media = create_test_media(
+            self.user,
+            media_file="original/media/test-video.mp4",
+            thumbnail_time=0,
+            duration=120,
+        )
+
+        with (
+            patch("files.models.helpers.create_temp_file", return_value="/tmp/test-thumb.jpg"),
+            patch("files.models.helpers.run_command") as run_command,
+            patch("files.models.helpers.rm_file"),
+            patch("files.models.os.path.exists", return_value=False),
+            patch("files.models.random.uniform", return_value=55) as random_time,
+        ):
+            media.produce_thumbnails_from_video()
+
+        command = run_command.call_args.args[0]
+        self.assertEqual(float(command[2]), 0)
+        random_time.assert_not_called()
+
+    def test_selected_video_frame_clears_existing_uploaded_poster(self):
+        media = create_test_media(
+            self.user,
+            media_file="original/media/test-video.mp4",
+            thumbnail_time=1,
+            uploaded_thumbnail="original/thumbnails/user/test/old-thumb.jpg",
+            uploaded_poster="original/thumbnails/user/test/old-poster.jpg",
+        )
+
+        media.thumbnail_time = 20
+
+        with patch.object(Media, "set_thumbnail", return_value=True) as set_thumbnail:
+            media.save()
+
+        media.refresh_from_db()
+        self.assertFalse(media.uploaded_thumbnail)
+        self.assertFalse(media.uploaded_poster)
+        set_thumbnail.assert_called_once_with(force=True)

--- a/files/tests/test_media_serializer.py
+++ b/files/tests/test_media_serializer.py
@@ -1,4 +1,4 @@
-from django.test import RequestFactory, TestCase
+from django.test import RequestFactory, TestCase, override_settings
 
 from files.models import ContentSensitivity, EncodeProfile, Encoding
 from files.serializers import HeroPlaybackSerializer, MediaSerializer, SingleMediaSerializer
@@ -32,6 +32,18 @@ class MediaSerializerTest(TestCase):
         data = SingleMediaSerializer(media, context={"request": request}).data
 
         self.assertEqual(data["content_sensitivity_info"], [{"title": "Graphic Violence"}])
+
+    @override_settings(SPRITE_NUM_SECS=7)
+    def test_single_media_serializer_exposes_sprite_num_secs(self):
+        # The thumbnail selector maps a chosen tile back to its timestamp via this value;
+        # it must reflect the server setting so the client never assumes a hardcoded 10.
+        media = create_test_media(self.user)
+        request = RequestFactory().get("/api/v1/media/test")
+        request.user = self.user
+
+        data = SingleMediaSerializer(media, context={"request": request}).data
+
+        self.assertEqual(data["sprite_num_secs"], 7)
 
     def test_hero_playback_serializer_includes_playback_fields(self):
         media = create_test_media(self.user)

--- a/files/tests/test_video_sprite_backfill.py
+++ b/files/tests/test_video_sprite_backfill.py
@@ -1,0 +1,280 @@
+import os
+import tempfile
+from io import StringIO
+from unittest.mock import patch
+
+from django.core.files.base import ContentFile
+from django.core.management import call_command
+from django.test import TestCase, override_settings
+
+from files.models import Media
+from files.sprites import generate_sprite_for_media, resolve_imagemagick_command
+from files.tests.helpers import create_test_media, create_test_user
+
+
+class VideoSpriteBackfillTests(TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+        self.fake_ffmpeg = self._fake_executable("ffmpeg")
+        self.fake_magick = self._fake_executable("magick")
+        self.override = override_settings(
+            ADMINS_NOTIFICATIONS={"NEW_USER": False},
+            MEDIA_ROOT=self.tmpdir.name,
+            TEMP_DIRECTORY=self.tmpdir.name,
+            FFMPEG_COMMAND=self.fake_ffmpeg,
+            IMAGEMAGICK_COMMAND=self.fake_magick,
+        )
+        self.override.enable()
+        self.addCleanup(self.override.disable)
+        self.user = create_test_user(username="sprite_owner")
+
+    def _fake_executable(self, name):
+        command_path = os.path.join(self.tmpdir.name, name)
+        with open(command_path, "w", encoding="utf-8") as command_file:
+            command_file.write("#!/bin/sh\n")
+        os.chmod(command_path, 0o700)
+        return command_path
+
+    def _attach_media_file(self, media, name="original.mp4"):
+        media.media_file.save(name, ContentFile(b"video"), save=False)
+        Media.objects.filter(pk=media.pk).update(media_file=media.media_file.name)
+        media.refresh_from_db()
+        media._Media__original_media_file = media.media_file
+        return media
+
+    def _attach_sprite_file(self, media, name="sprites.jpg"):
+        media.sprites.save(name, ContentFile(b"sprite"), save=False)
+        Media.objects.filter(pk=media.pk).update(sprites=media.sprites.name)
+        media.refresh_from_db()
+        return media
+
+    def test_generate_sprite_for_media_saves_sprite_on_success(self):
+        media = self._attach_media_file(create_test_media(self.user))
+
+        def fake_run(command):
+            if command[0] == self.fake_ffmpeg:
+                # Each tile is extracted with its own `-ss <time> ... -y <frame_path>`.
+                with open(command[-1], "wb") as frame_file:
+                    frame_file.write(b"frame")
+            else:
+                with open(command[-1], "wb") as sprite_file:
+                    sprite_file.write(b"sprite")
+            return {"out": "", "error": ""}
+
+        with (
+            patch("files.sprites.run_command", side_effect=fake_run),
+            patch("files.sprites.get_file_type", return_value="image"),
+        ):
+            result = generate_sprite_for_media(media)
+
+        media.refresh_from_db()
+        self.assertTrue(result["ok"])
+        self.assertTrue(media.sprites)
+        self.assertIn("original.mp4sprites.jpg", media.sprites.name)
+
+    @override_settings(SPRITE_NUM_SECS=10)
+    def test_generate_sprite_extracts_tiles_at_exact_interval_timestamps(self):
+        # The fix: each tile is extracted at an exact `-ss i*SPRITE_NUM_SECS` so the tile a
+        # user clicks matches the poster the backend later generates for that same second.
+        media = self._attach_media_file(create_test_media(self.user, duration=35))
+
+        seek_times = []
+
+        def fake_run(command):
+            if command[0] == self.fake_ffmpeg:
+                # command is [ffmpeg, -threads, 1, -ss, <time>, -i, file, -vframes, 1, -vf, scale, -y, frame]
+                seek_times.append(command[command.index("-ss") + 1])
+                with open(command[-1], "wb") as frame_file:
+                    frame_file.write(b"frame")
+            else:
+                with open(command[-1], "wb") as sprite_file:
+                    sprite_file.write(b"sprite")
+            return {"out": "", "error": ""}
+
+        with (
+            patch("files.sprites.run_command", side_effect=fake_run),
+            patch("files.sprites.get_file_type", return_value="image"),
+        ):
+            result = generate_sprite_for_media(media)
+
+        self.assertTrue(result["ok"])
+        # duration=35, interval=10 -> tiles at 0, 10, 20, 30 (range(0, 35, 10))
+        self.assertEqual(seek_times, ["0", "10", "20", "30"])
+
+    def test_generate_sprite_for_media_reports_missing_duration(self):
+        media = self._attach_media_file(create_test_media(self.user, duration=0))
+
+        result = generate_sprite_for_media(media)
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["reason"], "missing_duration")
+
+    def test_generate_sprite_for_media_fails_when_any_expected_tile_is_missing(self):
+        media = self._attach_media_file(create_test_media(self.user, duration=25))
+
+        def fake_run(command):
+            if command[0] == self.fake_ffmpeg:
+                timestamp = command[command.index("-ss") + 1]
+                if timestamp != "10":
+                    with open(command[-1], "wb") as frame_file:
+                        frame_file.write(b"frame")
+            return {"out": "", "error": "missing frame"}
+
+        with patch("files.sprites.run_command", side_effect=fake_run):
+            result = generate_sprite_for_media(media)
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["reason"], "ffmpeg_missing_frame")
+
+    def test_generate_sprite_for_media_reports_missing_ffmpeg(self):
+        media = self._attach_media_file(create_test_media(self.user))
+
+        with override_settings(FFMPEG_COMMAND="/missing/ffmpeg"):
+            result = generate_sprite_for_media(media)
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["reason"], "missing_ffmpeg")
+
+    def test_generate_sprite_for_media_reports_missing_imagemagick(self):
+        media = self._attach_media_file(create_test_media(self.user))
+
+        with (
+            override_settings(IMAGEMAGICK_COMMAND=None),
+            patch("files.sprites.shutil.which", return_value=None),
+        ):
+            result = generate_sprite_for_media(media)
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["reason"], "missing_imagemagick")
+
+    def test_generate_sprite_for_media_reports_missing_output(self):
+        media = self._attach_media_file(create_test_media(self.user))
+
+        def fake_run(command):
+            if command[0] == self.fake_ffmpeg:
+                with open(command[-1], "wb") as frame_file:
+                    frame_file.write(b"frame")
+            return {"out": "", "error": "no output"}
+
+        with patch("files.sprites.run_command", side_effect=fake_run):
+            result = generate_sprite_for_media(media)
+
+        media.refresh_from_db()
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["reason"], "imagemagick_no_output")
+        self.assertFalse(media.sprites)
+
+    def test_resolve_imagemagick_command_prefers_convert_then_magick(self):
+        with (
+            override_settings(IMAGEMAGICK_COMMAND=None),
+            patch(
+                "files.sprites.shutil.which",
+                side_effect=lambda command: f"/bin/{command}" if command == "convert" else None,
+            ),
+        ):
+            self.assertEqual(resolve_imagemagick_command(), ["/bin/convert"])
+
+        with (
+            override_settings(IMAGEMAGICK_COMMAND=None),
+            patch(
+                "files.sprites.shutil.which", side_effect=lambda command: "/bin/magick" if command == "magick" else None
+            ),
+        ):
+            self.assertEqual(resolve_imagemagick_command(), ["/bin/magick"])
+
+    def test_backfill_command_enqueues_missing_video_sprites_only(self):
+        target = self._attach_media_file(create_test_media(self.user))
+        existing = self._attach_sprite_file(self._attach_media_file(create_test_media(self.user)))
+        missing_file = create_test_media(self.user)
+        self._attach_media_file(create_test_media(self.user, media_type="audio"))
+
+        out = StringIO()
+        with patch("files.management.commands.backfill_video_sprites.produce_sprite_from_video.delay") as delay:
+            call_command(
+                "backfill_video_sprites",
+                user_id=self.user.id,
+                min_age_minutes=0,
+                sleep=0,
+                stdout=out,
+            )
+
+        delay.assert_called_once_with(target.friendly_token)
+        self.assertNotIn(existing.friendly_token, str(delay.mock_calls))
+        self.assertNotIn(missing_file.friendly_token, str(delay.mock_calls))
+        self.assertIn("enqueued=1", out.getvalue())
+        self.assertIn("skipped_missing_media_file=1", out.getvalue())
+
+    def test_backfill_command_repairs_missing_sprite_file(self):
+        media = self._attach_media_file(create_test_media(self.user))
+        Media.objects.filter(pk=media.pk).update(sprites="original/thumbnails/missing-sprites.jpg")
+        media.refresh_from_db()
+
+        out = StringIO()
+        with patch("files.management.commands.backfill_video_sprites.produce_sprite_from_video.delay") as delay:
+            call_command(
+                "backfill_video_sprites",
+                repair_missing_files=True,
+                user_id=self.user.id,
+                min_age_minutes=0,
+                sleep=0,
+                stdout=out,
+            )
+
+        delay.assert_called_once_with(media.friendly_token)
+
+    def test_backfill_command_default_skips_broken_sprite_reference(self):
+        # A row whose sprites value points at a missing file looks "done" to the
+        # default query and must be skipped unless --repair-missing-files is passed.
+        media = self._attach_media_file(create_test_media(self.user))
+        Media.objects.filter(pk=media.pk).update(sprites="original/thumbnails/missing-sprites.jpg")
+
+        with patch("files.management.commands.backfill_video_sprites.produce_sprite_from_video.delay") as delay:
+            call_command(
+                "backfill_video_sprites",
+                user_id=self.user.id,
+                min_age_minutes=0,
+                sleep=0,
+                stdout=StringIO(),
+            )
+
+        delay.assert_not_called()
+
+    def test_backfill_command_skips_unencoded_videos_by_default(self):
+        encoded = self._attach_media_file(create_test_media(self.user))
+        Media.objects.filter(pk=encoded.pk).update(encoding_status="success")
+        for status in ("pending", "running", "fail"):
+            pending = self._attach_media_file(create_test_media(self.user))
+            Media.objects.filter(pk=pending.pk).update(encoding_status=status)
+
+        with patch("files.management.commands.backfill_video_sprites.produce_sprite_from_video.delay") as delay:
+            call_command(
+                "backfill_video_sprites",
+                user_id=self.user.id,
+                min_age_minutes=0,
+                sleep=0,
+                stdout=StringIO(),
+            )
+
+        # Only the successfully-encoded video is targeted.
+        delay.assert_called_once_with(encoded.friendly_token)
+
+    def test_backfill_command_include_unencoded_targets_all_statuses(self):
+        tokens = []
+        for status in ("success", "pending", "running"):
+            media = self._attach_media_file(create_test_media(self.user))
+            Media.objects.filter(pk=media.pk).update(encoding_status=status)
+            tokens.append(media.friendly_token)
+
+        with patch("files.management.commands.backfill_video_sprites.produce_sprite_from_video.delay") as delay:
+            call_command(
+                "backfill_video_sprites",
+                include_unencoded=True,
+                user_id=self.user.id,
+                min_age_minutes=0,
+                sleep=0,
+                stdout=StringIO(),
+            )
+
+        enqueued_tokens = {call.args[0] for call in delay.mock_calls}
+        self.assertEqual(enqueued_tokens, set(tokens))

--- a/frontend/src/features/add-media/AddMediaPage.jsx
+++ b/frontend/src/features/add-media/AddMediaPage.jsx
@@ -28,7 +28,14 @@ import BulkUploadPage from './bulk-upload/components/BulkUploadPage.jsx';
 import { BulkStepperSlot } from './bulk-upload/components/BulkStepperSlot';
 import useBulkUploadStore from './bulk-upload/useBulkUploadStore';
 
-const EMPTY_SINGLE_PREVIEW = { title: '', company: '', country: '', category: null, thumbnailUrl: '' };
+const EMPTY_SINGLE_PREVIEW = {
+	title: '',
+	company: '',
+	country: '',
+	category: null,
+	thumbnailUrl: '',
+	thumbnailFrame: null,
+};
 
 export class AddMediaPage extends Page {
 	static contextType = UserContext;
@@ -499,7 +506,9 @@ export class AddMediaPage extends Page {
 				}
 				const thumbnailUrl = data && (data.thumbnail_url || data.poster_url);
 				if (thumbnailUrl) {
-					this.setState((state) => ({ singlePreview: { ...state.singlePreview, thumbnailUrl } }));
+					this.setState((state) => ({
+						singlePreview: { ...state.singlePreview, thumbnailUrl, thumbnailFrame: null },
+					}));
 				}
 			})
 			.catch(() => {
@@ -669,6 +678,7 @@ export class AddMediaPage extends Page {
 									country={singlePreview.country}
 									category={singlePreview.category}
 									thumbnailUrl={singlePreview.thumbnailUrl}
+									thumbnailFrame={singlePreview.thumbnailFrame}
 									views={0}
 									className="min-w-0"
 								/>

--- a/frontend/src/features/add-media/AddMediaPage.jsx
+++ b/frontend/src/features/add-media/AddMediaPage.jsx
@@ -507,7 +507,12 @@ export class AddMediaPage extends Page {
 				const thumbnailUrl = data && (data.thumbnail_url || data.poster_url);
 				if (thumbnailUrl) {
 					this.setState((state) => ({
-						singlePreview: { ...state.singlePreview, thumbnailUrl, thumbnailFrame: null },
+						singlePreview: {
+							...state.singlePreview,
+							thumbnailUrl: state.singlePreview.thumbnailFrame
+								? state.singlePreview.thumbnailUrl
+								: thumbnailUrl,
+						},
 					}));
 				}
 			})

--- a/frontend/src/features/add-media/bulk-upload/buildSubmitItems.js
+++ b/frontend/src/features/add-media/bulk-upload/buildSubmitItems.js
@@ -8,7 +8,13 @@
  * appended when enabled, and omitted (→ False) otherwise — matching the native
  * checkboxes the single-upload form renders.
  */
-export function buildEditFormData({ metadata = {}, posterFile = null, action = 'submit', csrfToken = '' }) {
+export function buildEditFormData({
+	metadata = {},
+	posterFile = null,
+	thumbnailTime = null,
+	action = 'submit',
+	csrfToken = '',
+}) {
 	const data = new FormData();
 	data.set('csrfmiddlewaretoken', csrfToken || '');
 	data.set('action', action);
@@ -72,6 +78,8 @@ export function buildEditFormData({ metadata = {}, posterFile = null, action = '
 
 	if (posterFile) {
 		data.set('uploaded_poster', posterFile);
+	} else if (thumbnailTime != null) {
+		data.set('thumbnail_time', String(thumbnailTime));
 	}
 
 	return data;

--- a/frontend/src/features/add-media/bulk-upload/buildSubmitItems.test.js
+++ b/frontend/src/features/add-media/bulk-upload/buildSubmitItems.test.js
@@ -78,6 +78,24 @@ describe('buildEditFormData', () => {
 		const data = buildEditFormData({ metadata: createDefaultMetadata(), posterFile: poster });
 		expect(data.get('reported_times')).toBe('0');
 		expect(data.get('uploaded_poster')).toBeInstanceOf(File);
+		expect(data.get('thumbnail_time')).toBeNull();
+	});
+
+	it('sends thumbnail_time when a frame is selected without a poster file', () => {
+		const data = buildEditFormData({ metadata: createDefaultMetadata(), thumbnailTime: 20 });
+		expect(data.get('thumbnail_time')).toBe('20');
+		expect(data.get('uploaded_poster')).toBeNull();
+	});
+
+	it('prefers uploaded_poster over thumbnail_time when both are present', () => {
+		const poster = new File(['x'], 'poster.png', { type: 'image/png' });
+		const data = buildEditFormData({
+			metadata: createDefaultMetadata(),
+			posterFile: poster,
+			thumbnailTime: 20,
+		});
+		expect(data.get('uploaded_poster')).toBeInstanceOf(File);
+		expect(data.get('thumbnail_time')).toBeNull();
 	});
 });
 

--- a/frontend/src/features/add-media/bulk-upload/components/FileQuickPreview.jsx
+++ b/frontend/src/features/add-media/bulk-upload/components/FileQuickPreview.jsx
@@ -30,6 +30,7 @@ export function FileQuickPreview({ file, options = {}, className = '' }) {
 		<QuickPreview
 			title={meta.title}
 			thumbnailUrl={posterPreviewUrl || file.thumbnailUrl || ''}
+			thumbnailFrame={file.thumbnailFrame}
 			subtitle={userName || ''}
 			country={countryLabel}
 			category={previewCategory}

--- a/frontend/src/features/add-media/bulk-upload/components/step2/FileCard.jsx
+++ b/frontend/src/features/add-media/bulk-upload/components/step2/FileCard.jsx
@@ -43,7 +43,7 @@ const SECTION_META = {
 	thumbnail: {
 		title: 'Thumbnail Image Upload',
 		description:
-			'This image will display when your video isn’t autoplaying. You can select an auto-generated image, upload a custom image or choose a still frame from your video.',
+			'This image displays when your video isn’t autoplaying. Use the auto-generated thumbnail, upload a custom image, or choose a still frame from your video.',
 	},
 	other: { title: 'Other Details' },
 	final: { title: 'Final Settings' },
@@ -59,6 +59,7 @@ const SECTION_META = {
 export function FileCard({ file, subStep, options, errors = {}, onClearErrors }) {
 	const setMetadata = useBulkUploadStore((state) => state.setMetadata);
 	const setPosterFile = useBulkUploadStore((state) => state.setPosterFile);
+	const setThumbnailTime = useBulkUploadStore((state) => state.setThumbnailTime);
 	const { deleteFile } = useBulkUploadActions();
 	const { isTrustedUser, canUseAdminSettings } = useBulkUploadConfig();
 	const meta = file.metadata;
@@ -139,8 +140,14 @@ export function FileCard({ file, subStep, options, errors = {}, onClearErrors })
 					) : null}
 					{subStep === 'thumbnail' ? (
 						<ThumbnailUploadField
+							currentThumbnailTime={file.thumbnailTime ?? ''}
+							friendlyToken={file.friendlyToken ?? ''}
+							onFrameSelect={(seconds, frame) => setThumbnailTime(file.id, seconds, frame)}
 							posterFile={file.posterFile}
+							posterUrl={file.thumbnailUrl ?? ''}
 							onFileSelected={(posterFile) => setPosterFile(file.id, posterFile)}
+							thumbnailFrame={file.thumbnailFrame}
+							thumbnailTime={file.thumbnailTime}
 						/>
 					) : null}
 					{subStep === 'other' ? (

--- a/frontend/src/features/add-media/bulk-upload/components/step2/FileCard.jsx
+++ b/frontend/src/features/add-media/bulk-upload/components/step2/FileCard.jsx
@@ -140,7 +140,6 @@ export function FileCard({ file, subStep, options, errors = {}, onClearErrors })
 					) : null}
 					{subStep === 'thumbnail' ? (
 						<ThumbnailUploadField
-							currentThumbnailTime={file.thumbnailTime ?? ''}
 							friendlyToken={file.friendlyToken ?? ''}
 							onFrameSelect={(seconds, frame) => setThumbnailTime(file.id, seconds, frame)}
 							posterFile={file.posterFile}

--- a/frontend/src/features/add-media/bulk-upload/hooks/useSubmitBulk.js
+++ b/frontend/src/features/add-media/bulk-upload/hooks/useSubmitBulk.js
@@ -22,6 +22,7 @@ export function useSubmitBulk() {
 					const body = buildEditFormData({
 						metadata: file.metadata,
 						posterFile: file.posterFile,
+						thumbnailTime: file.thumbnailTime,
 						action,
 						csrfToken,
 					});

--- a/frontend/src/features/add-media/bulk-upload/useBulkUploadStore.js
+++ b/frontend/src/features/add-media/bulk-upload/useBulkUploadStore.js
@@ -69,6 +69,8 @@ const useBulkUploadStore = create((set) => ({
 						thumbnailUrl: null,
 						// Chosen thumbnail image File, sent as uploaded_poster on submit.
 						posterFile: null,
+						thumbnailTime: null,
+						thumbnailFrame: null,
 						error: null,
 						metadata: createDefaultMetadata(),
 					},
@@ -95,7 +97,16 @@ const useBulkUploadStore = create((set) => ({
 
 	setPosterFile: (id, posterFile) =>
 		set((state) => ({
-			files: state.files.map((file) => (file.id === id ? { ...file, posterFile } : file)),
+			files: state.files.map((file) =>
+				file.id === id ? { ...file, posterFile, thumbnailTime: null, thumbnailFrame: null } : file
+			),
+		})),
+
+	setThumbnailTime: (id, thumbnailTime, thumbnailFrame = null) =>
+		set((state) => ({
+			files: state.files.map((file) =>
+				file.id === id ? { ...file, thumbnailTime, thumbnailFrame, posterFile: null } : file
+			),
 		})),
 
 	setStep: (currentStep) => set({ currentStep }),

--- a/frontend/src/features/add-media/bulk-upload/useBulkUploadStore.test.js
+++ b/frontend/src/features/add-media/bulk-upload/useBulkUploadStore.test.js
@@ -24,6 +24,41 @@ describe('useBulkUploadStore', () => {
 		expect(file.metadata.title).toBe('Hi');
 	});
 
+	it('keeps per-file poster upload and frame selection mutually exclusive', () => {
+		const { addFile, setPosterFile, setThumbnailTime } = useBulkUploadStore.getState();
+		const poster = new File(['poster'], 'poster.png', { type: 'image/png' });
+		const frame = { index: 2, seconds: 20, spritesUrl: '/sprites.jpg', rowsInSheet: 3 };
+
+		addFile({ id: 4, name: 'd.mp4', sizeBytes: 1 });
+		addFile({ id: 5, name: 'e.mp4', sizeBytes: 1 });
+
+		setPosterFile(4, poster);
+		expect(useBulkUploadStore.getState().files.find((file) => file.id === 4)).toMatchObject({
+			posterFile: poster,
+			thumbnailTime: null,
+			thumbnailFrame: null,
+		});
+
+		setThumbnailTime(4, 20, frame);
+		expect(useBulkUploadStore.getState().files.find((file) => file.id === 4)).toMatchObject({
+			posterFile: null,
+			thumbnailTime: 20,
+			thumbnailFrame: frame,
+		});
+		expect(useBulkUploadStore.getState().files.find((file) => file.id === 5)).toMatchObject({
+			posterFile: null,
+			thumbnailTime: null,
+			thumbnailFrame: null,
+		});
+
+		setPosterFile(4, poster);
+		expect(useBulkUploadStore.getState().files.find((file) => file.id === 4)).toMatchObject({
+			posterFile: poster,
+			thumbnailTime: null,
+			thumbnailFrame: null,
+		});
+	});
+
 	it('removes files', () => {
 		const { addFile, removeFile } = useBulkUploadStore.getState();
 		addFile({ id: 3, name: 'c.mp4', sizeBytes: 1 });

--- a/frontend/src/features/add-media/single-upload/SingleUploadPage.jsx
+++ b/frontend/src/features/add-media/single-upload/SingleUploadPage.jsx
@@ -53,9 +53,22 @@ function SingleUploadContent({
 		if (preview.thumbnailUrl) {
 			next.thumbnailUrl = preview.thumbnailUrl;
 		}
-
+		if (Object.prototype.hasOwnProperty.call(preview, 'thumbnailUrl') && preview.thumbnailUrl === '') {
+			next.thumbnailUrl = '';
+		}
+		if (Object.prototype.hasOwnProperty.call(preview, 'thumbnailFrame')) {
+			next.thumbnailFrame = preview.thumbnailFrame;
+		}
 		onPreviewChange?.(next);
-	}, [onPreviewChange, preview.title, preview.company, countryLabel, categoryLabel, preview.thumbnailUrl]);
+	}, [
+		onPreviewChange,
+		preview.title,
+		preview.company,
+		countryLabel,
+		categoryLabel,
+		preview.thumbnailUrl,
+		preview.thumbnailFrame,
+	]);
 
 	return (
 		<div className="single-upload-page">
@@ -112,6 +125,7 @@ function SingleUploadContent({
 					mediaCountries={mediaCountries}
 					mediaLanguages={mediaLanguages}
 					topics={topics}
+					uploadedMedia={uploadedMedia}
 					onPreviewChange={handleFormPreviewChange}
 				/>
 			) : null}

--- a/frontend/src/features/add-media/single-upload/SingleUploadPage.test.jsx
+++ b/frontend/src/features/add-media/single-upload/SingleUploadPage.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SingleUploadPage } from './SingleUploadPage';
 import useSingleUploadStore from './useSingleUploadStore';
@@ -47,9 +47,29 @@ vi.mock('../../shared/components/upload-media', async (importOriginal) => {
 	};
 });
 
+class MockImage {
+	static instances = [];
+
+	constructor() {
+		this.naturalHeight = 450;
+		MockImage.instances.push(this);
+	}
+
+	set src(value) {
+		this._src = value;
+	}
+
+	get src() {
+		return this._src;
+	}
+}
+
+const OriginalImage = global.Image;
+
 describe('SingleUploadPage', () => {
 	beforeEach(() => {
 		useSingleUploadStore.getState().reset();
+		MockImage.instances = [];
 	});
 
 	function renderUploadedPage(props = {}) {
@@ -57,6 +77,7 @@ describe('SingleUploadPage', () => {
 	}
 
 	afterEach(() => {
+		global.Image = OriginalImage;
 		vi.restoreAllMocks();
 		vi.unstubAllGlobals();
 	});
@@ -272,6 +293,40 @@ describe('SingleUploadPage', () => {
 		expect(
 			screen.queryByText('Please fill in all required fields before sharing your media.')
 		).not.toBeInTheDocument();
+	});
+
+	it('submits a selected video frame as thumbnail_time', async () => {
+		const user = userEvent.setup();
+		global.Image = MockImage;
+		Element.prototype.scrollIntoView = vi.fn();
+		const fetchMock = vi.fn().mockResolvedValue({
+			ok: false,
+			status: 500,
+			json: async () => ({}),
+		});
+		vi.stubGlobal('fetch', fetchMock);
+
+		renderUploadedPage({
+			uploadedMedia: {
+				duration: 80,
+				editUrl: '/media/test/edit',
+				friendlyToken: 'abc123',
+				spritesUrl: '/sprites.jpg',
+			},
+		});
+
+		await user.click(screen.getByRole('tab', { name: 'CHOOSE FROM VIDEO' }));
+		act(() => {
+			MockImage.instances[0].onload();
+		});
+		await user.click(await screen.findByRole('button', { name: /0:20/i }));
+		await user.click(screen.getByRole('button', { name: 'Save as Draft' }));
+
+		await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+		const submittedBody = fetchMock.mock.calls[0][1].body;
+
+		expect(submittedBody.get('thumbnail_time')).toBe('20');
+		expect(submittedBody.get('uploaded_poster')).toBeNull();
 	});
 
 	it('submits for review with the submit action', async () => {

--- a/frontend/src/features/add-media/single-upload/components/FieldGroup.jsx
+++ b/frontend/src/features/add-media/single-upload/components/FieldGroup.jsx
@@ -1,17 +1,22 @@
 import { Card, Text } from '../../../shared/components';
 
-export function FieldGroup({ children, description, title }) {
+export function FieldGroup({ children, description, headerAside = null, title }) {
 	return (
 		<Card className="py-8 px-6">
-			<Text variant="h6-medium" as="h2" className="m-0 text-text-strong">
-				{title}
-			</Text>
+			<div className="flex items-start justify-between gap-6">
+				<div className="min-w-0">
+					<Text variant="h6-medium" as="h2" className="m-0 text-text-strong">
+						{title}
+					</Text>
 
-			{description ? (
-				<Text variant="body-14" color="meta" className="m-0 mt-2">
-					{description}
-				</Text>
-			) : null}
+					{description ? (
+						<Text variant="body-14" color="meta" className="m-0 mt-2">
+							{description}
+						</Text>
+					) : null}
+				</div>
+				{headerAside ? <div className="hidden shrink-0 md:block">{headerAside}</div> : null}
+			</div>
 
 			<div className="my-6 border-b border-b-border-divider" />
 

--- a/frontend/src/features/add-media/single-upload/components/MediaDetailsForm.jsx
+++ b/frontend/src/features/add-media/single-upload/components/MediaDetailsForm.jsx
@@ -23,6 +23,7 @@ export function MediaDetailsForm({
 	mediaLanguages = [],
 	topics = [],
 	onPreviewChange,
+	uploadedMedia = null,
 }) {
 	const formRef = useRef(null);
 	const submitMutation = useSubmitSingle();
@@ -41,7 +42,7 @@ export function MediaDetailsForm({
 			return undefined;
 		}
 		const url = URL.createObjectURL(selectedThumbnailFile);
-		onPreviewChange({ thumbnailUrl: url });
+		onPreviewChange({ thumbnailUrl: url, thumbnailFrame: null });
 		return () => URL.revokeObjectURL(url);
 	}, [selectedThumbnailFile, onPreviewChange]);
 
@@ -60,6 +61,11 @@ export function MediaDetailsForm({
 	function onFileChanged(files) {
 		const [file] = files;
 		singleUpload.setSelectedThumbnailFile(file ?? null);
+	}
+
+	function onFrameSelect(seconds, frame) {
+		singleUpload.setThumbnailTime(seconds);
+		onPreviewChange?.({ thumbnailUrl: '', thumbnailFrame: frame });
 	}
 
 	function validateForm() {
@@ -136,7 +142,12 @@ export function MediaDetailsForm({
 
 		singleUpload.setSubmitError('');
 		submitMutation.mutate(
-			{ action, form, thumbnailFile: singleUpload.selectedThumbnailFile },
+			{
+				action,
+				form,
+				thumbnailFile: singleUpload.selectedThumbnailFile,
+				thumbnailTime: singleUpload.thumbnailTime,
+			},
 			{
 				onSuccess: (data) => {
 					window.location.assign(data.url);
@@ -205,9 +216,16 @@ export function MediaDetailsForm({
 			<BasicDetailsForm singleUpload={singleUpload} />
 
 			<ThumbnailImageUpload
+				currentThumbnailTime={uploadedMedia?.thumbnailTime ?? ''}
+				duration={uploadedMedia?.duration ?? ''}
+				friendlyToken={uploadedMedia?.friendlyToken ?? ''}
 				lastSelectedThumbnailFile={singleUpload.lastSelectedThumbnailFile}
 				onFileChanged={onFileChanged}
+				onFrameSelect={onFrameSelect}
+				posterUrl={uploadedMedia?.posterUrl ?? ''}
 				selectedThumbnailFile={singleUpload.selectedThumbnailFile}
+				spriteSecs={uploadedMedia?.spriteNumSecs ?? ''}
+				spritesUrl={uploadedMedia?.spritesUrl ?? ''}
 			/>
 
 			<OtherDetailsForm

--- a/frontend/src/features/add-media/single-upload/components/ThumbnailImageUpload.jsx
+++ b/frontend/src/features/add-media/single-upload/components/ThumbnailImageUpload.jsx
@@ -1,11 +1,21 @@
 import { useEffect, useState } from 'react';
-import { TabContent, TabView } from '../../../shared/components';
-import { MediaDropzone } from '../../../shared/components/MediaDropzone';
-import { Text } from '../../../shared/components/Text';
+import { ThumbnailUploadField } from '../../../shared/components/upload-media';
+import { SpriteFrame } from '../../../shared/components/upload-media/ChooseFromVideo/SpriteFrame';
 import { FieldGroup } from './FieldGroup';
 
-export function ThumbnailImageUpload({ lastSelectedThumbnailFile, onFileChanged, selectedThumbnailFile }) {
+export function ThumbnailImageUpload({
+	currentThumbnailTime = '',
+	duration = '',
+	friendlyToken = '',
+	onFileChanged,
+	onFrameSelect,
+	posterUrl = '',
+	selectedThumbnailFile,
+	spriteSecs = '',
+	spritesUrl = '',
+}) {
 	const [previewUrl, setPreviewUrl] = useState('');
+	const [selectedVideoFrame, setSelectedVideoFrame] = useState(null);
 
 	useEffect(() => {
 		if (!selectedThumbnailFile || typeof URL === 'undefined' || typeof URL.createObjectURL !== 'function') {
@@ -13,56 +23,63 @@ export function ThumbnailImageUpload({ lastSelectedThumbnailFile, onFileChanged,
 			return undefined;
 		}
 
+		setSelectedVideoFrame(null);
 		const nextPreviewUrl = URL.createObjectURL(selectedThumbnailFile);
 		setPreviewUrl(nextPreviewUrl);
 
 		return () => URL.revokeObjectURL(nextPreviewUrl);
 	}, [selectedThumbnailFile]);
 
+	function handleFrameSelect(seconds, frame) {
+		setSelectedVideoFrame(frame);
+		onFrameSelect?.(seconds, frame);
+	}
+
+	function handleFileSelected(file) {
+		onFileChanged?.(file ? [file] : []);
+	}
+
+	const headerPreview = selectedVideoFrame?.spritesUrl ? (
+		<SpriteFrame
+			index={selectedVideoFrame.index}
+			label={`Selected video frame at ${selectedVideoFrame.mmss}`}
+			rowsInSheet={selectedVideoFrame.rowsInSheet}
+			selected
+			spritesUrl={selectedVideoFrame.spritesUrl}
+			variant="preview"
+		/>
+	) : previewUrl ? (
+		<img
+			src={previewUrl}
+			alt="Selected thumbnail header preview"
+			className="aspect-video w-[150px] rounded-ds-4 object-cover"
+		/>
+	) : posterUrl ? (
+		<img
+			src={posterUrl}
+			alt="Current thumbnail preview"
+			className="aspect-video w-[150px] rounded-ds-4 object-cover"
+		/>
+	) : null;
+
 	return (
 		<FieldGroup
 			title="Thumbnail Image Upload"
-			description="This image will display when your video isn’t autoplaying. You can select an auto-generated image, upload a custom image or choose a still frame from your video."
+			description="This image displays when your video isn’t autoplaying. Use the auto-generated thumbnail, upload a custom image, or choose a still frame from your video."
+			headerAside={headerPreview}
 		>
-			<div>
-				<TabView
-					tabMode="wrap"
-					triggerClassName="rounded-none py-3 px-size-22 text-text-tab-trigger"
-					triggerSelectedColor="bg-bg-tab-trigger-selected"
-					panelClassName="mt-8"
-					aria-label="Upload media type"
-					defaultSelectedTab="upload-thumbnail"
-				>
-					<TabContent title="UPLOAD THUMBNAIL" value="upload-thumbnail">
-						<MediaDropzone
-							accept="image/*"
-							buttonVariant="secondary"
-							iconName={null}
-							multiple={false}
-							name="uploaded_poster"
-							aria-label="Choose thumbnail image"
-							onFilesSelected={onFileChanged}
-						/>
-
-						{previewUrl ? (
-							<img
-								src={previewUrl}
-								alt="Selected thumbnail preview"
-								className="mt-4 aspect-video w-full max-w-[280px] rounded-ds-4 object-cover"
-							/>
-						) : null}
-
-						{lastSelectedThumbnailFile ? (
-							<Text variant="body-14" className="m-0 mt-4 text-cinemata-pacific-deep-300">
-								Last selected: {lastSelectedThumbnailFile}
-							</Text>
-						) : null}
-					</TabContent>
-					<TabContent title="CHOOSE FROM VIDEO" value="choose-from-video">
-						<p>Choose from video</p>
-					</TabContent>
-				</TabView>
-			</div>
+			<ThumbnailUploadField
+				currentThumbnailTime={currentThumbnailTime}
+				duration={duration}
+				friendlyToken={friendlyToken}
+				onFileSelected={handleFileSelected}
+				onFrameSelect={handleFrameSelect}
+				posterFile={selectedThumbnailFile}
+				posterPreviewClassName="mt-4 aspect-video w-full max-w-[280px] rounded-ds-4 object-cover md:hidden"
+				posterUrl={posterUrl}
+				spriteSecs={spriteSecs}
+				spritesUrl={spritesUrl}
+			/>
 		</FieldGroup>
 	);
 }

--- a/frontend/src/features/add-media/single-upload/components/ThumbnailImageUpload.test.jsx
+++ b/frontend/src/features/add-media/single-upload/components/ThumbnailImageUpload.test.jsx
@@ -1,0 +1,74 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThumbnailImageUpload } from './ThumbnailImageUpload';
+
+class MockImage {
+	static instances = [];
+
+	constructor() {
+		this.naturalHeight = 450;
+		MockImage.instances.push(this);
+	}
+
+	set src(value) {
+		this._src = value;
+	}
+
+	get src() {
+		return this._src;
+	}
+}
+
+describe('ThumbnailImageUpload', () => {
+	const OriginalImage = global.Image;
+
+	beforeEach(() => {
+		MockImage.instances = [];
+		global.Image = MockImage;
+		Element.prototype.scrollIntoView = vi.fn();
+	});
+
+	afterEach(() => {
+		global.Image = OriginalImage;
+	});
+
+	it('renders the choose-from-video frame strip and reports selected seconds', async () => {
+		const user = userEvent.setup();
+		const onFrameSelect = vi.fn();
+
+		render(
+			<ThumbnailImageUpload
+				duration={80}
+				friendlyToken="abc123"
+				onFileChanged={vi.fn()}
+				onFrameSelect={onFrameSelect}
+				spritesUrl="/sprites.jpg"
+			/>
+		);
+
+		await user.click(screen.getByRole('tab', { name: 'CHOOSE FROM VIDEO' }));
+
+		act(() => {
+			MockImage.instances[0].onload();
+		});
+
+		await waitFor(() => expect(screen.getByRole('button', { name: /0:20/i })).toBeInTheDocument());
+		await user.click(screen.getByRole('button', { name: /0:20/i }));
+
+		expect(onFrameSelect).toHaveBeenCalledWith(
+			20,
+			expect.objectContaining({ index: 2, rowsInSheet: 5, seconds: 20, spritesUrl: '/sprites.jpg' })
+		);
+		expect(screen.getByText('0:20')).toBeInTheDocument();
+	});
+
+	it('shows the loading wording when sprite data is unavailable', async () => {
+		const user = userEvent.setup();
+
+		render(<ThumbnailImageUpload friendlyToken="" onFileChanged={vi.fn()} onFrameSelect={vi.fn()} />);
+
+		await user.click(screen.getByRole('tab', { name: 'CHOOSE FROM VIDEO' }));
+
+		expect(screen.getByText(/Please hang tight when the video loads/i)).toBeInTheDocument();
+	});
+});

--- a/frontend/src/features/add-media/single-upload/hooks/useSubmitSingle.js
+++ b/frontend/src/features/add-media/single-upload/hooks/useSubmitSingle.js
@@ -6,13 +6,15 @@ import { useMutation } from '@tanstack/react-query';
  */
 export function useSubmitSingle() {
 	return useMutation({
-		mutationFn: async ({ action = 'submit', form, thumbnailFile }) => {
+		mutationFn: async ({ action = 'submit', form, thumbnailFile, thumbnailTime = null }) => {
 			const body = new FormData(form);
 			body.set('action', action);
 
 			body.delete('uploaded_poster');
 			if (thumbnailFile) {
 				body.set('uploaded_poster', thumbnailFile);
+			} else if (thumbnailTime != null) {
+				body.set('thumbnail_time', String(thumbnailTime));
 			}
 
 			const response = await fetch(form.action, {

--- a/frontend/src/features/add-media/single-upload/hooks/useSubmitSingle.js
+++ b/frontend/src/features/add-media/single-upload/hooks/useSubmitSingle.js
@@ -11,6 +11,7 @@ export function useSubmitSingle() {
 			body.set('action', action);
 
 			body.delete('uploaded_poster');
+			body.delete('thumbnail_time');
 			if (thumbnailFile) {
 				body.set('uploaded_poster', thumbnailFile);
 			} else if (thumbnailTime != null) {

--- a/frontend/src/features/add-media/single-upload/useSingleUploadStore.js
+++ b/frontend/src/features/add-media/single-upload/useSingleUploadStore.js
@@ -55,6 +55,7 @@ export function createDefaultSingleUploadState() {
 		// Thumbnail
 		selectedThumbnailFile: null,
 		lastSelectedThumbnailFile: '',
+		thumbnailTime: null,
 
 		// Form state
 		errors: {},
@@ -121,7 +122,17 @@ const useSingleUploadStore = create((set) => ({
 
 	// Thumbnail
 	setSelectedThumbnailFile: (selectedThumbnailFile) =>
-		set({ selectedThumbnailFile, lastSelectedThumbnailFile: selectedThumbnailFile?.name ?? '' }),
+		set({
+			selectedThumbnailFile,
+			lastSelectedThumbnailFile: selectedThumbnailFile?.name ?? '',
+			thumbnailTime: null,
+		}),
+	setThumbnailTime: (thumbnailTime) =>
+		set({
+			thumbnailTime,
+			selectedThumbnailFile: null,
+			lastSelectedThumbnailFile: '',
+		}),
 
 	// Form state
 	setErrors: (errors) => set({ errors }),

--- a/frontend/src/features/add-media/single-upload/useSingleUploadStore.test.js
+++ b/frontend/src/features/add-media/single-upload/useSingleUploadStore.test.js
@@ -12,8 +12,35 @@ describe('useSingleUploadStore', () => {
 		expect(state.mediaStatus).toBe('public');
 		expect(state.noLicense).toBe(true);
 		expect(state.selectedThumbnailFile).toBeNull();
+		expect(state.thumbnailTime).toBeNull();
 		expect(state.selectedLicenseId).toBe('1');
 		expect(state.selectedLicenseFields).toEqual({ commercial: 'yes', derivatives: 'yes' });
+	});
+
+	it('keeps custom thumbnail upload and frame selection mutually exclusive', () => {
+		const store = useSingleUploadStore.getState();
+		const file = new File(['poster'], 'poster.png', { type: 'image/png' });
+
+		store.setSelectedThumbnailFile(file);
+		expect(useSingleUploadStore.getState()).toMatchObject({
+			selectedThumbnailFile: file,
+			lastSelectedThumbnailFile: 'poster.png',
+			thumbnailTime: null,
+		});
+
+		store.setThumbnailTime(20);
+		expect(useSingleUploadStore.getState()).toMatchObject({
+			selectedThumbnailFile: null,
+			lastSelectedThumbnailFile: '',
+			thumbnailTime: 20,
+		});
+
+		store.setSelectedThumbnailFile(file);
+		expect(useSingleUploadStore.getState()).toMatchObject({
+			selectedThumbnailFile: file,
+			lastSelectedThumbnailFile: 'poster.png',
+			thumbnailTime: null,
+		});
 	});
 
 	it('resets password when restricted status is disabled', () => {

--- a/frontend/src/features/add-media/utils/helpers.js
+++ b/frontend/src/features/add-media/utils/helpers.js
@@ -101,9 +101,14 @@ export function getUploadedMediaDetails(response, fileName) {
 	}
 
 	return {
+		duration: response?.duration ?? '',
 		editUrl,
 		friendlyToken,
 		name: fileName || '',
+		posterUrl: response?.poster_url ?? '',
+		spritesUrl: response?.sprites_url ?? '',
+		spriteNumSecs: response?.sprite_num_secs ?? '',
+		thumbnailTime: response?.thumbnail_time ?? '',
 		viewUrl,
 	};
 }

--- a/frontend/src/features/shared/components/MovieItem/MovieItem.jsx
+++ b/frontend/src/features/shared/components/MovieItem/MovieItem.jsx
@@ -106,6 +106,7 @@ function MoviePoster({
 	link = '',
 	linkTitle = '',
 	showTopRightIcon = false,
+	thumbnailOverlay = null,
 }) {
 	const visibleLabel = [badge, duration].filter(Boolean).join(' ');
 	const linkLabel = [visibleLabel, linkTitle ? `Open ${linkTitle}` : 'Open movie details'].filter(Boolean).join(', ');
@@ -120,6 +121,8 @@ function MoviePoster({
 				loading="lazy"
 				decoding="async"
 			/>
+
+			{thumbnailOverlay ? <div className="absolute inset-0">{thumbnailOverlay}</div> : null}
 
 			{badge || duration ? (
 				<div className="absolute inset-x-2 bottom-2 flex items-center gap-2">
@@ -178,6 +181,7 @@ export function HorizontalMovieItem({
 	posterClassName = 'aspect-video w-[180px]',
 	subtitle = '',
 	subtitleLink = '',
+	thumbnailOverlay = null,
 	title = 'Movie Title',
 }) {
 	const useStandaloneLinks = Boolean(subtitleLink);
@@ -199,6 +203,7 @@ export function HorizontalMovieItem({
 				link={useStandaloneLinks ? link : ''}
 				linkTitle={title}
 				className={cn(posterClassName, 'shrink-0')}
+				thumbnailOverlay={thumbnailOverlay}
 			/>
 
 			<div className="flex min-w-0 flex-1 flex-col gap-3">
@@ -228,6 +233,7 @@ export function VerticalMovieItem({
 	metadata = [],
 	subtitle = '',
 	subtitleLink = '',
+	thumbnailOverlay = null,
 	title = 'Movie Title',
 }) {
 	const useStandaloneLinks = Boolean(subtitleLink);
@@ -252,6 +258,7 @@ export function VerticalMovieItem({
 				linkTitle={title}
 				showTopRightIcon
 				className="aspect-video w-full"
+				thumbnailOverlay={thumbnailOverlay}
 			/>
 
 			<MovieCopy

--- a/frontend/src/features/shared/components/upload-media/ChooseFromVideo/ChooseFromVideo.jsx
+++ b/frontend/src/features/shared/components/upload-media/ChooseFromVideo/ChooseFromVideo.jsx
@@ -1,0 +1,46 @@
+import { FrameStrip } from './FrameStrip';
+import { useSpritePolling } from '../hooks/useSpritePolling';
+
+export function ChooseFromVideo({
+	currentThumbnailTime = '',
+	duration = '',
+	friendlyToken = '',
+	onFrameSelect,
+	posterUrl = '',
+	spriteSecs = '',
+	spritesUrl = '',
+}) {
+	const spriteData = useSpritePolling({
+		friendlyToken,
+		initialDuration: duration,
+		initialPosterUrl: posterUrl,
+		initialSpritesUrl: spritesUrl,
+		initialThumbnailTime: currentThumbnailTime,
+		initialSpriteNumSecs: spriteSecs,
+	});
+	const activeSpritesUrl = spriteData.spritesUrl || spritesUrl;
+	const activeDuration = spriteData.duration || duration;
+	const activeThumbnailTime = spriteData.thumbnailTime ?? currentThumbnailTime;
+	// Prefer the server-authoritative interval (must match how files/sprites.py spaced the
+	// tiles); fall back to the prop, then 10. Never assume a hardcoded interval here, or the
+	// chosen tile's timestamp won't match the frame the backend extracts for the poster.
+	const activeSpriteSecs = Number(spriteData.spriteNumSecs) || Number(spriteSecs) || 10;
+
+	function handleFrameSelect(frame) {
+		onFrameSelect?.({ ...frame, spritesUrl: activeSpritesUrl });
+	}
+
+	return (
+		<div className="flex min-w-0 max-w-full flex-col overflow-hidden">
+			<FrameStrip
+				currentThumbnailTime={activeThumbnailTime}
+				duration={activeDuration}
+				onFrameSelect={handleFrameSelect}
+				pending={spriteData.status === 'polling' || spriteData.status === 'idle'}
+				spriteSecs={activeSpriteSecs}
+				spritesUrl={activeSpritesUrl}
+				unavailable={spriteData.status === 'unavailable'}
+			/>
+		</div>
+	);
+}

--- a/frontend/src/features/shared/components/upload-media/ChooseFromVideo/FrameStrip.jsx
+++ b/frontend/src/features/shared/components/upload-media/ChooseFromVideo/FrameStrip.jsx
@@ -1,0 +1,126 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { cn } from '../../../utils/classNames';
+import { SpriteFrame } from './SpriteFrame';
+import { useSpriteFrames } from '../hooks/useSpriteFrames';
+
+function nearestFrameIndex(frames, currentSeconds, spriteSecs) {
+	if (!frames.length) {
+		return 0;
+	}
+
+	const index = Math.floor((Number(currentSeconds) || 0) / (Number(spriteSecs) || 10));
+	return Math.max(0, Math.min(index, frames.length - 1));
+}
+
+function placeholderMessage() {
+	return 'Please hang tight when the video loads...';
+}
+
+export function FrameStrip({
+	currentThumbnailTime = '',
+	duration,
+	onFrameSelect,
+	onSpriteStatusChange,
+	pending = false,
+	spriteSecs,
+	spritesUrl,
+	thumbnailInput,
+	unavailable = false,
+	uploadedPosterClearInput,
+}) {
+	const { frames, rowsInSheet, status } = useSpriteFrames({ spritesUrl, duration, spriteSecs });
+	const initialSelection = useMemo(
+		() => nearestFrameIndex(frames, currentThumbnailTime, spriteSecs),
+		[frames, currentThumbnailTime, spriteSecs]
+	);
+	const [selectedIndex, setSelectedIndex] = useState(initialSelection);
+	const selectedFrame = frames[selectedIndex] || frames[0] || null;
+	const selectedButtonRef = useRef(null);
+
+	useEffect(() => {
+		if (onSpriteStatusChange) {
+			onSpriteStatusChange(status);
+		}
+	}, [onSpriteStatusChange, status]);
+
+	useEffect(() => {
+		setSelectedIndex(initialSelection);
+	}, [initialSelection]);
+
+	useEffect(() => {
+		if (selectedButtonRef.current) {
+			selectedButtonRef.current.scrollIntoView({ block: 'nearest', inline: 'center' });
+		}
+	}, [selectedIndex]);
+
+	function selectFrame(frame) {
+		setSelectedIndex(frame.index);
+		const selectedFrameData = { ...frame, rowsInSheet };
+
+		if (thumbnailInput) {
+			thumbnailInput.value = String(frame.seconds);
+			thumbnailInput.dispatchEvent(new Event('input', { bubbles: true }));
+			thumbnailInput.dispatchEvent(new Event('change', { bubbles: true }));
+		}
+
+		if (uploadedPosterClearInput) {
+			uploadedPosterClearInput.checked = true;
+			uploadedPosterClearInput.dispatchEvent(new Event('change', { bubbles: true }));
+		}
+
+		if (onFrameSelect) {
+			onFrameSelect(selectedFrameData);
+		}
+	}
+
+	const showPlaceholder = unavailable || pending || status !== 'ready' || frames.length === 0;
+	const message = placeholderMessage();
+
+	return (
+		<div className="flex min-w-0 max-w-full flex-col gap-space-base overflow-hidden">
+			<div
+				className={cn(
+					'w-full min-w-0 max-w-full rounded-ds-4 border-2 border-border-scrollbar bg-bg-surface-muted',
+					showPlaceholder
+						? 'h-[56px]'
+						: 'flex h-[56px] items-start overflow-x-auto overflow-y-hidden p-size-4 [scrollbar-width:thin] [scrollbar-color:var(--border-scrollbar)_transparent] [&::-webkit-scrollbar]:h-[6px] [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-ds-full [&::-webkit-scrollbar-thumb]:bg-border-scrollbar'
+				)}
+			>
+				{showPlaceholder
+					? null
+					: frames.map((frame) => {
+							const selected = frame.index === selectedFrame?.index;
+
+							return (
+								<button
+									key={frame.index}
+									ref={selected ? selectedButtonRef : null}
+									aria-pressed={selected}
+									className={cn(
+										'h-[44px] w-[78.421px] shrink-0 cursor-pointer appearance-none border-0 bg-transparent p-0 shadow-none outline-none transition-opacity duration-150 focus-visible:ring-2 focus-visible:ring-ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-bg-surface-muted',
+										selected && 'rounded-ds-4 ring-2 ring-ring-focus'
+									)}
+									onClick={() => selectFrame(frame)}
+									type="button"
+								>
+									<SpriteFrame
+										index={frame.index}
+										label={`Select video frame at ${frame.mmss}`}
+										selected={selected}
+										spritesUrl={spritesUrl}
+									/>
+								</button>
+							);
+						})}
+			</div>
+			<p
+				className={cn(
+					'body-body-16-regular m-0 min-h-[24px]',
+					showPlaceholder ? 'text-text-accent' : 'w-full text-center text-text-muted md:w-[553px]'
+				)}
+			>
+				{showPlaceholder ? message : selectedFrame?.mmss}
+			</p>
+		</div>
+	);
+}

--- a/frontend/src/features/shared/components/upload-media/ChooseFromVideo/FrameStrip.jsx
+++ b/frontend/src/features/shared/components/upload-media/ChooseFromVideo/FrameStrip.jsx
@@ -8,12 +8,12 @@ function nearestFrameIndex(frames, currentSeconds, spriteSecs) {
 		return 0;
 	}
 
-	const index = Math.floor((Number(currentSeconds) || 0) / (Number(spriteSecs) || 10));
+	const index = Math.round((Number(currentSeconds) || 0) / (Number(spriteSecs) || 10));
 	return Math.max(0, Math.min(index, frames.length - 1));
 }
 
-function placeholderMessage() {
-	return 'Please hang tight when the video loads...';
+function placeholderMessage(unavailable) {
+	return unavailable ? 'Frame preview is unavailable for this video.' : 'Please hang tight when the video loads...';
 }
 
 export function FrameStrip({
@@ -74,7 +74,7 @@ export function FrameStrip({
 	}
 
 	const showPlaceholder = unavailable || pending || status !== 'ready' || frames.length === 0;
-	const message = placeholderMessage();
+	const message = placeholderMessage(unavailable);
 
 	return (
 		<div className="flex min-w-0 max-w-full flex-col gap-space-base overflow-hidden">

--- a/frontend/src/features/shared/components/upload-media/ChooseFromVideo/FrameStrip.jsx
+++ b/frontend/src/features/shared/components/upload-media/ChooseFromVideo/FrameStrip.jsx
@@ -57,7 +57,7 @@ export function FrameStrip({
 
 	function selectFrame(frame) {
 		setSelectedIndex(frame.index);
-		const selectedFrameData = { ...frame, rowsInSheet };
+		const selectedFrameData = { ...frame, rowsInSheet, spritesUrl };
 
 		if (thumbnailInput) {
 			thumbnailInput.value = String(frame.seconds);

--- a/frontend/src/features/shared/components/upload-media/ChooseFromVideo/FrameStrip.jsx
+++ b/frontend/src/features/shared/components/upload-media/ChooseFromVideo/FrameStrip.jsx
@@ -12,8 +12,10 @@ function nearestFrameIndex(frames, currentSeconds, spriteSecs) {
 	return Math.max(0, Math.min(index, frames.length - 1));
 }
 
-function placeholderMessage(unavailable) {
-	return unavailable ? 'Frame preview is unavailable for this video.' : 'Please hang tight when the video loads...';
+function placeholderMessage(unavailable, status) {
+	return unavailable || status === 'error'
+		? 'Frame preview is unavailable for this video.'
+		: 'Please hang tight when the video loads...';
 }
 
 export function FrameStrip({
@@ -74,7 +76,7 @@ export function FrameStrip({
 	}
 
 	const showPlaceholder = unavailable || pending || status !== 'ready' || frames.length === 0;
-	const message = placeholderMessage(unavailable);
+	const message = placeholderMessage(unavailable, status);
 
 	return (
 		<div className="flex min-w-0 max-w-full flex-col gap-space-base overflow-hidden">

--- a/frontend/src/features/shared/components/upload-media/ChooseFromVideo/FrameStrip.test.jsx
+++ b/frontend/src/features/shared/components/upload-media/ChooseFromVideo/FrameStrip.test.jsx
@@ -70,7 +70,7 @@ describe('FrameStrip', () => {
 		});
 
 		await waitFor(() => {
-			expect(screen.getByText(/Please hang tight when the video loads/i)).toBeInTheDocument();
+			expect(screen.getByText(/Frame preview is unavailable for this video/i)).toBeInTheDocument();
 		});
 	});
 });

--- a/frontend/src/features/shared/components/upload-media/ChooseFromVideo/FrameStrip.test.jsx
+++ b/frontend/src/features/shared/components/upload-media/ChooseFromVideo/FrameStrip.test.jsx
@@ -1,0 +1,76 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FrameStrip } from './FrameStrip';
+
+class MockImage {
+	static instances = [];
+
+	constructor() {
+		this.naturalHeight = 450;
+		MockImage.instances.push(this);
+	}
+
+	set src(value) {
+		this._src = value;
+	}
+
+	get src() {
+		return this._src;
+	}
+}
+
+describe('FrameStrip', () => {
+	const OriginalImage = global.Image;
+
+	beforeEach(() => {
+		MockImage.instances = [];
+		global.Image = MockImage;
+		Element.prototype.scrollIntoView = vi.fn();
+	});
+
+	afterEach(() => {
+		global.Image = OriginalImage;
+	});
+
+	it('writes the selected frame seconds into the hidden thumbnail input', async () => {
+		const user = userEvent.setup();
+		const thumbnailInput = document.createElement('input');
+		const clearInput = document.createElement('input');
+		thumbnailInput.id = 'id_thumbnail_time';
+		clearInput.type = 'checkbox';
+
+		render(
+			<FrameStrip
+				currentThumbnailTime="0"
+				duration={80}
+				spriteSecs={10}
+				spritesUrl="/sprites.jpg"
+				thumbnailInput={thumbnailInput}
+				uploadedPosterClearInput={clearInput}
+			/>
+		);
+
+		act(() => {
+			MockImage.instances[0].onload();
+		});
+
+		await waitFor(() => expect(screen.getByRole('button', { name: /0:20/i })).toBeInTheDocument());
+		await user.click(screen.getByRole('button', { name: /0:20/i }));
+
+		expect(thumbnailInput.value).toBe('20');
+		expect(clearInput.checked).toBe(true);
+		expect(screen.getByText('0:20')).toBeInTheDocument();
+	});
+
+	it('shows an unavailable message when the sprite image fails to load', async () => {
+		render(<FrameStrip duration={80} spriteSecs={10} spritesUrl="/missing-sprites.jpg" />);
+
+		act(() => {
+			MockImage.instances[0].onerror();
+		});
+
+		await waitFor(() => {
+			expect(screen.getByText(/Please hang tight when the video loads/i)).toBeInTheDocument();
+		});
+	});
+});

--- a/frontend/src/features/shared/components/upload-media/ChooseFromVideo/FrameStrip.test.jsx
+++ b/frontend/src/features/shared/components/upload-media/ChooseFromVideo/FrameStrip.test.jsx
@@ -22,6 +22,8 @@ class MockImage {
 describe('FrameStrip', () => {
 	const OriginalImage = global.Image;
 
+	const originalScrollIntoView = Element.prototype.scrollIntoView;
+
 	beforeEach(() => {
 		MockImage.instances = [];
 		global.Image = MockImage;
@@ -30,6 +32,7 @@ describe('FrameStrip', () => {
 
 	afterEach(() => {
 		global.Image = OriginalImage;
+		Element.prototype.scrollIntoView = originalScrollIntoView;
 	});
 
 	it('writes the selected frame seconds into the hidden thumbnail input', async () => {

--- a/frontend/src/features/shared/components/upload-media/ChooseFromVideo/SpriteFrame.jsx
+++ b/frontend/src/features/shared/components/upload-media/ChooseFromVideo/SpriteFrame.jsx
@@ -1,0 +1,66 @@
+import { cn } from '../../../utils/classNames';
+import { SPRITE_FRAME_WIDTH, SPRITE_SOURCE_HEIGHT, SPRITE_SOURCE_WIDTH } from '../hooks/useSpriteFrames';
+
+export function SpriteFrame({
+	className = '',
+	index,
+	label,
+	rowsInSheet = 0,
+	selected = false,
+	spritesUrl,
+	variant = 'strip',
+}) {
+	const width = variant === 'preview' ? 150 : SPRITE_FRAME_WIDTH;
+
+	if (variant === 'fill') {
+		const safeRows = Math.max(1, Number(rowsInSheet) || Number(index) + 1 || 1);
+
+		return (
+			<span
+				aria-label={label}
+				className={cn('relative block h-full w-full overflow-hidden', className)}
+				role={label ? 'img' : undefined}
+			>
+				<span
+					aria-hidden="true"
+					className="absolute top-0 left-0 block w-full bg-no-repeat"
+					style={{
+						height: `${safeRows * 100}%`,
+						backgroundImage: `url("${spritesUrl}")`,
+						backgroundPosition: '0 0',
+						backgroundSize: '100% 100%',
+						transform: `translateY(-${(Number(index) / safeRows) * 100}%)`,
+					}}
+				/>
+			</span>
+		);
+	}
+
+	// The sprite sheet is a vertical column of SPRITE_SOURCE_WIDTH x SPRITE_SOURCE_HEIGHT
+	// frames. We render each frame at `width`, so the whole sheet is scaled by this ratio;
+	// the per-frame height and the vertical offset must use the SAME scaled height, or the
+	// slice drifts a fraction of a pixel per row and every frame ends up showing nearly the
+	// same content. Derive both from the source aspect ratio instead of a rounded constant.
+	const scale = width / SPRITE_SOURCE_WIDTH;
+	const scaledFrameHeight = SPRITE_SOURCE_HEIGHT * scale;
+
+	return (
+		<span
+			aria-label={label}
+			className={cn(
+				'block shrink-0 bg-no-repeat',
+				variant === 'preview' ? 'rounded-ds-4' : 'rounded-ds-2',
+				selected ? 'opacity-100' : 'opacity-30',
+				className
+			)}
+			role={label ? 'img' : undefined}
+			style={{
+				width,
+				height: scaledFrameHeight,
+				backgroundImage: `url("${spritesUrl}")`,
+				backgroundPosition: `0 -${index * scaledFrameHeight}px`,
+				backgroundSize: `${width}px auto`,
+			}}
+		/>
+	);
+}

--- a/frontend/src/features/shared/components/upload-media/fields/ThumbnailUpload.jsx
+++ b/frontend/src/features/shared/components/upload-media/fields/ThumbnailUpload.jsx
@@ -2,15 +2,26 @@ import { useEffect, useState } from 'react';
 import { TabContent, TabView } from '../../TabView';
 import { MediaDropzone } from '../../MediaDropzone';
 import { Text } from '../../Text';
+import { ChooseFromVideo } from '../ChooseFromVideo/ChooseFromVideo';
 
 /**
  * Per-file thumbnail picker, mirroring the single-upload ThumbnailImageUpload
- * (identical TabView styling, dropzone props and preview): an "Upload Thumbnail"
- * tab (choose a photo) and a "Choose from Video" placeholder (owned by #541).
- * Controlled by the chosen poster File so the bulk wizard can keep one per file;
- * the file is sent as `uploaded_poster` on submit (decision D4).
+ * tab contract: upload a photo or choose a frame from the uploaded video.
  */
-export function ThumbnailUploadField({ posterFile = null, onFileSelected }) {
+export function ThumbnailUploadField({
+	currentThumbnailTime = '',
+	duration = '',
+	friendlyToken = '',
+	onFileSelected,
+	onFrameSelect,
+	posterFile = null,
+	posterPreviewClassName = 'mt-4 aspect-video w-full max-w-[280px] rounded-ds-4 object-cover',
+	posterUrl = '',
+	spriteSecs = '',
+	spritesUrl = '',
+	thumbnailFrame = null,
+	thumbnailTime = null,
+}) {
 	const [previewUrl, setPreviewUrl] = useState('');
 
 	useEffect(() => {
@@ -25,13 +36,18 @@ export function ThumbnailUploadField({ posterFile = null, onFileSelected }) {
 		return () => URL.revokeObjectURL(nextPreviewUrl);
 	}, [posterFile]);
 
+	function handleFrameSelect(frame) {
+		onFrameSelect?.(frame.seconds, frame);
+	}
+
 	return (
-		<div>
+		<div className="min-w-0 max-w-full overflow-hidden">
 			<TabView
+				className="min-w-0 max-w-full overflow-hidden"
 				tabMode="wrap"
 				triggerClassName="rounded-none py-3 px-size-22 text-text-tab-trigger"
 				triggerSelectedColor="bg-bg-tab-trigger-selected"
-				panelClassName="mt-8"
+				panelClassName="mt-4 min-w-0 max-w-full overflow-hidden"
 				aria-label="Upload media type"
 				defaultSelectedTab="upload-thumbnail"
 			>
@@ -41,16 +57,13 @@ export function ThumbnailUploadField({ posterFile = null, onFileSelected }) {
 						buttonVariant="secondary"
 						iconName={null}
 						multiple={false}
+						name="uploaded_poster"
 						aria-label="Choose thumbnail image"
 						onFilesSelected={(files) => onFileSelected?.(files?.[0] ?? null)}
 					/>
 
 					{previewUrl ? (
-						<img
-							src={previewUrl}
-							alt="Selected thumbnail preview"
-							className="mt-4 aspect-video w-full max-w-[280px] rounded-ds-4 object-cover"
-						/>
+						<img src={previewUrl} alt="Selected thumbnail preview" className={posterPreviewClassName} />
 					) : null}
 
 					{posterFile?.name ? (
@@ -60,7 +73,15 @@ export function ThumbnailUploadField({ posterFile = null, onFileSelected }) {
 					) : null}
 				</TabContent>
 				<TabContent title="CHOOSE FROM VIDEO" value="choose-from-video">
-					<p>Choose from video</p>
+					<ChooseFromVideo
+						currentThumbnailTime={thumbnailTime ?? currentThumbnailTime}
+						duration={duration}
+						friendlyToken={friendlyToken}
+						onFrameSelect={handleFrameSelect}
+						posterUrl={posterUrl}
+						spriteSecs={spriteSecs}
+						spritesUrl={spritesUrl || thumbnailFrame?.spritesUrl || ''}
+					/>
 				</TabContent>
 			</TabView>
 		</div>

--- a/frontend/src/features/shared/components/upload-media/fields/ThumbnailUpload.test.jsx
+++ b/frontend/src/features/shared/components/upload-media/fields/ThumbnailUpload.test.jsx
@@ -1,0 +1,73 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThumbnailUploadField } from './ThumbnailUpload';
+
+class MockImage {
+	static instances = [];
+
+	constructor() {
+		this.naturalHeight = 450;
+		MockImage.instances.push(this);
+	}
+
+	set src(value) {
+		this._src = value;
+	}
+
+	get src() {
+		return this._src;
+	}
+}
+
+describe('ThumbnailUploadField', () => {
+	const OriginalImage = global.Image;
+
+	beforeEach(() => {
+		MockImage.instances = [];
+		global.Image = MockImage;
+		Element.prototype.scrollIntoView = vi.fn();
+	});
+
+	afterEach(() => {
+		global.Image = OriginalImage;
+	});
+
+	it('renders the choose-from-video strip and reports selected frame seconds', async () => {
+		const user = userEvent.setup();
+		const onFrameSelect = vi.fn();
+
+		render(
+			<ThumbnailUploadField
+				duration={80}
+				friendlyToken="abc123"
+				onFrameSelect={onFrameSelect}
+				spritesUrl="/sprites.jpg"
+			/>
+		);
+
+		await user.click(screen.getByRole('tab', { name: 'CHOOSE FROM VIDEO' }));
+		act(() => {
+			MockImage.instances[0].onload();
+		});
+
+		await waitFor(() => expect(screen.getByRole('button', { name: /0:20/i })).toBeInTheDocument());
+		await user.click(screen.getByRole('button', { name: /0:20/i }));
+
+		expect(onFrameSelect).toHaveBeenCalledWith(
+			20,
+			expect.objectContaining({ index: 2, seconds: 20, spritesUrl: '/sprites.jpg' })
+		);
+	});
+
+	it('keeps the upload tab usable without a media token', () => {
+		const poster = new File(['poster'], 'poster.png', { type: 'image/png' });
+		const onFileSelected = vi.fn();
+
+		render(<ThumbnailUploadField onFileSelected={onFileSelected} />);
+
+		fireEvent.change(screen.getByLabelText('Choose thumbnail image'), { target: { files: [poster] } });
+
+		expect(onFileSelected).toHaveBeenCalledWith(poster);
+		expect(screen.queryByRole('button', { name: /0:20/i })).not.toBeInTheDocument();
+	});
+});

--- a/frontend/src/features/shared/components/upload-media/hooks/useSpriteFrames.js
+++ b/frontend/src/features/shared/components/upload-media/hooks/useSpriteFrames.js
@@ -1,0 +1,111 @@
+import { useEffect, useMemo, useState } from 'react';
+
+export const SPRITE_SOURCE_WIDTH = 160;
+export const SPRITE_SOURCE_HEIGHT = 90;
+// Rendered strip-cell width. The matching cell height is derived from the source
+// aspect ratio in SpriteFrame (SPRITE_SOURCE_HEIGHT * width / SPRITE_SOURCE_WIDTH)
+// so the background offset and scale always agree — see SpriteFrame.jsx.
+export const SPRITE_FRAME_WIDTH = 78.421;
+
+const spriteRowsCache = new Map();
+
+export function formatFrameTime(totalSeconds) {
+	const safeSeconds = Math.max(0, Math.floor(Number(totalSeconds) || 0));
+	const hours = Math.floor(safeSeconds / 3600);
+	const minutes = Math.floor((safeSeconds % 3600) / 60);
+	const seconds = safeSeconds % 60;
+
+	if (hours > 0) {
+		return `${hours}:${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+	}
+
+	return `${minutes}:${String(seconds).padStart(2, '0')}`;
+}
+
+export function buildSpriteFrames({ duration, rowsInSheet, spriteSecs }) {
+	const numericDuration = Number(duration) || 0;
+	const numericRows = Number(rowsInSheet) || 0;
+	const numericSpriteSecs = Number(spriteSecs) || 10;
+
+	if (numericDuration <= 0 || numericRows <= 0 || numericSpriteSecs <= 0) {
+		return [];
+	}
+
+	const frameCount = Math.min(Math.ceil(numericDuration / numericSpriteSecs), numericRows);
+
+	return Array.from({ length: frameCount }, (_, index) => {
+		const seconds = index * numericSpriteSecs;
+
+		return {
+			index,
+			seconds,
+			mmss: formatFrameTime(seconds),
+		};
+	});
+}
+
+export function useSpriteFrames({ spritesUrl, duration, spriteSecs }) {
+	const cachedRows = spritesUrl ? spriteRowsCache.get(spritesUrl) : 0;
+	const [rowsInSheet, setRowsInSheet] = useState(cachedRows || 0);
+	const [status, setStatus] = useState(cachedRows ? 'ready' : spritesUrl ? 'loading' : 'idle');
+
+	useEffect(() => {
+		if (!spritesUrl) {
+			setRowsInSheet(0);
+			setStatus('idle');
+			return undefined;
+		}
+
+		const cached = spriteRowsCache.get(spritesUrl);
+		if (cached) {
+			setRowsInSheet(cached);
+			setStatus('ready');
+			return undefined;
+		}
+
+		let cancelled = false;
+		const image = new Image();
+		const timeoutId = window.setTimeout(() => {
+			if (!cancelled) {
+				setRowsInSheet(0);
+				setStatus('error');
+			}
+		}, 10000);
+		setStatus('loading');
+		setRowsInSheet(0);
+
+		image.onload = () => {
+			if (cancelled) return;
+			window.clearTimeout(timeoutId);
+
+			const rows = Math.floor((image.naturalHeight || 0) / SPRITE_SOURCE_HEIGHT);
+			if (rows > 0) {
+				spriteRowsCache.set(spritesUrl, rows);
+				setRowsInSheet(rows);
+				setStatus('ready');
+			} else {
+				setStatus('error');
+			}
+		};
+		image.onerror = () => {
+			if (!cancelled) {
+				window.clearTimeout(timeoutId);
+				setRowsInSheet(0);
+				setStatus('error');
+			}
+		};
+		image.src = spritesUrl;
+
+		return () => {
+			cancelled = true;
+			window.clearTimeout(timeoutId);
+		};
+	}, [spritesUrl]);
+
+	const frames = useMemo(
+		() => buildSpriteFrames({ duration, rowsInSheet, spriteSecs }),
+		[duration, rowsInSheet, spriteSecs]
+	);
+
+	return { frames, status, rowsInSheet };
+}

--- a/frontend/src/features/shared/components/upload-media/hooks/useSpriteFrames.test.jsx
+++ b/frontend/src/features/shared/components/upload-media/hooks/useSpriteFrames.test.jsx
@@ -1,0 +1,73 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { buildSpriteFrames, formatFrameTime, useSpriteFrames } from './useSpriteFrames';
+
+class MockImage {
+	static instances = [];
+
+	constructor() {
+		this.naturalHeight = 270;
+		MockImage.instances.push(this);
+	}
+
+	set src(value) {
+		this._src = value;
+	}
+
+	get src() {
+		return this._src;
+	}
+}
+
+describe('useSpriteFrames utilities', () => {
+	it('formats minute and hour timestamps', () => {
+		expect(formatFrameTime(0)).toBe('0:00');
+		expect(formatFrameTime(741)).toBe('12:21');
+		expect(formatFrameTime(3723)).toBe('1:02:03');
+	});
+
+	it('caps duration-derived frames by sprite sheet rows', () => {
+		expect(buildSpriteFrames({ duration: 35, rowsInSheet: 3, spriteSecs: 10 })).toEqual([
+			{ index: 0, seconds: 0, mmss: '0:00' },
+			{ index: 1, seconds: 10, mmss: '0:10' },
+			{ index: 2, seconds: 20, mmss: '0:20' },
+		]);
+	});
+});
+
+describe('useSpriteFrames', () => {
+	const OriginalImage = global.Image;
+
+	beforeEach(() => {
+		MockImage.instances = [];
+		global.Image = MockImage;
+	});
+
+	afterEach(() => {
+		global.Image = OriginalImage;
+	});
+
+	it('derives frame rows from the loaded sprite image', async () => {
+		const { result } = renderHook(() =>
+			useSpriteFrames({ spritesUrl: '/sprites.jpg', duration: 100, spriteSecs: 10 })
+		);
+
+		expect(result.current.status).toBe('loading');
+
+		act(() => {
+			MockImage.instances[0].onload();
+		});
+
+		await waitFor(() => expect(result.current.status).toBe('ready'));
+		expect(result.current.frames).toHaveLength(3);
+		expect(result.current.frames[2]).toEqual({ index: 2, seconds: 20, mmss: '0:20' });
+	});
+
+	it('reuses cached sprite rows without returning to loading', () => {
+		const { result } = renderHook(() =>
+			useSpriteFrames({ spritesUrl: '/sprites.jpg', duration: 100, spriteSecs: 10 })
+		);
+
+		expect(result.current.status).toBe('ready');
+		expect(result.current.frames).toHaveLength(3);
+	});
+});

--- a/frontend/src/features/shared/components/upload-media/hooks/useSpritePolling.js
+++ b/frontend/src/features/shared/components/upload-media/hooks/useSpritePolling.js
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { config as mediacmsConfig } from '../../../../../static/js/mediacms/config.js';
 import { apiFetch } from '../../../utils/api';
 
 const DEFAULT_MAX_ATTEMPTS = 12;
@@ -28,7 +29,13 @@ function buildMediaApiUrl(friendlyToken) {
 		return '';
 	}
 
-	return `/api/v1/media/${encodeURIComponent(friendlyToken)}`;
+	let base = '/api/v1/media';
+	try {
+		base = mediacmsConfig(window.MediaCMS).api.media || base;
+	} catch (_e) {
+		// window.MediaCMS not yet initialised (e.g. test environment); use default.
+	}
+	return `${base}/${encodeURIComponent(friendlyToken)}`;
 }
 
 export function useSpritePolling({

--- a/frontend/src/features/shared/components/upload-media/hooks/useSpritePolling.js
+++ b/frontend/src/features/shared/components/upload-media/hooks/useSpritePolling.js
@@ -53,7 +53,7 @@ export function useSpritePolling({
 		duration: initialDuration || cachedMediaData?.duration || '',
 		posterUrl: initialPosterUrl || cachedMediaData?.posterUrl || '',
 		spritesUrl: initialSpritesUrl || cachedMediaData?.spritesUrl || '',
-		thumbnailTime: resolveThumbnailTime(initialThumbnailTime, cachedMediaData?.thumbnailTime || ''),
+		thumbnailTime: resolveThumbnailTime(initialThumbnailTime, cachedMediaData?.thumbnailTime ?? ''),
 		spriteNumSecs: initialSpriteNumSecs || cachedMediaData?.spriteNumSecs || '',
 	});
 	const [status, setStatus] = useState(initialSpritesUrl || cachedMediaData?.spritesUrl ? 'ready' : 'idle');
@@ -77,7 +77,7 @@ export function useSpritePolling({
 					: initialSpritesUrl || current.spritesUrl || cached?.spritesUrl || '',
 				thumbnailTime: resolveThumbnailTime(
 					initialThumbnailTime,
-					tokenChanged ? cached?.thumbnailTime || '' : current.thumbnailTime
+					tokenChanged ? (cached?.thumbnailTime ?? '') : current.thumbnailTime
 				),
 				spriteNumSecs: tokenChanged
 					? initialSpriteNumSecs || cached?.spriteNumSecs || ''

--- a/frontend/src/features/shared/components/upload-media/hooks/useSpritePolling.js
+++ b/frontend/src/features/shared/components/upload-media/hooks/useSpritePolling.js
@@ -1,0 +1,170 @@
+import { useEffect, useRef, useState } from 'react';
+import { apiFetch } from '../../../utils/api';
+
+const DEFAULT_MAX_ATTEMPTS = 12;
+const DEFAULT_INTERVAL_MS = 5000;
+const mediaDataCache = new Map();
+
+function resolveThumbnailTime(nextValue, fallback) {
+	return nextValue === '' || nextValue == null ? fallback : nextValue;
+}
+
+function getCachedMediaData(friendlyToken) {
+	return friendlyToken ? mediaDataCache.get(friendlyToken) : null;
+}
+
+function setCachedMediaData(friendlyToken, mediaData) {
+	if (friendlyToken && mediaData.spritesUrl) {
+		mediaDataCache.set(friendlyToken, mediaData);
+	}
+}
+
+export function clearSpritePollingCache() {
+	mediaDataCache.clear();
+}
+
+function buildMediaApiUrl(friendlyToken) {
+	if (!friendlyToken) {
+		return '';
+	}
+
+	return `/api/v1/media/${encodeURIComponent(friendlyToken)}`;
+}
+
+export function useSpritePolling({
+	friendlyToken,
+	initialDuration = '',
+	initialPosterUrl = '',
+	initialSpritesUrl = '',
+	initialThumbnailTime = '',
+	initialSpriteNumSecs = '',
+	intervalMs = DEFAULT_INTERVAL_MS,
+	maxAttempts = DEFAULT_MAX_ATTEMPTS,
+}) {
+	const cachedMediaData = getCachedMediaData(friendlyToken);
+	const [mediaData, setMediaData] = useState({
+		duration: initialDuration || cachedMediaData?.duration || '',
+		posterUrl: initialPosterUrl || cachedMediaData?.posterUrl || '',
+		spritesUrl: initialSpritesUrl || cachedMediaData?.spritesUrl || '',
+		thumbnailTime: resolveThumbnailTime(initialThumbnailTime, cachedMediaData?.thumbnailTime || ''),
+		spriteNumSecs: initialSpriteNumSecs || cachedMediaData?.spriteNumSecs || '',
+	});
+	const [status, setStatus] = useState(initialSpritesUrl || cachedMediaData?.spritesUrl ? 'ready' : 'idle');
+	const previousFriendlyToken = useRef(friendlyToken);
+
+	useEffect(() => {
+		const tokenChanged = previousFriendlyToken.current !== friendlyToken;
+		previousFriendlyToken.current = friendlyToken;
+		const cached = getCachedMediaData(friendlyToken);
+
+		setMediaData((current) => {
+			const next = {
+				duration: tokenChanged
+					? initialDuration || cached?.duration || ''
+					: initialDuration || current.duration || cached?.duration || '',
+				posterUrl: tokenChanged
+					? initialPosterUrl || cached?.posterUrl || ''
+					: initialPosterUrl || current.posterUrl || cached?.posterUrl || '',
+				spritesUrl: tokenChanged
+					? initialSpritesUrl || cached?.spritesUrl || ''
+					: initialSpritesUrl || current.spritesUrl || cached?.spritesUrl || '',
+				thumbnailTime: resolveThumbnailTime(
+					initialThumbnailTime,
+					tokenChanged ? cached?.thumbnailTime || '' : current.thumbnailTime
+				),
+				spriteNumSecs: tokenChanged
+					? initialSpriteNumSecs || cached?.spriteNumSecs || ''
+					: initialSpriteNumSecs || current.spriteNumSecs || cached?.spriteNumSecs || '',
+			};
+			setCachedMediaData(friendlyToken, next);
+			return next;
+		});
+
+		setStatus((currentStatus) => {
+			if (initialSpritesUrl || cached?.spritesUrl) {
+				return 'ready';
+			}
+
+			if (tokenChanged) {
+				return 'idle';
+			}
+
+			return currentStatus;
+		});
+	}, [
+		friendlyToken,
+		initialDuration,
+		initialPosterUrl,
+		initialSpritesUrl,
+		initialThumbnailTime,
+		initialSpriteNumSecs,
+	]);
+
+	useEffect(() => {
+		if (initialSpritesUrl || mediaData.spritesUrl || !friendlyToken) {
+			return undefined;
+		}
+
+		let cancelled = false;
+		let attempts = 0;
+		let timeoutId;
+
+		async function poll() {
+			if (cancelled || attempts >= maxAttempts) {
+				if (!cancelled) {
+					setStatus('unavailable');
+				}
+				return;
+			}
+
+			attempts += 1;
+			setStatus('polling');
+
+			try {
+				const response = await apiFetch(buildMediaApiUrl(friendlyToken));
+
+				if (cancelled) {
+					return;
+				}
+
+				if (response.ok) {
+					const data = await response.json();
+					setMediaData((current) => {
+						const next = {
+							duration: data.duration ?? current.duration,
+							posterUrl: data.poster_url ?? current.posterUrl,
+							spritesUrl: data.sprites_url ?? current.spritesUrl,
+							thumbnailTime: data.thumbnail_time ?? current.thumbnailTime,
+							spriteNumSecs: data.sprite_num_secs ?? current.spriteNumSecs,
+						};
+						setCachedMediaData(friendlyToken, next);
+						return next;
+					});
+
+					if (data.sprites_url) {
+						setStatus('ready');
+						return;
+					}
+				}
+			} catch (_error) {
+				// Keep polling; fresh uploads often need a little time before sprite data is ready.
+			}
+
+			if (!cancelled) {
+				timeoutId = window.setTimeout(poll, intervalMs);
+			}
+		}
+
+		poll();
+
+		return () => {
+			cancelled = true;
+			window.clearTimeout(timeoutId);
+		};
+	}, [friendlyToken, initialSpritesUrl, intervalMs, maxAttempts, mediaData.spritesUrl]);
+
+	return {
+		...mediaData,
+		status,
+	};
+}

--- a/frontend/src/features/shared/components/upload-media/hooks/useSpritePolling.test.jsx
+++ b/frontend/src/features/shared/components/upload-media/hooks/useSpritePolling.test.jsx
@@ -1,0 +1,82 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { apiFetch } from '../../../utils/api';
+import { clearSpritePollingCache, useSpritePolling } from './useSpritePolling';
+
+vi.mock('../../../utils/api', () => ({
+	apiFetch: vi.fn(),
+}));
+
+describe('useSpritePolling', () => {
+	beforeEach(() => {
+		apiFetch.mockReset();
+		clearSpritePollingCache();
+	});
+
+	it('keeps loaded sprite data when only the selected thumbnail time changes', async () => {
+		apiFetch.mockResolvedValue({
+			ok: true,
+			json: async () => ({
+				duration: 30,
+				sprites_url: '/sprites.jpg',
+				thumbnail_time: 0,
+			}),
+		});
+
+		const { result, rerender } = renderHook(
+			({ initialThumbnailTime }) =>
+				useSpritePolling({
+					friendlyToken: 'abc123',
+					initialThumbnailTime,
+				}),
+			{ initialProps: { initialThumbnailTime: '' } }
+		);
+
+		await waitFor(() => expect(result.current.status).toBe('ready'));
+		expect(result.current.spritesUrl).toBe('/sprites.jpg');
+
+		rerender({ initialThumbnailTime: 20 });
+
+		expect(result.current.status).toBe('ready');
+		expect(result.current.spritesUrl).toBe('/sprites.jpg');
+		expect(result.current.thumbnailTime).toBe(20);
+	});
+
+	it('surfaces the server sprite interval so the tile->time mapping stays authoritative', async () => {
+		apiFetch.mockResolvedValue({
+			ok: true,
+			json: async () => ({
+				duration: 30,
+				sprites_url: '/sprites.jpg',
+				sprite_num_secs: 7,
+				thumbnail_time: 0,
+			}),
+		});
+
+		const { result } = renderHook(() => useSpritePolling({ friendlyToken: 'abc123' }));
+
+		await waitFor(() => expect(result.current.status).toBe('ready'));
+		expect(result.current.spriteNumSecs).toBe(7);
+	});
+
+	it('reuses cached sprite data after the selector remounts for the same media token', async () => {
+		apiFetch.mockResolvedValue({
+			ok: true,
+			json: async () => ({
+				duration: 30,
+				sprites_url: '/sprites.jpg',
+				thumbnail_time: 0,
+			}),
+		});
+
+		const firstRender = renderHook(() => useSpritePolling({ friendlyToken: 'abc123' }));
+		await waitFor(() => expect(firstRender.result.current.status).toBe('ready'));
+		expect(firstRender.result.current.spritesUrl).toBe('/sprites.jpg');
+		firstRender.unmount();
+
+		const secondRender = renderHook(() => useSpritePolling({ friendlyToken: 'abc123' }));
+
+		expect(secondRender.result.current.status).toBe('ready');
+		expect(secondRender.result.current.spritesUrl).toBe('/sprites.jpg');
+		expect(apiFetch).toHaveBeenCalledTimes(1);
+	});
+});

--- a/frontend/src/features/upload-quick-preview/QuickPreview.jsx
+++ b/frontend/src/features/upload-quick-preview/QuickPreview.jsx
@@ -1,4 +1,5 @@
 import { VerticalMovieItem } from '../shared/components/MovieItem';
+import { SpriteFrame } from '../shared/components/upload-media/ChooseFromVideo/SpriteFrame';
 import { cn } from '../shared/utils/classNames';
 
 // Fully transparent 1x1 GIF. While no thumbnail has been selected or
@@ -33,6 +34,7 @@ function formatViews(views) {
 export function QuickPreview({
 	title = '',
 	thumbnailUrl = '',
+	thumbnailFrame = null,
 	durationLabel = '',
 	category = null,
 	subtitle = '',
@@ -41,6 +43,17 @@ export function QuickPreview({
 	className = '',
 }) {
 	const metadata = [country, formatViews(views)].filter(Boolean);
+	const thumbnailOverlay = thumbnailFrame?.spritesUrl ? (
+		<SpriteFrame
+			className="h-full w-full"
+			index={thumbnailFrame.index}
+			label={title ? `${title} selected video frame` : 'Selected video frame thumbnail preview'}
+			rowsInSheet={thumbnailFrame.rowsInSheet}
+			selected
+			spritesUrl={thumbnailFrame.spritesUrl}
+			variant="fill"
+		/>
+	) : null;
 
 	return (
 		<section
@@ -53,6 +66,7 @@ export function QuickPreview({
 				title={title || 'Untitled media'}
 				imageSrc={thumbnailUrl || PLACEHOLDER_THUMBNAIL}
 				imageAlt={title ? `${title} thumbnail` : 'Thumbnail preview'}
+				thumbnailOverlay={thumbnailOverlay}
 				duration={durationLabel}
 				badge={category?.title || ''}
 				badgeColor={category?.color || DEFAULT_BADGE_COLOR}

--- a/frontend/src/features/upload-quick-preview/QuickPreview.test.jsx
+++ b/frontend/src/features/upload-quick-preview/QuickPreview.test.jsx
@@ -38,6 +38,18 @@ describe('QuickPreview', () => {
 		expect(screen.getByText('12,345 views')).toBeVisible();
 	});
 
+	it('renders a selected video frame over the poster when supplied', () => {
+		render(
+			<QuickPreview
+				title="A"
+				thumbnailUrl={samplePoster}
+				thumbnailFrame={{ index: 1, rowsInSheet: 3, spritesUrl: '/sprites.jpg' }}
+			/>
+		);
+
+		expect(screen.getByRole('img', { name: 'A selected video frame' })).toBeVisible();
+	});
+
 	it('falls back to placeholders while fields are empty', () => {
 		render(<QuickPreview />);
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Implements the "Choose from Video" thumbnail selector in the **new upload page** (single **and** bulk upload). In the Thumbnail Image Upload card's **FROM VIDEO** tab, the user scrubs a horizontal strip of frames sliced from the video's sprite sheet and clicks the one they want, instead of guessing a `thumbnail_time` number. The chosen frame's seconds are submitted as `thumbnail_time` through the existing async edit path, so `produce_thumbnails_from_video()` regenerates the poster on save (no new backend write path).

**Scope:** the new upload page (single + bulk). The legacy edit page is **out of scope** and keeps its existing behavior.

**Frontend**
- Consolidated the selector into `shared/components/upload-media`: `ChooseFromVideo` + `FrameStrip` + `SpriteFrame` + `useSpriteFrames` / `useSpritePolling`, so single and bulk share **one** implementation. Single's `ThumbnailImageUpload` and the shared `ThumbnailUploadField` both render the real FROM VIDEO tab when given a `friendlyToken` (polls `/api/v1/media/{token}` for `sprites_url` / `duration`).
- Frame selection is held per-flow (`useSingleUploadStore.thumbnailTime`; per-file `thumbnailTime` in `useBulkUploadStore`), mutually exclusive with a custom `uploaded_poster`. `useSubmitSingle` / `useSubmitBulk` send `thumbnail_time` when a frame is picked, `uploaded_poster` when a custom image is chosen.
- Quick Preview reflects the selected thumbnail/frame in both flows.
- `SpriteFrame` derives the vertical offset from the rendered width (scale ratio) so tiles render distinct frames instead of all-identical.

**Sprite tile/poster alignment (the core correctness fix)**
- `files/sprites.py` now extracts each tile with the **same** `-ss i*sprite_num_secs -i … -vframes 1` input-seek the poster uses, so tile `i` is the exact frame the backend extracts for `thumbnail_time = i*sprite_num_secs`. The previous `fps=1/N` decode landed on a different frame than the poster's keyframe-snapped seek, so the tile a user clicked and the generated thumbnail could differ. Generation now fails fast (`ffmpeg_missing_frame` / `missing_duration`) instead of appending frames out of order and shifting tile indices.
- Exposes `sprite_num_secs` via `SingleMediaSerializer` and threads it to the client, so the tile→time mapping is **server-authoritative** rather than a hardcoded `10`.

**Backend**
- `forms`: `thumbnail_time` added to `MediaForm.Meta.fields` (persists for videos).
- `models`: treats `thumbnail_time=0` as a valid selection (it was falsy → fell back to a random frame); choosing a frame clears `uploaded_poster` / `uploaded_thumbnail` so the video frame wins.

**Sprite generation hardening + backfill (bundled)**
- `produce_sprite_from_video` refactored to call `generate_sprite_for_media` with explicit failure reporting and `convert`/`magick` resolution via a new optional `IMAGEMAGICK_COMMAND` setting.
- `backfill_video_sprites` management command to regenerate sprites for existing videos, with an admin-guide doc.

> ⚠️ **Reviewer note — changes broader than the upload SPA:**
> - **`media_version` now uses millisecond precision** (`int(timestamp() * 1000)` instead of seconds). `media_version` is the `?v=` cache-buster appended to **every** media asset URL platform-wide (posters, thumbnails, sprites, subtitles). This fixes stale assets after two edits within the same second, but it (a) affects all media URLs site-wide, and (b) will trigger a **one-time re-fetch of all media assets** on deploy as every `?v=` value changes format. Flagging so it gets reviewed as the cross-cutting change it is.
> - The `Media.save()` / `produce_thumbnails_from_video()` changes (the `thumbnail_time=0` fix and clearing `uploaded_poster` on frame select) run for **all** media saves, including the legacy edit page — not just the upload SPA.
> - **Deploy step:** existing videos have old-timeline sprite sheets. Run a one-time `python manage.py backfill_video_sprites --force` so their tiles align with the new extraction. New uploads are correct automatically.

## Related Issue
<!--- Please link to the issue here: -->
Fixes #541

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Previously, picking a video thumbnail meant typing a number of seconds (`thumbnail_time`) into a bare input — no visual feedback, pure guesswork. Issue #541 (P0, Cinemata × Kumquat modernization) calls for a visual frame selector. With the upload flow migrated to the new React SPA, the teammate's upload card shipped the FROM VIDEO tab as a stub; this PR fills it for both single and bulk upload and fixes the underlying sprite/poster timeline mismatch so the frame you pick is the thumbnail you get.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
- **Manual, end-to-end (dev, `cms.settings` + Docker Postgres):** uploaded videos via single upload, picked frames in the FROM VIDEO tab, submitted, and confirmed the generated poster matches the selected frame. Verified the sprite tile at a given timestamp is byte-for-byte the frame the backend extracts at that `thumbnail_time` (compared `ffmpeg -ss` extraction vs the cropped sprite tile).
- **Frontend unit tests (vitest):** `81 passed` across `src/features/add-media`, `src/features/shared/components/upload-media`, `src/features/upload-quick-preview` — store mutual-exclusion (single + per-file bulk), `ThumbnailImageUpload` / `ChooseFromVideo` / `FrameStrip` / `useSpriteFrames` / `useSpritePolling`, submit payloads.
- **Backend tests (`manage.py test`, `cms.settings`):** sprite generation (per-tile timestamps, missing-frame/missing-duration failure modes, ImageMagick resolution), `backfill_video_sprites` command, `sprite_num_secs` serializer, and the edit-media thumbnail form field. `manage.py check` clean.
- **Lint:** `pre-commit` (ruff + prettier + django-upgrade) clean on all changed files.

## Screenshots (if appropriate):
<img width="1276" height="580" alt="image" src="https://github.com/user-attachments/assets/8eea1157-4ac1-47ce-b982-72c46eb7f2a1" />
<img width="385" height="357" alt="image" src="https://github.com/user-attachments/assets/2418e677-0318-4c63-8cb8-f1518018e69a" />

<img width="1269" height="944" alt="image" src="https://github.com/user-attachments/assets/a51db071-c119-4f91-91ef-3c51878468d8" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):
- [x] I have not imported `flux` in a new component
- [x] If adding a new feature, I used Modern Track patterns
- [x] New features do not create new SCSS files (use Tailwind instead)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added video sprite generation/backfill tooling and behavior for restoring missing sprite sheets.
  * Introduced frame-based thumbnail selection for video uploads and quick previews.
  * Exposed `sprite_num_secs` (sprite timing granularity) in media API responses.
* **Bug Fixes**
  * `thumbnail_time=0` is now treated as a valid selection.
  * Updating thumbnail frame now correctly clears stale uploaded poster/thumbnail artifacts.
* **Documentation**
  * Added an admin guide for backfilling video sprite sheets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->