### PR TITLE
feat: update search filter checkmark icons to standard Phosphor Check

### DIFF
--- a/frontend/src/features/search/components/FilterCategory.jsx
+++ b/frontend/src/features/search/components/FilterCategory.jsx
@@ -24,8 +24,6 @@ export function FilterCategory({
 	const [isExpanded, setIsExpanded] = useState(defaultExpanded);
 	const selected = new Set(normalizeSelectedValues(selectedValues));
 	const Control = selectMode === 'single' ? RadioButton : CheckboxButton;
-	const controlProps = selectMode === 'single' ? {} : { iconName: 'check' };
-
 	function handleChange(value) {
 		if (selectMode === 'single') {
 			onChange?.(value, true);
@@ -74,7 +72,6 @@ export function FilterCategory({
 								value={option.value}
 								checked={selected.has(option.value)}
 								onChange={() => handleChange(option.value)}
-								{...controlProps}
 								className="w-full items-start"
 								controlClassName={cn(
 									'bg-bg-control-unchecked ',


### PR DESCRIPTION
## Description
Replaces the two custom checkmark SVG files (`check.svg` and `checklist.svg`) in the shared icon registry with the canonical Phosphor `Check` icon. The new SVGs use the standard Phosphor format (`viewBox="0 0 256 256"`, `polyline` stroke with `stroke-width="16"`) to align with the other Phosphor icons already in the repo (`close`, `caret-down`, `sort-arrows`).

## Related Issue
Related to #522 / #727 (search filter redesign)

## Motivation and Context
The lead requested that the search filter checkbox icon use a standard Phosphor icon rather than a custom SVG path. The other icons in the search filter feature (`caretDown`, `sortArrows`, `close`) were already confirmed Phosphor — this brings `check` and `checklist` in line with the same standard.

## How Has This Been Tested?
- Visually verified the checkbox checkmark renders correctly in the search filter (`FilterCategory`) and `CheckboxButton` component
- Confirmed the SVG format matches the canonical Phosphor pattern used by other icons in the registry
- Pre-commit hooks passed (trailing whitespace, end of files, large file checks)

## Screenshots (if appropriate):
<img width="1146" height="831" alt="image" src="https://github.com/user-attachments/assets/f8440448-29c1-4402-8793-93b86f9c2afb" />

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):
- [x] I have not imported `flux` in a new component
- [x] If adding a new feature, I used Modern Track patterns
- [x] New features do not create new SCSS files (use Tailwind instead)