### PR TITLE
feat(media): improve visibility expiration helper text and hide for Private status

### DIFF
--- a/frontend/src/features/add-media/bulk-upload/components/step2/FileCard.jsx
+++ b/frontend/src/features/add-media/bulk-upload/components/step2/FileCard.jsx
@@ -220,9 +220,15 @@ export function FileCard({ file, subStep, options, errors = {}, onClearErrors })
 								name={`status-${file.id}`}
 								value={meta.state}
 								includeRestricted={isTrustedUser}
-								onChange={(value) =>
-									patch({ state: value, password: value === 'restricted' ? meta.password : '' })
-								}
+								onChange={(value) => {
+									const next = {
+										state: value,
+										password: value === 'restricted' ? meta.password : '',
+									};
+									if (value === 'private')
+										Object.assign(next, { expireEnabled: false, startDate: '', endDate: '' });
+									patch(next);
+								}}
 							/>
 							{isTrustedUser && meta.state === 'restricted' ? (
 								<RestrictedPasswordField
@@ -233,23 +239,28 @@ export function FileCard({ file, subStep, options, errors = {}, onClearErrors })
 								/>
 							) : null}
 
-							<Divider />
+							{meta.state !== 'private' ? (
+								<>
+									<Divider />
 
-							<VisibilityExpirationField
-								idPrefix={`visibility-${file.id}`}
-								expireEnabled={meta.expireEnabled}
-								startDate={meta.startDate}
-								endDate={meta.endDate}
-								onToggle={(checked) =>
-									patch(
-										checked
-											? { expireEnabled: true }
-											: { expireEnabled: false, startDate: '', endDate: '' }
-									)
-								}
-								onStartDateChange={(value) => patch({ startDate: value })}
-								onEndDateChange={(value) => patch({ endDate: value })}
-							/>
+									<VisibilityExpirationField
+										idPrefix={`visibility-${file.id}`}
+										expireEnabled={meta.expireEnabled}
+										startDate={meta.startDate}
+										endDate={meta.endDate}
+										mediaStatus={meta.state}
+										onToggle={(checked) =>
+											patch(
+												checked
+													? { expireEnabled: true }
+													: { expireEnabled: false, startDate: '', endDate: '' }
+											)
+										}
+										onStartDateChange={(value) => patch({ startDate: value })}
+										onEndDateChange={(value) => patch({ endDate: value })}
+									/>
+								</>
+							) : null}
 
 							<Divider />
 

--- a/frontend/src/features/add-media/single-upload/components/FinalSettingsForm.jsx
+++ b/frontend/src/features/add-media/single-upload/components/FinalSettingsForm.jsx
@@ -49,7 +49,10 @@ export function FinalSettingsForm({ singleUpload, canUseRestrictedStatus = false
 								value={option.value}
 								controlClassName="bg-bg-surface-hover"
 								checked={singleUpload.mediaStatus === option.value}
-								onChange={() => singleUpload.setMediaStatus(option.value)}
+								onChange={() => {
+									if (option.value === 'private') singleUpload.setExpireEnabled(false);
+									singleUpload.setMediaStatus(option.value);
+								}}
 							>
 								{option.label}
 							</RadioButton>
@@ -75,16 +78,21 @@ export function FinalSettingsForm({ singleUpload, canUseRestrictedStatus = false
 					/>
 				) : null}
 
-				<div className="my-4 border-b border-b-border-divider" />
+				{singleUpload.mediaStatus !== 'private' ? (
+					<>
+						<div className="my-4 border-b border-b-border-divider" />
 
-				<VisibilityExpirationField
-					expireEnabled={singleUpload.expireEnabled}
-					startDate={singleUpload.startDate}
-					endDate={singleUpload.endDate}
-					onToggle={singleUpload.setExpireEnabled}
-					onStartDateChange={singleUpload.setStartDate}
-					onEndDateChange={singleUpload.setEndDate}
-				/>
+						<VisibilityExpirationField
+							expireEnabled={singleUpload.expireEnabled}
+							startDate={singleUpload.startDate}
+							endDate={singleUpload.endDate}
+							mediaStatus={singleUpload.mediaStatus}
+							onToggle={singleUpload.setExpireEnabled}
+							onStartDateChange={singleUpload.setStartDate}
+							onEndDateChange={singleUpload.setEndDate}
+						/>
+					</>
+				) : null}
 
 				<div className="my-4 border-b border-b-border-divider" />
 

--- a/frontend/src/features/shared/components/upload-media/fields/FinalFields.jsx
+++ b/frontend/src/features/shared/components/upload-media/fields/FinalFields.jsx
@@ -70,10 +70,18 @@ function diffInDays(startIso, endIso) {
 	return Math.max(0, Math.ceil((end - start) / 86400000));
 }
 
+const STATUS_LABELS = {
+	public: 'Public',
+	private: 'Private',
+	restricted: 'Restricted',
+	unlisted: 'Unlisted',
+};
+
 export function VisibilityExpirationField({
 	expireEnabled = false,
 	startDate = '',
 	endDate = '',
+	mediaStatus = 'public',
 	onToggle,
 	onStartDateChange,
 	onEndDateChange,
@@ -83,12 +91,18 @@ export function VisibilityExpirationField({
 	// Backend treats end date as inclusive (+1 day in forms.py), so add 1 to
 	// match: same start and end date = a valid 1-day window, not 0 days.
 	const visibleDays = endDate ? diffInDays(effectiveStart, endDate) + 1 : 0;
+	const statusLabel = STATUS_LABELS[mediaStatus] ?? 'Public';
 
 	return (
 		<>
 			<CheckboxButton checked={expireEnabled} onChange={(event) => onToggle?.(event.target.checked)}>
 				Set Visibility Expiration
 			</CheckboxButton>
+
+			<Text variant="body-14" color="meta" className="m-0">
+				Set a window during which your film is visible. Once the end date passes, it will automatically switch
+				to Private.
+			</Text>
 
 			{expireEnabled ? (
 				<>
@@ -112,8 +126,8 @@ export function VisibilityExpirationField({
 
 					{endDate ? (
 						<Text variant="body-14" color="meta" className="m-0">
-							Your film will be visible for {visibleDays} days, starting {formatDMY(effectiveStart)} to{' '}
-							{formatDMY(endDate)}
+							Your film will be set to {statusLabel} from {formatDMY(effectiveStart)} to{' '}
+							{formatDMY(endDate)}. After that, it will automatically switch to Private.
 						</Text>
 					) : null}
 				</>


### PR DESCRIPTION
Closes #780

## Summary

- Added helper text below the "Set Visibility Expiration" checkbox: _"Set a window during which your film is visible. Once the end date passes, it will automatically switch to Private."_
- Updated confirmation text to include the selected status and the after-expiry behaviour: _"Your film will be set to [Status] from [Start Date] to [End Date]. After that, it will automatically switch to Private."_
- Hides the entire `VisibilityExpirationField` when **Private** status is selected (since setting an expiration window on an already-private film is a no-op). Switching to Private also clears any previously entered expiration dates from the store so they are not silently submitted.
- Applied to both single-upload (`FinalSettingsForm`) and bulk-upload (`FileCard`).

## Screenshots

<img width="911" height="682" alt="image" src="https://github.com/user-attachments/assets/31819409-667d-444e-9c33-9f61d2407126" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated upload visibility settings to better reflect status changes and expiration behavior.
  * Expiration details now show clearer, status-specific wording during setup.

* **Bug Fixes**
  * Private uploads no longer display expiration options.
  * Changing visibility now correctly resets related expiration settings when needed.
  * Restricted uploads keep password settings aligned with the selected status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->