### PR TITLE
fix(media): cap sprite tiles and use dynamic interval for long videos (#541)

### DIFF
--- a/cms/settings.py
+++ b/cms/settings.py
@@ -390,6 +390,14 @@ FFPROBE_COMMAND = "ffprobe"  # this is the path
 IMAGEMAGICK_COMMAND = None  # optional path/name for ImageMagick; auto-detects convert or magick when unset
 MP4HLS = "mp4hls"
 
+# Sprite sheet generation (powers the "choose from video" thumbnail selector).
+# SPRITE_NUM_SECS is the *minimum* spacing between tiles for short videos. For long
+# videos the spacing is widened automatically so the total tile count never exceeds
+# SPRITE_MAX_TILES — this bounds both the ffmpeg cost on the worker and the height of
+# the generated JPEG (which the browser must decode). See files/sprites.py.
+SPRITE_NUM_SECS = 10
+SPRITE_MAX_TILES = 100
+
 ALLOW_ANONYMOUS_ACTIONS = ["watch"]  # need be a list - only watching allowed for anonymous users
 MASK_IPS_FOR_ACTIONS = True
 # how many seconds a process in running state without reporting progress is

--- a/files/migrations/0029_media_sprite_num_secs.py
+++ b/files/migrations/0029_media_sprite_num_secs.py
@@ -1,0 +1,26 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("files", "0028_media_visibility_schedule"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="media",
+            name="sprite_num_secs",
+            field=models.PositiveIntegerField(
+                blank=True,
+                null=True,
+                help_text=(
+                    "Seconds between consecutive tiles in the generated sprite sheet. Stored per "
+                    "media because long videos use a widened interval (see SPRITE_MAX_TILES). The "
+                    "thumbnail selector maps a chosen tile back to its timestamp as tile_index * "
+                    "this value, so it must match what files/sprites.py used to space the tiles. "
+                    "Null for legacy rows generated before this field existed; callers fall back "
+                    "to settings.SPRITE_NUM_SECS."
+                ),
+            ),
+        ),
+    ]

--- a/files/models.py
+++ b/files/models.py
@@ -252,6 +252,18 @@ class Media(models.Model):
         help_text="Time on video file that a thumbnail will be taken",
     )
     sprites = models.FileField(upload_to=original_thumbnail_file_path, blank=True, max_length=500)
+    sprite_num_secs = models.PositiveIntegerField(
+        null=True,
+        blank=True,
+        help_text=(
+            "Seconds between consecutive tiles in the generated sprite sheet. Stored per "
+            "media because long videos use a widened interval (see SPRITE_MAX_TILES). The "
+            "thumbnail selector maps a chosen tile back to its timestamp as tile_index * "
+            "this value, so it must match what files/sprites.py used to space the tiles. "
+            "Null for legacy rows generated before this field existed; callers fall back "
+            "to settings.SPRITE_NUM_SECS."
+        ),
+    )
     duration = models.IntegerField(default=0)
     views = models.IntegerField(default=1)
     likes = models.IntegerField(default=1)

--- a/files/serializers.py
+++ b/files/serializers.py
@@ -290,6 +290,12 @@ class ManageCommunityImpactSerializer(serializers.ModelSerializer):
         )
 
 
+# Spacing (seconds) at which sprite sheets were generated before Media.sprite_num_secs
+# existed. Fixed by history (the old generator hardcoded a 10s fallback), so legacy rows
+# must report this value regardless of the current SPRITE_NUM_SECS setting.
+LEGACY_SPRITE_NUM_SECS = 10
+
+
 class SingleMediaSerializer(serializers.ModelSerializer):
     user = serializers.ReadOnlyField(source="user.username")
     url = serializers.SerializerMethodField()
@@ -304,11 +310,16 @@ class SingleMediaSerializer(serializers.ModelSerializer):
     def get_sprite_num_secs(self, obj):
         # Seconds between consecutive sprite-sheet frames. The thumbnail selector needs
         # this to map a chosen tile back to its exact timestamp (tile i -> i * value),
-        # which must match how files/sprites.py extracts the tiles. Exposed instead of
-        # hardcoding 10 on the client so the two never drift if the setting changes.
-        from django.conf import settings
-
-        return getattr(settings, "SPRITE_NUM_SECS", 10)
+        # which must match how files/sprites.py extracted the tiles for THIS media. Long
+        # videos use a widened interval, so this is stored per-media.
+        #
+        # Legacy rows created before sprite_num_secs existed have a null field. Their
+        # sheets were ALWAYS generated at a fixed 10s (the old code used a hardcoded
+        # getattr(settings, "SPRITE_NUM_SECS", 10) and the setting was never defined), so
+        # we fall back to the historical constant 10 — NOT the live setting. Using the
+        # current setting would remap those legacy sheets to the wrong timestamps if an
+        # admin ever changes SPRITE_NUM_SECS.
+        return obj.sprite_num_secs or LEGACY_SPRITE_NUM_SECS
 
     def get_user_has_liked(self, obj):
         request = self.context.get("request")

--- a/files/sprites.py
+++ b/files/sprites.py
@@ -1,3 +1,5 @@
+import logging
+import math
 import os
 import shutil
 import tempfile
@@ -7,8 +9,28 @@ from django.core.files import File
 
 from .helpers import get_file_name, get_file_type, run_command
 
+logger = logging.getLogger(__name__)
+
 SPRITE_WIDTH = 160
 SPRITE_HEIGHT = 90
+
+
+def resolve_sprite_interval(duration, base_interval, max_tiles):
+    """Choose the spacing (in seconds) between sprite tiles for a video.
+
+    Short videos keep ``base_interval`` (e.g. 10s). Long videos widen the spacing so the
+    total tile count never exceeds ``max_tiles`` — this bounds both the number of ffmpeg
+    invocations on the worker and the height of the stacked JPEG the browser must decode.
+    The returned value is authoritative: it is persisted on the media and used by the
+    thumbnail selector to map a chosen tile (index i) back to its timestamp (i * interval),
+    so it MUST match the spacing actually used to extract the tiles.
+    """
+    base_interval = max(1, int(base_interval or 1))
+    if duration <= 0 or max_tiles <= 0:
+        return base_interval
+    # ceil(duration / max_tiles) is the smallest interval that keeps tile count <= max_tiles.
+    min_interval_for_cap = math.ceil(duration / max_tiles)
+    return max(base_interval, min_interval_for_cap)
 
 
 def _command_exists(command):
@@ -78,7 +100,8 @@ def generate_sprite_for_media(media):
     with tempfile.TemporaryDirectory(dir=temp_directory) as tmpdirname:
         output_name = os.path.join(tmpdirname, "sprites.jpg")
 
-        sprite_num_secs = getattr(settings, "SPRITE_NUM_SECS", 10)
+        base_interval = getattr(settings, "SPRITE_NUM_SECS", 10)
+        max_tiles = getattr(settings, "SPRITE_MAX_TILES", 100)
 
         # Extract each sprite tile at an EXACT timestamp (i * sprite_num_secs) using the
         # same `-ss <time> -i <file> -vframes 1` input-seek mechanism the poster uses in
@@ -91,11 +114,23 @@ def generate_sprite_for_media(media):
         if duration <= 0:
             return _failure(media, "missing_duration")
 
+        # Widen the spacing for long videos so the tile count stays bounded. The interval
+        # used here is persisted on the media (sprite_num_secs) and surfaced to the client
+        # so the chosen tile maps to the correct poster timestamp. See resolve_sprite_interval.
+        sprite_num_secs = resolve_sprite_interval(duration, base_interval, max_tiles)
+
         timestamps = list(range(0, duration, sprite_num_secs))
         if not timestamps:
             timestamps = [0]
 
         last_ffmpeg_error = None
+        # A single failed frame must NOT abort the whole job — for long/large files an
+        # occasional seek failure near EOF is expected, and a partial sheet is far better
+        # than none. But the thumbnail selector maps tile position i back to time
+        # i*sprite_num_secs, so the surviving tiles must stay aligned to their original
+        # positions. We therefore keep the contiguous run of tiles from index 0 and STOP
+        # at the first failure (truncating the tail) rather than renumbering past a gap,
+        # which would shift every later tile onto the wrong timestamp.
         image_files = []
         for index, timestamp in enumerate(timestamps):
             frame_path = os.path.join(tmpdirname, f"img{index:03d}.jpg")
@@ -119,7 +154,14 @@ def generate_sprite_for_media(media):
                 image_files.append(frame_path)
             else:
                 last_ffmpeg_error = ffmpeg_result.get("error")
-                return _failure(media, "ffmpeg_missing_frame", last_ffmpeg_error)
+                logger.warning(
+                    "Sprite generation for media %s stopped at frame %d/%d (error: %s)",
+                    getattr(media, "friendly_token", None),
+                    index,
+                    len(timestamps),
+                    last_ffmpeg_error,
+                )
+                break
 
         if not image_files:
             return _failure(media, "ffmpeg_no_frames", last_ffmpeg_error)
@@ -137,6 +179,10 @@ def generate_sprite_for_media(media):
         if get_file_type(output_name) != "image":
             return _failure(media, "invalid_sprite_output")
 
+        # Persist the interval actually used so the serializer can report it per-media and
+        # the selector maps tiles to the correct timestamps. Set it before sprites.save()
+        # so the FileField save also writes the column in one round-trip.
+        media.sprite_num_secs = sprite_num_secs
         with open(output_name, "rb") as sprite_file:
             media.sprites.save(
                 content=File(sprite_file),
@@ -150,5 +196,6 @@ def generate_sprite_for_media(media):
         "ok": True,
         "reason": None,
         "friendly_token": media.friendly_token,
+        "sprite_num_secs": sprite_num_secs,
         "sprites": media.sprites.name,
     }

--- a/files/tests/test_media_serializer.py
+++ b/files/tests/test_media_serializer.py
@@ -34,16 +34,33 @@ class MediaSerializerTest(TestCase):
         self.assertEqual(data["content_sensitivity_info"], [{"title": "Graphic Violence"}])
 
     @override_settings(SPRITE_NUM_SECS=7)
-    def test_single_media_serializer_exposes_sprite_num_secs(self):
-        # The thumbnail selector maps a chosen tile back to its timestamp via this value;
-        # it must reflect the server setting so the client never assumes a hardcoded 10.
+    def test_single_media_serializer_uses_historical_constant_for_legacy_rows(self):
+        # Legacy media generated before sprite_num_secs existed has a null field. Its sheet
+        # was always spaced at a fixed 10s, so the serializer must report 10 regardless of
+        # the current SPRITE_NUM_SECS setting (here overridden to 7) — otherwise changing
+        # the setting would remap legacy sheets to the wrong timestamps.
         media = create_test_media(self.user)
+        self.assertIsNone(media.sprite_num_secs)
         request = RequestFactory().get("/api/v1/media/test")
         request.user = self.user
 
         data = SingleMediaSerializer(media, context={"request": request}).data
 
-        self.assertEqual(data["sprite_num_secs"], 7)
+        self.assertEqual(data["sprite_num_secs"], 10)
+
+    @override_settings(SPRITE_NUM_SECS=10)
+    def test_single_media_serializer_prefers_per_media_sprite_num_secs(self):
+        # Long videos store a widened interval; the serializer must report THAT value, not
+        # the global setting, so the selector maps tiles to the correct timestamps.
+        media = create_test_media(self.user)
+        media.sprite_num_secs = 17
+        media.save(update_fields=["sprite_num_secs"])
+        request = RequestFactory().get("/api/v1/media/test")
+        request.user = self.user
+
+        data = SingleMediaSerializer(media, context={"request": request}).data
+
+        self.assertEqual(data["sprite_num_secs"], 17)
 
     def test_hero_playback_serializer_includes_playback_fields(self):
         media = create_test_media(self.user)

--- a/files/tests/test_video_sprite_backfill.py
+++ b/files/tests/test_video_sprite_backfill.py
@@ -8,7 +8,7 @@ from django.core.management import call_command
 from django.test import TestCase, override_settings
 
 from files.models import Media
-from files.sprites import generate_sprite_for_media, resolve_imagemagick_command
+from files.sprites import generate_sprite_for_media, resolve_imagemagick_command, resolve_sprite_interval
 from files.tests.helpers import create_test_media, create_test_user
 
 
@@ -101,6 +101,44 @@ class VideoSpriteBackfillTests(TestCase):
         self.assertTrue(result["ok"])
         # duration=35, interval=10 -> tiles at 0, 10, 20, 30 (range(0, 35, 10))
         self.assertEqual(seek_times, ["0", "10", "20", "30"])
+        media.refresh_from_db()
+        # Short video keeps the base interval and persists it for the selector.
+        self.assertEqual(media.sprite_num_secs, 10)
+        self.assertEqual(result["sprite_num_secs"], 10)
+
+    @override_settings(SPRITE_NUM_SECS=10, SPRITE_MAX_TILES=100)
+    def test_generate_sprite_caps_tile_count_for_long_videos(self):
+        # A 27-minute video at 10s spacing would be 162 tiles. With max_tiles=100 the
+        # interval widens to ceil(1620/100)=17s, yielding <=100 evenly spaced tiles, and
+        # the widened interval is persisted so tile i still maps to time i*17.
+        duration = 1620
+        media = self._attach_media_file(create_test_media(self.user, duration=duration))
+
+        seek_times = []
+
+        def fake_run(command):
+            if command[0] == self.fake_ffmpeg:
+                seek_times.append(int(command[command.index("-ss") + 1]))
+                with open(command[-1], "wb") as frame_file:
+                    frame_file.write(b"frame")
+            else:
+                with open(command[-1], "wb") as sprite_file:
+                    sprite_file.write(b"sprite")
+            return {"out": "", "error": ""}
+
+        with (
+            patch("files.sprites.run_command", side_effect=fake_run),
+            patch("files.sprites.get_file_type", return_value="image"),
+        ):
+            result = generate_sprite_for_media(media)
+
+        media.refresh_from_db()
+        self.assertTrue(result["ok"])
+        self.assertEqual(media.sprite_num_secs, 17)
+        self.assertEqual(result["sprite_num_secs"], 17)
+        self.assertLessEqual(len(seek_times), 100)
+        # Tiles are spaced exactly at the persisted interval starting from 0.
+        self.assertEqual(seek_times[:3], [0, 17, 34])
 
     def test_generate_sprite_for_media_reports_missing_duration(self):
         media = self._attach_media_file(create_test_media(self.user, duration=0))
@@ -110,22 +148,52 @@ class VideoSpriteBackfillTests(TestCase):
         self.assertFalse(result["ok"])
         self.assertEqual(result["reason"], "missing_duration")
 
-    def test_generate_sprite_for_media_fails_when_any_expected_tile_is_missing(self):
-        media = self._attach_media_file(create_test_media(self.user, duration=25))
+    @override_settings(SPRITE_NUM_SECS=10)
+    def test_generate_sprite_truncates_at_first_failed_tile(self):
+        # A frame failure (e.g. a seek near EOF) must NOT abort the whole job. We keep the
+        # contiguous run of tiles from index 0 and stop at the first failure, so surviving
+        # tiles stay aligned to their original timestamps (tile i -> i * interval).
+        media = self._attach_media_file(create_test_media(self.user, duration=45))
+
+        appended_frames = []
 
         def fake_run(command):
             if command[0] == self.fake_ffmpeg:
                 timestamp = command[command.index("-ss") + 1]
-                if timestamp != "10":
-                    with open(command[-1], "wb") as frame_file:
-                        frame_file.write(b"frame")
-            return {"out": "", "error": "missing frame"}
+                # Frame at 20 fails; 0 and 10 succeed, 30/40 are never attempted.
+                if timestamp == "20":
+                    return {"out": "", "error": "seek failed"}
+                with open(command[-1], "wb") as frame_file:
+                    frame_file.write(b"frame")
+            else:
+                # ImageMagick append: every arg before -append is an input tile.
+                appended_frames.extend(arg for arg in command if arg.endswith(".jpg") and "img" in arg)
+                with open(command[-1], "wb") as sprite_file:
+                    sprite_file.write(b"sprite")
+            return {"out": "", "error": ""}
 
-        with patch("files.sprites.run_command", side_effect=fake_run):
+        with (
+            patch("files.sprites.run_command", side_effect=fake_run),
+            patch("files.sprites.get_file_type", return_value="image"),
+        ):
+            result = generate_sprite_for_media(media)
+
+        media.refresh_from_db()
+        self.assertTrue(result["ok"])
+        self.assertTrue(media.sprites)
+        # Only the two tiles before the failure (img000, img001) make it into the sheet.
+        self.assertEqual(len(appended_frames), 2)
+
+    def test_generate_sprite_for_media_fails_when_first_tile_is_missing(self):
+        # If even the very first tile cannot be extracted there is nothing to build a sheet
+        # from, so the job reports ffmpeg_no_frames rather than producing an empty image.
+        media = self._attach_media_file(create_test_media(self.user, duration=25))
+
+        with patch("files.sprites.run_command", return_value={"out": "", "error": "missing frame"}):
             result = generate_sprite_for_media(media)
 
         self.assertFalse(result["ok"])
-        self.assertEqual(result["reason"], "ffmpeg_missing_frame")
+        self.assertEqual(result["reason"], "ffmpeg_no_frames")
 
     def test_generate_sprite_for_media_reports_missing_ffmpeg(self):
         media = self._attach_media_file(create_test_media(self.user))
@@ -278,3 +346,29 @@ class VideoSpriteBackfillTests(TestCase):
 
         enqueued_tokens = {call.args[0] for call in delay.mock_calls}
         self.assertEqual(enqueued_tokens, set(tokens))
+
+
+class ResolveSpriteIntervalTests(TestCase):
+    def test_short_video_keeps_base_interval(self):
+        # Below the cap the base interval is used unchanged.
+        self.assertEqual(resolve_sprite_interval(duration=120, base_interval=10, max_tiles=100), 10)
+
+    def test_long_video_widens_interval_to_stay_under_cap(self):
+        # 1620s / 100 tiles -> ceil = 17s spacing.
+        self.assertEqual(resolve_sprite_interval(duration=1620, base_interval=10, max_tiles=100), 17)
+        # Resulting tile count must not exceed the cap.
+        interval = resolve_sprite_interval(duration=1620, base_interval=10, max_tiles=100)
+        self.assertLessEqual(len(range(0, 1620, interval)), 100)
+
+    def test_exactly_at_cap_keeps_base_interval(self):
+        # duration / base_interval == max_tiles -> no widening needed.
+        self.assertEqual(resolve_sprite_interval(duration=1000, base_interval=10, max_tiles=100), 10)
+
+    def test_zero_or_negative_inputs_fall_back_to_base(self):
+        self.assertEqual(resolve_sprite_interval(duration=0, base_interval=10, max_tiles=100), 10)
+        self.assertEqual(resolve_sprite_interval(duration=1620, base_interval=10, max_tiles=0), 10)
+        # A zero/None base interval is clamped to 1 (never 0, which would break range()/the
+        # tile->timestamp mapping); the cap may still widen it: ceil(120/100) = 2.
+        self.assertEqual(resolve_sprite_interval(duration=120, base_interval=0, max_tiles=100), 2)
+        # With a short duration and a zero base interval, the clamp floor of 1 wins.
+        self.assertEqual(resolve_sprite_interval(duration=50, base_interval=0, max_tiles=100), 1)

--- a/frontend/src/features/shared/components/upload-media/hooks/useSpriteFrames.js
+++ b/frontend/src/features/shared/components/upload-media/hooks/useSpriteFrames.js
@@ -65,12 +65,15 @@ export function useSpriteFrames({ spritesUrl, duration, spriteSecs }) {
 
 		let cancelled = false;
 		const image = new Image();
+		// Decoding the stacked sprite JPEG can take a while for longer videos (taller sheet).
+		// The backend caps tile count so the sheet height stays bounded, but slower devices
+		// still need more than the previous 10s before we declare the preview unavailable.
 		const timeoutId = window.setTimeout(() => {
 			if (!cancelled) {
 				setRowsInSheet(0);
 				setStatus('error');
 			}
-		}, 10000);
+		}, 30000);
 		setStatus('loading');
 		setRowsInSheet(0);
 

--- a/frontend/src/features/shared/components/upload-media/hooks/useSpritePolling.js
+++ b/frontend/src/features/shared/components/upload-media/hooks/useSpritePolling.js
@@ -2,7 +2,12 @@ import { useEffect, useRef, useState } from 'react';
 import { config as mediacmsConfig } from '../../../../../static/js/mediacms/config.js';
 import { apiFetch } from '../../../utils/api';
 
-const DEFAULT_MAX_ATTEMPTS = 12;
+// Sprite generation runs on the long_tasks worker, competing with the encode job that the
+// same upload kicks off. For long/large videos the sheet can take a few minutes to appear,
+// so poll for up to ~5 minutes (60 attempts x 5s) before giving up. The backend caps the
+// tile count (SPRITE_MAX_TILES), which keeps generation bounded, but queue contention can
+// still push the wait past the previous 60s budget.
+const DEFAULT_MAX_ATTEMPTS = 60;
 const DEFAULT_INTERVAL_MS = 5000;
 const mediaDataCache = new Map();
 

--- a/frontend/src/static/js/components/-NEW-/VideoPlayerByPageLink.js
+++ b/frontend/src/static/js/components/-NEW-/VideoPlayerByPageLink.js
@@ -202,7 +202,10 @@ export function VideoPlayerByPageLink(props) {
 						!!data.sprites_url
 							? {
 									url: formatInnerLink(data.sprites_url, site.url),
-									frame: { width: 160, height: 90, seconds: 10 },
+									// seconds-per-tile must match the interval the backend used to build
+									// THIS sheet. Long videos use a widened interval (see files/sprites.py),
+									// exposed as sprite_num_secs; fall back to 10 for legacy rows.
+									frame: { width: 160, height: 90, seconds: data.sprite_num_secs || 10 },
 								}
 							: null
 					);

--- a/frontend/src/static/js/components/MediaViewer/VideoViewer/index.js
+++ b/frontend/src/static/js/components/MediaViewer/VideoViewer/index.js
@@ -800,7 +800,10 @@ export default class VideoViewer extends React.PureComponent {
 		const previewSprite = !!this.props.data.sprites_url
 			? {
 					url: this.props.siteUrl + '/' + this.props.data.sprites_url.replace(/^\//g, ''),
-					frame: { width: 160, height: 90, seconds: 10 },
+					// seconds-per-tile must match the interval the backend used to build THIS
+					// sheet. Long videos use a widened interval (see files/sprites.py), exposed
+					// as sprite_num_secs; fall back to 10 for legacy rows without the field.
+					frame: { width: 160, height: 90, seconds: this.props.data.sprite_num_secs || 10 },
 				}
 			: null;
 


### PR DESCRIPTION
## Description
Fixes the "choose from video" thumbnail selector breaking on long/large videos. For long videos the frame strip showed **"Frame preview is unavailable for this video."** instead of selectable frames.

The fix bounds sprite-sheet generation so cost and image size no longer grow with duration:
- **Cap the tile count** at `SPRITE_MAX_TILES = 100`. For long videos the spacing between tiles widens automatically: `interval = max(SPRITE_NUM_SECS, ceil(duration / SPRITE_MAX_TILES))` (`resolve_sprite_interval` in `files/sprites.py`). A 29-min video goes from 175 tiles (10s spacing) to **98 tiles at 18s spacing**.
- **Persist the interval per-media** on `Media.sprite_num_secs` (migration `0029`). A global setting can't represent a per-video interval — the selector maps tile `i` → time `i * interval`, so the value used at generation time must travel to every consumer. The serializer reports it with a legacy fallback to `settings.SPRITE_NUM_SECS` for rows created before the field existed.
- **Resilient generation**: a failed frame (e.g. a seek near EOF) truncates at the first failure instead of aborting the whole job, keeping surviving tiles aligned to their timestamps.
- **All three sprite consumers** now use the per-media interval, not a hardcoded `10`: the upload selector and the two legacy players' hover scrub-preview (`VideoViewer/index.js`, `VideoPlayerByPageLink.js`).
- **Frontend timeouts raised** as defense-in-depth: sprite polling 60s → ~5 min (queue contention with the encode job), image decode 10s → 30s.

## Related Issue
Fixes #541 (follow-up: long/large video regression reported in [this comment](https://github.com/EngageMedia-video/cinematacms/issues/541#issuecomment-4808180691))

## Motivation and Context
Sprite cost and sheet height grew **unbounded** with video duration: 1 tile per 10s meant a 27-min video produced 162+ tiles stacked into a ~15,000px-tall JPEG. Backend generation overran the frontend's 60s poll budget, and even when a sheet existed the browser couldn't decode it within the 10s image timeout — so long videos always reported "unavailable". Filmmakers uploading long-form content (the platform's core audience) were the most affected.

## How Has This Been Tested?
**Environment:** local dev (Docker PostgreSQL, `cms.settings`), real `long_tasks` Celery worker, ffmpeg + ImageMagick.

- **Unit tests (new + updated):**
  - `resolve_sprite_interval` — short video keeps base interval; long video widens to stay ≤ cap; boundary and zero/negative guards.
  - `generate_sprite_for_media` — long video caps tile count and persists the widened interval; truncates at first failed frame (resilience); fails only when no frame succeeds.
  - Serializer — reports per-media `sprite_num_secs`, falls back to setting for legacy (null) rows.
  - Backend: **25/25 pass** (`test_video_sprite_backfill`, `test_media_serializer`). Frontend hooks: **7/7 pass**.
- **Real long-video end-to-end:** uploaded a **29:10 (1750s)** video.
  - Persisted `sprite_num_secs = 18` (matches `ceil(1750/100)`), **98 tiles** (≤ 100).
  - Frame strip loaded with selectable frames — no "unavailable" message.
  - Selecting a tile produced `thumbnail_time = 1674.0` → exactly tile 93 × 18s, confirming the tile→timestamp→poster mapping holds with the dynamic interval. Selected frame propagated correctly to the poster, Quick Preview, and Uploads thumbnail.
- Pre-commit clean on all changed files. Two Codex review passes (first caught the legacy-player scrub-preview gap, now fixed; second clean).

## Screenshots (if appropriate):
<img width="661" height="327" alt="image" src="https://github.com/user-attachments/assets/17137ff4-ca8a-47a9-8e0a-a394699a02e5" />
<img width="392" height="360" alt="image" src="https://github.com/user-attachments/assets/db38b53d-bf57-45b6-848c-5f3750be5fb4" />


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):
- [x] I have not imported `flux` in a new component
- [x] If adding a new feature, I used Modern Track patterns
- [x] New features do not create new SCSS files (use Tailwind instead)

## Notes for reviewers
- **Migration `0029`** adds a nullable `Media.sprite_num_secs`; no backfill required (legacy rows fall back to the global setting). Existing long-video rows get the new capped sheet + populated field when re-run through `backfill_video_sprites`.
- Granularity trade-off: capping at 100 tiles means ~18s between selectable frames for a 29-min video (vs 10s). Tunable via `SPRITE_MAX_TILES`.
- Kept the per-tile ffmpeg extraction model (matches the poster's input-seek exactly) rather than a single-pass approach, to avoid tile/poster drift.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sprite previews now use per-media timing when available, improving alignment between thumbnail tiles and video duration.
  * Long videos can automatically use wider tile spacing to keep preview sheets manageable.

* **Bug Fixes**
  * Preview generation is more resilient when a frame is missing mid-process.
  * Upload previews wait longer before marking sprite sheets as unavailable.
  * Sprite polling now continues longer before timing out.

* **Tests**
  * Expanded coverage for per-media sprite timing, long-video spacing, and frame-extraction failure behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->