### PR TITLE
fix: Unreviewed state and year chooser on media upload

### DIFF
--- a/files/forms.py
+++ b/files/forms.py
@@ -56,8 +56,8 @@ class MediaForm(forms.ModelForm):
         widget=forms.NumberInput(
             attrs={
                 "class": "year-custom-input",
-                "placeholder": "Enter year (e.g. 1995)",
-                "min": "1900",
+                "placeholder": "Enter year (e.g. 1895)",
+                "min": "1",
                 "style": "display: none;",
             }
         ),
@@ -247,8 +247,8 @@ class MediaForm(forms.ModelForm):
                     if not self.has_error("year_produced_custom"):
                         self.add_error("year_produced_custom", "Please specify a year.")
                 else:
-                    if not (1900 <= year_produced_custom <= current_year):
-                        self.add_error("year_produced_custom", f"Please enter a year between 1900 and {current_year}.")
+                    if not (1 <= year_produced_custom <= current_year):
+                        self.add_error("year_produced_custom", f"Please enter a year up to {current_year}.")
                     else:
                         cleaned_data["year_produced"] = year_produced_custom
             elif year_produced:

--- a/files/tests/test_bulk_upload.py
+++ b/files/tests/test_bulk_upload.py
@@ -143,6 +143,7 @@ class AutoDraftUploadTests(TestCase):
 
     def setUp(self):
         self.client = Client()
+        self.regular = User.objects.create_user(username="regupload", email="regupload@e.com", password="pw")
         self.trusted = User.objects.create_user(username="tru", email="tru@e.com", password="pw")
         self.trusted.advancedUser = True
         self.trusted.save()
@@ -175,3 +176,21 @@ class AutoDraftUploadTests(TestCase):
         self.assertEqual(response.status_code, 200)
         media = Media.objects.filter(user=self.trusted).latest("add_date")
         self.assertFalse(media.is_draft)
+
+    @patch.object(Media, "media_init", return_value=None)
+    @override_settings(MEDIA_IS_REVIEWED=False)
+    def test_trusted_upload_is_reviewed_even_when_global_default_requires_review(self, _mock_init):
+        response = self._upload()
+        self.assertEqual(response.status_code, 200)
+        media = Media.objects.filter(user=self.trusted).latest("add_date")
+        self.assertTrue(media.is_reviewed)
+
+    @patch.object(Media, "media_init", return_value=None)
+    @override_settings(MEDIA_IS_REVIEWED=True)
+    def test_regular_upload_is_unreviewed_even_when_global_default_allows_reviewed(self, _mock_init):
+        self.client.force_login(self.regular)
+
+        response = self._upload()
+        self.assertEqual(response.status_code, 200)
+        media = Media.objects.filter(user=self.regular).latest("add_date")
+        self.assertFalse(media.is_reviewed)

--- a/files/tests/test_media_forms.py
+++ b/files/tests/test_media_forms.py
@@ -93,6 +93,19 @@ class MediaFormPasswordValidationTest(TestCase):
         if not form.is_valid():
             self.assertNotIn("password", form.errors)
 
+    def test_custom_year_before_1900_is_accepted(self):
+        data = self._get_form_data(year_produced="other", year_produced_custom="1898")
+        form = MediaForm(self.user, data=data, instance=self.media)
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+        media = form.save()
+        self.assertEqual(media.year_produced, 1898)
+
+    def test_custom_year_zero_is_rejected(self):
+        data = self._get_form_data(year_produced="other", year_produced_custom="0")
+        form = MediaForm(self.user, data=data, instance=self.media)
+        self.assertFalse(form.is_valid())
+        self.assertIn("year_produced_custom", form.errors)
+
     @override_settings(MEDIA_PASSWORD_MIN_LENGTH=12)
     def test_respects_configurable_min_length(self):
         data = self._get_form_data(password="short1234")  # 9 chars, less than 12

--- a/frontend/src/features/add-media/bulk-upload/buildSubmitItems.js
+++ b/frontend/src/features/add-media/bulk-upload/buildSubmitItems.js
@@ -27,8 +27,8 @@ export function buildEditFormData({
 	data.set('summary', metadata.summary ?? '');
 	data.set('description', metadata.description ?? '');
 	// Map the picked year to MediaForm's dropdown + custom contract: 2000..current
-	// posts as-is, while older years (1900..1999) post the "other" sentinel plus the
-	// custom year (mirrors the legacy / single-upload year field).
+	// posts as-is, while older years post the "other" sentinel plus the custom year
+	// (mirrors the legacy / single-upload year field).
 	const yearProduced = String(metadata.year_produced ?? '').trim();
 	if (yearProduced && Number(yearProduced) < 2000) {
 		data.set('year_produced', 'other');

--- a/frontend/src/features/add-media/bulk-upload/buildSubmitItems.js
+++ b/frontend/src/features/add-media/bulk-upload/buildSubmitItems.js
@@ -14,10 +14,14 @@ export function buildEditFormData({
 	thumbnailTime = null,
 	action = 'submit',
 	csrfToken = '',
+	isReviewed = false,
 }) {
 	const data = new FormData();
 	data.set('csrfmiddlewaretoken', csrfToken || '');
 	data.set('action', action);
+	if (isReviewed) {
+		data.set('is_reviewed', 'on');
+	}
 
 	data.set('title', metadata.title ?? '');
 	data.set('summary', metadata.summary ?? '');

--- a/frontend/src/features/add-media/bulk-upload/buildSubmitItems.test.js
+++ b/frontend/src/features/add-media/bulk-upload/buildSubmitItems.test.js
@@ -15,6 +15,14 @@ describe('buildEditFormData', () => {
 		expect(data.get('year_produced_custom')).toBeNull();
 	});
 
+	it('only marks the media reviewed when the trusted flow requests it', () => {
+		const regular = buildEditFormData({ metadata: createDefaultMetadata() });
+		expect(regular.get('is_reviewed')).toBeNull();
+
+		const trusted = buildEditFormData({ metadata: createDefaultMetadata(), isReviewed: true });
+		expect(trusted.get('is_reviewed')).toBe('on');
+	});
+
 	it('maps a pre-2000 year to the MediaForm "other" + custom contract', () => {
 		const data = buildEditFormData({
 			metadata: { ...createDefaultMetadata(), year_produced: '1995' },

--- a/frontend/src/features/add-media/bulk-upload/hooks/useSubmitBulk.js
+++ b/frontend/src/features/add-media/bulk-upload/hooks/useSubmitBulk.js
@@ -1,6 +1,7 @@
 import { useMutation } from '@tanstack/react-query';
 import { getCSRFToken } from '../../../shared/utils/api';
 import { buildEditFormData, getMediaEditUrl } from '../buildSubmitItems';
+import { useBulkUploadConfig } from '../bulkUploadConfig';
 
 /**
  * Submits each completed file per-file through the shared `edit_media` view —
@@ -13,6 +14,8 @@ import { buildEditFormData, getMediaEditUrl } from '../buildSubmitItems';
  * name, same as the single-upload edit response.
  */
 export function useSubmitBulk() {
+	const config = useBulkUploadConfig();
+
 	return useMutation({
 		mutationFn: async ({ action, files }) => {
 			const csrfToken = getCSRFToken() ?? '';
@@ -25,6 +28,7 @@ export function useSubmitBulk() {
 						thumbnailTime: file.thumbnailTime,
 						action,
 						csrfToken,
+						isReviewed: !!config.isTrustedUser,
 					});
 					try {
 						const response = await fetch(getMediaEditUrl(file.friendlyToken), {

--- a/frontend/src/features/add-media/single-upload/SingleUploadPage.test.jsx
+++ b/frontend/src/features/add-media/single-upload/SingleUploadPage.test.jsx
@@ -289,10 +289,30 @@ describe('SingleUploadPage', () => {
 		await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
 		const submittedBody = fetchMock.mock.calls[0][1].body;
 
+		expect(submittedBody.get('is_reviewed')).toBeNull();
 		expect(submittedBody.get('action')).toBe('draft');
 		expect(
 			screen.queryByText('Please fill in all required fields before sharing your media.')
 		).not.toBeInTheDocument();
+	});
+
+	it('marks direct-publish uploads as reviewed by default', async () => {
+		const user = userEvent.setup();
+		const fetchMock = vi.fn().mockResolvedValue({
+			ok: false,
+			status: 500,
+			json: async () => ({}),
+		});
+		vi.stubGlobal('fetch', fetchMock);
+
+		renderUploadedPage({ canPublishDirectly: true });
+
+		await user.click(screen.getByRole('button', { name: 'Save as Draft' }));
+
+		await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+		const submittedBody = fetchMock.mock.calls[0][1].body;
+
+		expect(submittedBody.get('is_reviewed')).toBe('on');
 	});
 
 	it('submits a selected video frame as thumbnail_time', async () => {
@@ -365,5 +385,6 @@ describe('SingleUploadPage', () => {
 		await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
 
 		expect(fetchMock.mock.calls[0][1].body.get('action')).toBe('submit');
+		expect(fetchMock.mock.calls[0][1].body.get('is_reviewed')).toBeNull();
 	});
 });

--- a/frontend/src/features/add-media/single-upload/components/BasicDetailsForm.jsx
+++ b/frontend/src/features/add-media/single-upload/components/BasicDetailsForm.jsx
@@ -62,7 +62,6 @@ export function BasicDetailsForm({ singleUpload }) {
 				value={singleUpload.yearProduced}
 				onChange={singleUpload.setYearProduced}
 				error={errors.year_produced}
-				minYear={2000}
 			/>
 		</FieldGroup>
 	);

--- a/frontend/src/features/add-media/single-upload/components/MediaDetailsForm.jsx
+++ b/frontend/src/features/add-media/single-upload/components/MediaDetailsForm.jsx
@@ -84,8 +84,8 @@ export function MediaDetailsForm({
 		const year = String(singleUpload.yearProduced).trim();
 		if (!year) {
 			nextErrors.year_produced = 'This field is required';
-		} else if (!/^\d+$/.test(year) || Number(year) < 2000 || Number(year) > CURRENT_YEAR) {
-			nextErrors.year_produced = `Enter a year between 2000 and ${CURRENT_YEAR}`;
+		} else if (!/^\d+$/.test(year) || Number(year) < 1 || Number(year) > CURRENT_YEAR) {
+			nextErrors.year_produced = `Enter a year up to ${CURRENT_YEAR}`;
 		}
 
 		if (singleUpload.website && !singleUpload.website.startsWith('https://')) {

--- a/frontend/src/features/add-media/single-upload/components/MediaDetailsForm.jsx
+++ b/frontend/src/features/add-media/single-upload/components/MediaDetailsForm.jsx
@@ -211,6 +211,7 @@ export function MediaDetailsForm({
 			data-single-upload-form
 		>
 			<input type="hidden" name="csrfmiddlewaretoken" value={csrfToken} />
+			{canPublishDirectly ? <input type="hidden" name="is_reviewed" value="on" /> : null}
 			{canUseAdminSettings ? null : <input type="hidden" name="reported_times" value="0" />}
 
 			<BasicDetailsForm singleUpload={singleUpload} />

--- a/frontend/src/features/add-media/single-upload/components/OtherDetailsForm.jsx
+++ b/frontend/src/features/add-media/single-upload/components/OtherDetailsForm.jsx
@@ -198,7 +198,7 @@ export function OtherDetailsForm({
 	topics,
 }) {
 	return (
-		<FieldGroup title="Others Details">
+		<FieldGroup title="Other Details">
 			<TextField
 				className="w-full"
 				id="production-company"

--- a/frontend/src/features/shared/components/YearChooserField/YearChooserField.jsx
+++ b/frontend/src/features/shared/components/YearChooserField/YearChooserField.jsx
@@ -1,15 +1,51 @@
 import { useEffect, useId, useMemo, useRef, useState } from 'react';
 import { cn } from '../../utils/classNames';
+import { Icon } from '../Icon';
 import { TextField } from '../TextField';
 
 const CURRENT_YEAR = new Date().getFullYear();
+const YEARS_PER_PAGE = 12;
+
+function normalizeYear(value, fallback) {
+	if (value === '' || value === null || value === undefined) {
+		return fallback;
+	}
+	const year = Number(value);
+	return Number.isFinite(year) ? year : fallback;
+}
+
+function clampYear(year, maxYear) {
+	return Math.min(maxYear, Math.max(1, year));
+}
+
+function getPageStartForYear(year, maxYear) {
+	const target = clampYear(normalizeYear(year, maxYear), maxYear);
+	const pageOffset = Math.floor((maxYear - target) / YEARS_PER_PAGE);
+	return Math.max(1, maxYear - (pageOffset + 1) * YEARS_PER_PAGE + 1);
+}
+
+function getOldestPageSize(maxYear) {
+	const totalYears = maxYear;
+	return ((totalYears - 1) % YEARS_PER_PAGE) + 1;
+}
+
+function getNewestPageStart(maxYear) {
+	return getPageStartForYear(maxYear, maxYear);
+}
+
+function getPageYears(pageStart, maxYear) {
+	const pageSize = pageStart === 1 ? getOldestPageSize(maxYear) : YEARS_PER_PAGE;
+	const pageEnd = Math.min(maxYear, pageStart + pageSize - 1);
+	const years = [];
+	for (let year = pageStart; year <= pageEnd; year += 1) {
+		years.push(year);
+	}
+	return years;
+}
 
 /**
- * Year-only "calendar" picker: a read-only field that opens a popover grid of
- * years to choose from. The visible input never accepts typed text, so an invalid
- * year can't be entered (issue #771 edge cases). Years run newest-first from
- * `maxYear` down to `minYear` (default 1900..current, matching MediaForm's year
- * dropdown + custom range).
+ * Year-only calendar picker: an editable year field paired with a bounded,
+ * paged grid of years for users who prefer choosing instead of typing.
  */
 export function YearChooserField({
 	className = 'w-full',
@@ -20,7 +56,6 @@ export function YearChooserField({
 	error = '',
 	required = false,
 	placeholder = 'Select year',
-	minYear = 1900,
 	maxYear = CURRENT_YEAR,
 	value = '',
 }) {
@@ -30,14 +65,23 @@ export function YearChooserField({
 	const rootRef = useRef(null);
 	const gridRef = useRef(null);
 	const [open, setOpen] = useState(false);
+	const normalizedMaxYear = normalizeYear(maxYear, CURRENT_YEAR);
+	const lastYear = Math.max(1, normalizedMaxYear);
+	const [pageStart, setPageStart] = useState(() => getNewestPageStart(lastYear));
 
 	const years = useMemo(() => {
-		const list = [];
-		for (let year = maxYear; year >= minYear; year -= 1) {
-			list.push(year);
+		return getPageYears(pageStart, lastYear);
+	}, [lastYear, pageStart]);
+
+	const pageEnd = years[years.length - 1] ?? pageStart;
+	const canGoOlder = pageStart > 1;
+	const canGoNewer = pageEnd < lastYear;
+
+	useEffect(() => {
+		if (open) {
+			setPageStart(getNewestPageStart(lastYear));
 		}
-		return list;
-	}, [minYear, maxYear]);
+	}, [lastYear, open]);
 
 	useEffect(() => {
 		if (!open) {
@@ -65,8 +109,8 @@ export function YearChooserField({
 		};
 	}, [open]);
 
-	// Move focus into the popover (the selected year, else the first) when opened,
-	// so keyboard users land on the grid.
+	// Move focus into the popover (the selected year, else the first) when opened
+	// or paged, so keyboard users stay in the chooser.
 	useEffect(() => {
 		if (!open) {
 			return;
@@ -77,12 +121,37 @@ export function YearChooserField({
 		}
 		const target = grid.querySelector('[aria-pressed="true"]') ?? grid.querySelector('button');
 		target?.focus();
-	}, [open]);
+	}, [open, pageStart]);
 
 	function selectYear(year) {
 		onChange?.(String(year));
 		setOpen(false);
 	}
+
+	function handleInputChange(event) {
+		onChange?.(event.target.value.replace(/\D/g, '').slice(0, 4));
+	}
+
+	function goOlder() {
+		if (!canGoOlder) {
+			return;
+		}
+		setPageStart((current) => Math.max(1, current - YEARS_PER_PAGE));
+	}
+
+	function goNewer() {
+		if (!canGoNewer) {
+			return;
+		}
+		setPageStart((current) => {
+			const oldestPageSize = getOldestPageSize(lastYear);
+			const nextStart = current === 1 ? 1 + oldestPageSize : current + YEARS_PER_PAGE;
+			return Math.min(getNewestPageStart(lastYear), nextStart);
+		});
+	}
+
+	const hiddenYearValue = value && Number(value) < 2000 ? 'other' : (value ?? '');
+	const hiddenCustomYearValue = value && Number(value) < 2000 ? value : '';
 
 	return (
 		<div ref={rootRef} className={cn('relative', className)}>
@@ -93,22 +162,57 @@ export function YearChooserField({
 				required={required}
 				placeholder={placeholder}
 				value={value ? String(value) : ''}
-				readOnly
+				onChange={handleInputChange}
 				invalid={Boolean(error)}
 				helperText={error}
 				rightButtonLabel="Choose"
 				onRightButtonClick={() => setOpen((current) => !current)}
+				inputMode="numeric"
+				pattern="[0-9]*"
+				maxLength={4}
+				aria-haspopup="dialog"
+				aria-expanded={open}
+				aria-controls={open ? popoverId : undefined}
 			/>
-			{name ? <input type="hidden" name={name} value={value ?? ''} /> : null}
+			{name ? (
+				<>
+					<input type="hidden" name={name} value={hiddenYearValue} />
+					<input type="hidden" name={`${name}_custom`} value={hiddenCustomYearValue} />
+				</>
+			) : null}
 
 			{open ? (
 				<div
 					id={popoverId}
 					role="dialog"
 					aria-label="Choose year"
-					className="absolute left-0 top-full z-20 mt-2 w-full rounded-ds-4 border border-border-strong-constant bg-bg-surface p-2"
+					className="absolute left-0 top-full z-20 mt-2 w-full max-w-[360px] rounded-ds-4 border border-border-strong-constant bg-bg-surface p-3 shadow-2xl"
 				>
-					<div ref={gridRef} className="thin-scrollbar grid max-h-64 grid-cols-4 gap-1 overflow-y-auto">
+					<div className="mb-3 grid grid-cols-[40px_minmax(0,1fr)_40px] items-center gap-2">
+						<button
+							type="button"
+							aria-label="Show older years"
+							onClick={goOlder}
+							disabled={!canGoOlder}
+							className="inline-flex h-10 w-10 cursor-pointer items-center justify-center rounded-ds-4 border-0 bg-transparent text-text-strong transition-colors hover:bg-bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring-focus disabled:cursor-not-allowed disabled:text-text-disabled disabled:hover:bg-transparent"
+						>
+							<Icon name="chevronLeft" size={18} decorative />
+						</button>
+						<div className="body-body-14-bold text-center text-text-strong" aria-live="polite">
+							{pageStart}-{pageEnd}
+						</div>
+						<button
+							type="button"
+							aria-label="Show newer years"
+							onClick={goNewer}
+							disabled={!canGoNewer}
+							className="inline-flex h-10 w-10 cursor-pointer items-center justify-center rounded-ds-4 border-0 bg-transparent text-text-strong transition-colors hover:bg-bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring-focus disabled:cursor-not-allowed disabled:text-text-disabled disabled:hover:bg-transparent"
+						>
+							<Icon name="chevronLeft" size={18} decorative className="rotate-180" />
+						</button>
+					</div>
+
+					<div ref={gridRef} className="grid grid-cols-3 gap-1">
 						{years.map((year) => {
 							const selected = String(year) === String(value);
 							return (
@@ -118,7 +222,7 @@ export function YearChooserField({
 									aria-pressed={selected}
 									onClick={() => selectYear(year)}
 									className={cn(
-										'body-body-14-medium cursor-pointer rounded-ds-4 border-0 px-2 py-2 text-center transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring-focus',
+										'body-body-14-medium h-10 cursor-pointer rounded-ds-4 border-0 px-2 text-center transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring-focus',
 										selected
 											? 'bg-bg-control-checked text-text-control-checked'
 											: 'bg-transparent text-text-strong hover:bg-bg-surface-hover'

--- a/frontend/src/features/shared/components/YearChooserField/YearChooserField.test.jsx
+++ b/frontend/src/features/shared/components/YearChooserField/YearChooserField.test.jsx
@@ -1,0 +1,77 @@
+import { useState } from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { YearChooserField } from './YearChooserField';
+
+function ControlledYearChooser({ initialValue = '', ...props }) {
+	const [value, setValue] = useState(initialValue);
+
+	return <YearChooserField name="year_produced" value={value} onChange={setValue} {...props} />;
+}
+
+describe('YearChooserField', () => {
+	it('opens on the newest valid page and does not show future years', async () => {
+		const user = userEvent.setup();
+
+		render(<YearChooserField maxYear={2026} value="" onChange={vi.fn()} />);
+
+		await user.click(screen.getByRole('button', { name: 'Choose' }));
+
+		expect(screen.getByText('2015-2026')).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: '2026' })).toBeInTheDocument();
+		expect(screen.queryByRole('button', { name: '2027' })).not.toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Show newer years' })).toBeDisabled();
+	});
+
+	it('pages backward into older years without a 1900/2000 floor', async () => {
+		const user = userEvent.setup();
+
+		render(<YearChooserField maxYear={1910} value="" onChange={vi.fn()} />);
+
+		await user.click(screen.getByRole('button', { name: 'Choose' }));
+		expect(screen.getByText('1899-1910')).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: '1899' })).toBeInTheDocument();
+
+		await user.click(screen.getByRole('button', { name: 'Show older years' }));
+		expect(screen.getByText('1887-1898')).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: '1887' })).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: 'Show older years' })).toBeEnabled();
+	});
+
+	it('allows typing a year while keeping the submitted value numeric', async () => {
+		const user = userEvent.setup();
+
+		render(<ControlledYearChooser maxYear={2026} />);
+
+		await user.type(screen.getByLabelText('Year Produced'), '20ab24');
+
+		expect(screen.getByLabelText('Year Produced')).toHaveValue('2024');
+		expect(document.querySelector('input[name="year_produced"]')).toHaveValue('2024');
+		expect(document.querySelector('input[name="year_produced_custom"]')).toHaveValue('');
+		expect(screen.queryByRole('dialog', { name: 'Choose year' })).not.toBeInTheDocument();
+	});
+
+	it('posts older typed years through MediaForm custom-year fields', async () => {
+		const user = userEvent.setup();
+
+		render(<ControlledYearChooser maxYear={2026} />);
+
+		await user.type(screen.getByLabelText('Year Produced'), '1898');
+
+		expect(screen.getByLabelText('Year Produced')).toHaveValue('1898');
+		expect(document.querySelector('input[name="year_produced"]')).toHaveValue('other');
+		expect(document.querySelector('input[name="year_produced_custom"]')).toHaveValue('1898');
+	});
+
+	it('does not jump the chooser range to the typed year', async () => {
+		const user = userEvent.setup();
+
+		render(<ControlledYearChooser maxYear={2026} />);
+
+		await user.type(screen.getByLabelText('Year Produced'), '1898');
+		await user.click(screen.getByRole('button', { name: 'Choose' }));
+
+		expect(screen.getByText('2015-2026')).toBeInTheDocument();
+		expect(screen.queryByText('1887-1898')).not.toBeInTheDocument();
+	});
+});

--- a/frontend/src/features/shared/components/upload-media/schema/mediaMetadataSchema.js
+++ b/frontend/src/features/shared/components/upload-media/schema/mediaMetadataSchema.js
@@ -46,14 +46,14 @@ export function validateMetadata(metadata = {}) {
 		errors.summary = `Synopsis should have ${SYNOPSIS_MAX_WORDS} words maximum.`;
 	}
 
-	// Year is chosen from a year picker spanning 1900..current. MediaForm accepts
-	// 2000..current directly and 1900..1999 via the "other"/custom path (handled in
-	// buildEditFormData), so the full range is valid here.
+	// Year is chosen from a year picker spanning 1..current. MediaForm accepts
+	// 2000..current directly and older years via the "other"/custom path (handled
+	// in buildEditFormData), so the full positive range is valid here.
 	const year = String(metadata.year_produced ?? '').trim();
 	if (!year) {
 		errors.year_produced = 'This field is required';
-	} else if (!/^\d+$/.test(year) || Number(year) < 1900 || Number(year) > currentYear) {
-		errors.year_produced = `Enter a year between 1900 and ${currentYear}`;
+	} else if (!/^\d+$/.test(year) || Number(year) < 1 || Number(year) > currentYear) {
+		errors.year_produced = `Enter a year up to ${currentYear}`;
 	}
 
 	if (!Array.isArray(metadata.category) || metadata.category.length === 0) {

--- a/frontend/src/features/shared/components/upload-media/schema/mediaMetadataSchema.test.js
+++ b/frontend/src/features/shared/components/upload-media/schema/mediaMetadataSchema.test.js
@@ -53,9 +53,10 @@ describe('validateMetadata', () => {
 		);
 	});
 
-	it('validates the year range (1900..current, from the year picker)', () => {
-		expect(validateMetadata({ ...validMetadata, year_produced: '1800' }).year_produced).toBeTruthy();
+	it('validates the year range (positive year through current, from the year picker)', () => {
+		expect(validateMetadata({ ...validMetadata, year_produced: '0' }).year_produced).toBeTruthy();
 		expect(validateMetadata({ ...validMetadata, year_produced: 'abc' }).year_produced).toBeTruthy();
+		expect(validateMetadata({ ...validMetadata, year_produced: '1800' }).year_produced).toBeUndefined();
 		expect(validateMetadata({ ...validMetadata, year_produced: '1995' }).year_produced).toBeUndefined();
 		expect(validateMetadata({ ...validMetadata, year_produced: '2010' }).year_produced).toBeUndefined();
 	});

--- a/uploader/views.py
+++ b/uploader/views.py
@@ -9,7 +9,7 @@ from django.core.files import File
 from django.http import JsonResponse
 from django.views import generic
 
-from cms.permissions import user_allowed_to_upload
+from cms.permissions import is_trusted_uploader, user_allowed_to_upload
 from files.helpers import cleanup_temp_upload_files, rm_file
 from files.models import Media
 
@@ -89,7 +89,12 @@ class FineUploaderView(generic.FormView):
         media_file = os.path.join(settings.MEDIA_ROOT, self.upload.real_path)
         with open(media_file, "rb") as f:
             myfile = File(f)
-            new = Media.objects.create(media_file=myfile, user=self.request.user, is_draft=is_draft)
+            new = Media.objects.create(
+                media_file=myfile,
+                user=self.request.user,
+                is_draft=is_draft,
+                is_reviewed=is_trusted_uploader(self.request.user),
+            )
         if is_draft and new.state != "private":
             # save() set the role-based default state (unlisted for advanced
             # users); normalise drafts to private to match the draft convention.


### PR DESCRIPTION
## Description
Fixes two add-media issues:
- Trusted users and above now default uploaded media to reviewed, while regular users remain unreviewed for admin review.
- Reworks the Year Produced field into an editable year input with a year-picker style chooser.
- Supports historic years before 1900 through the existing `year_produced=other` / `year_produced_custom` MediaForm contract.
- Keeps typed year input independent from the chooser range, so typing does not jump/filter the dropdown.

## Related Issue
Fixes #771 

## Motivation and Context
Trusted/direct-publish users were submitting media as unreviewed because the revamped upload flow did not preserve the old reviewed-default behavior. Regular users should still require admin review.

The Year Produced dropdown also had incorrect bounds and awkward behavior. Users now can type a year directly or use a paged chooser, including historic years.

## How Has This Been Tested?
Ran:

- `make lint`
- `npm run test:run` from `frontend/`
- `.venv/bin/python manage.py test files.tests.test_bulk_upload.AutoDraftUploadTests`
- `.venv/bin/python manage.py test files.tests.test_media_forms.MediaFormPasswordValidationTest`

Results:
- Root lint passed
- Frontend tests passed: 89 test files, 505 tests
- Focused backend tests passed

## Screenshots (if appropriate):
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/d8b7c422-6d32-4d95-8c64-0d60c07873e7" />
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/e25b1712-4ee9-4162-a69b-c68f4c2d41ff" />
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/e0e85db6-905a-4310-9b8a-18bc344a4528" />

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):
- [x] I have not imported `flux` in a new component
- [x] If adding a new feature, I used Modern Track patterns
- [x] New features do not create new SCSS files (use Tailwind instead)