### PR TITLE
feat(media): add revamped edit media page

### DIFF
--- a/cms/ui_variant.py
+++ b/cms/ui_variant.py
@@ -9,6 +9,7 @@ UI_VARIANT_PAGES = {
     "home": ("cms/index.html", "cms/index_revamp.html"),
     "media": ("cms/media.html", "cms/media_revamp.html"),
     "upload": ("cms/add-media.html", "cms/add-media_revamp.html"),
+    "edit_media": ("cms/edit_media.html", "cms/edit_media_revamp.html"),
 }
 
 

--- a/files/views.py
+++ b/files/views.py
@@ -19,6 +19,7 @@ from django.core.mail import EmailMessage
 from django.db import DatabaseError, models, transaction
 from django.db.models import Case, Exists, F, OuterRef, Q, Value, When
 from django.http import Http404, HttpResponse, HttpResponseRedirect, JsonResponse
+from django.middleware.csrf import get_token
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils import timezone
@@ -680,6 +681,171 @@ def upload_media(request):
     return render(request, template, context)
 
 
+def _json_value(value):
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, datetime):
+        return _local_or_naive_datetime(value).strftime("%Y-%m-%d")
+    if hasattr(value, "isoformat") and not isinstance(value, str):
+        return value.isoformat()
+    if isinstance(value, (list, tuple, set)):
+        return [_json_value(item) for item in value]
+    if hasattr(value, "value"):
+        return str(value.value)
+    return str(value)
+
+
+def _local_or_naive_datetime(value):
+    if timezone.is_naive(value):
+        return value
+    return timezone.localtime(value)
+
+
+def _choice_value(value):
+    if hasattr(value, "value"):
+        value = value.value
+    return "" if value is None else str(value)
+
+
+def _field_options(form, field_name):
+    field = form.fields.get(field_name)
+    if not field or not hasattr(field, "choices"):
+        return []
+
+    options = []
+    for value, label in field.choices:
+        if value in ("", None):
+            continue
+        options.append({"value": _choice_value(value), "label": str(label)})
+    return options
+
+
+def _field_value(form, field_name):
+    if field_name not in form.fields:
+        return "" if field_name not in {"enable_comments", "allow_download", "featured", "is_reviewed"} else False
+
+    return _json_value(form[field_name].value())
+
+
+def _datetime_field_value(form, field_name):
+    if field_name not in form.fields:
+        return ""
+
+    value = form[field_name].value()
+    if isinstance(value, datetime):
+        return _local_or_naive_datetime(value).strftime("%Y-%m-%d %H:%M:%S")
+    return _json_value(value)
+
+
+def _file_info(file_field):
+    if not file_field:
+        return {"name": "", "url": ""}
+
+    name = getattr(file_field, "name", "") or ""
+    try:
+        url = file_field.url
+    except Exception:
+        url = ""
+    return {"name": os.path.basename(name), "url": url}
+
+
+def _form_errors_for_json(form):
+    return {field: [str(error) for error in errors] for field, errors in form.errors.items()}
+
+
+def _license_options_for_json(licenses_dict):
+    return [
+        {
+            "id": str(data["id"]),
+            "title": data["title"],
+            "allowCommercial": data["allow_commercial"],
+            "allowModifications": data["allow_modifications"],
+        }
+        for data in licenses_dict.values()
+    ]
+
+
+def _edit_media_page_config(request, form, media, licenses_dict, video_extensions):
+    form_fields = set(form.fields.keys())
+    media_file = _file_info(media.media_file)
+    uploaded_poster = _file_info(media.uploaded_poster)
+
+    try:
+        sprites_url = media.sprites.url if media.sprites else ""
+    except Exception:
+        sprites_url = ""
+
+    selected_license = _field_value(form, "custom_license")
+    no_license = bool(_field_value(form, "no_license")) or selected_license in ("", "None", "none")
+    update_url = reverse("uploader:update", kwargs={"friendly_token": media.friendly_token})
+
+    return {
+        "csrfToken": get_token(request),
+        "editUrl": request.get_full_path(),
+        "uploadEndpoint": update_url,
+        "uploadCompleteEndpoint": f"{update_url}?{settings.CHUNKS_DONE_PARAM_NAME}",
+        "uploadCancelEndpoint": reverse("uploader:cancel", kwargs={"friendly_token": media.friendly_token}),
+        "uploadMaxSize": settings.UPLOAD_MAX_SIZE,
+        "allowedExtensions": video_extensions,
+        "permissions": {
+            "canReplaceMedia": "media_file" in form_fields,
+            "canUseAdminSettings": bool({"featured", "reported_times", "is_reviewed", "add_date"} & form_fields),
+            "canUseEncryption": "is_encrypted" in form_fields,
+            "canUseWhisperTranslate": "allow_whisper_transcribe_and_translate" in form_fields,
+        },
+        "fields": sorted(form_fields),
+        "options": {
+            "mediaLanguages": _field_options(form, "media_language"),
+            "mediaCountries": _field_options(form, "media_country"),
+            "categories": _field_options(form, "category"),
+            "contentSensitivities": _field_options(form, "content_sensitivity"),
+            "topics": _field_options(form, "topics"),
+            "states": _field_options(form, "state"),
+            "licenses": _license_options_for_json(licenses_dict),
+        },
+        "media": {
+            "friendlyToken": media.friendly_token,
+            "title": _field_value(form, "title"),
+            "summary": _field_value(form, "summary"),
+            "description": _field_value(form, "description"),
+            "yearProduced": _field_value(form, "year_produced_custom") or _field_value(form, "year_produced"),
+            "company": _field_value(form, "company"),
+            "website": _field_value(form, "website"),
+            "mediaLanguage": _field_value(form, "media_language"),
+            "mediaCountry": _field_value(form, "media_country"),
+            "category": _field_value(form, "category"),
+            "contentSensitivity": _field_value(form, "content_sensitivity"),
+            "topics": _field_value(form, "topics"),
+            "tags": _field_value(form, "new_tags"),
+            "selectedLicenseId": "" if no_license else selected_license,
+            "noLicense": no_license,
+            "enableComments": bool(_field_value(form, "enable_comments")),
+            "allowDownload": bool(_field_value(form, "allow_download")),
+            "isEncrypted": bool(_field_value(form, "is_encrypted")),
+            "mediaStatus": _field_value(form, "state"),
+            "hasPassword": bool(media.password),
+            "featured": bool(_field_value(form, "featured")),
+            "isReviewed": bool(_field_value(form, "is_reviewed")),
+            "reportedTimes": _field_value(form, "reported_times"),
+            "addDate": _datetime_field_value(form, "add_date"),
+            "allowWhisperTranslate": bool(_field_value(form, "allow_whisper_transcribe_and_translate")),
+            "visibilityStart": _field_value(form, "visibility_start"),
+            "visibilityEnd": _field_value(form, "visibility_end"),
+            "currentMediaFile": media_file,
+            "currentPosterFile": uploaded_poster,
+            "posterUrl": getattr(media, "poster_url", "") or uploaded_poster["url"],
+            "spritesUrl": sprites_url,
+            "spriteNumSecs": getattr(media, "sprite_num_secs", "") or "",
+            "thumbnailTime": _field_value(form, "thumbnail_time"),
+            "duration": getattr(media, "duration", "") or "",
+            "views": getattr(media, "views", 0) or 0,
+            "errors": _form_errors_for_json(form),
+        },
+    }
+
+
 def view_media(request):
     template = resolve_template(request, "media")
     friendly_token = request.GET.get("m", "").strip()
@@ -1117,16 +1283,15 @@ def edit_media(request):
     # Get allowed video extensions from helper function
     video_extensions = get_allowed_video_extensions()
 
-    return render(
-        request,
-        "cms/edit_media.html",
-        {
-            "form": form,
-            "licenses": json.dumps(licenses_dict),
-            "add_subtitle_url": media.add_subtitle_url,
-            "allowed_extensions": json.dumps(video_extensions),
-        },
-    )
+    template = resolve_template(request, "edit_media")
+    context = {
+        "form": form,
+        "licenses": json.dumps(licenses_dict),
+        "add_subtitle_url": media.add_subtitle_url,
+        "allowed_extensions": json.dumps(video_extensions),
+        "edit_media_page_config": _edit_media_page_config(request, form, media, licenses_dict, video_extensions),
+    }
+    return render(request, template, context)
 
 
 @login_required

--- a/files/views.py
+++ b/files/views.py
@@ -772,10 +772,7 @@ def _edit_media_page_config(request, form, media, licenses_dict, video_extension
     media_file = _file_info(media.media_file)
     uploaded_poster = _file_info(media.uploaded_poster)
 
-    try:
-        sprites_url = media.sprites.url if media.sprites else ""
-    except Exception:
-        sprites_url = ""
+    sprites_url = getattr(media, "sprites_url", "") or ""
 
     selected_license = _field_value(form, "custom_license")
     no_license = bool(_field_value(form, "no_license")) or selected_license in ("", "None", "none")

--- a/frontend/src/entries/edit-media.js
+++ b/frontend/src/entries/edit-media.js
@@ -1,0 +1,10 @@
+import { renderPage } from '../static/js/_helpers.js';
+import { EditMediaPage } from '../features/edit-media';
+
+const isRevamp = document.body?.dataset.uiVariant === 'revamp' && document.getElementById('app-root') !== null;
+
+if (isRevamp) {
+	renderPage('page-edit-media', EditMediaPage);
+} else {
+	renderPage('page-edit-media');
+}

--- a/frontend/src/entries/edit-media.js
+++ b/frontend/src/entries/edit-media.js
@@ -1,10 +1,11 @@
 import { renderPage } from '../static/js/_helpers.js';
-import { EditMediaPage } from '../features/edit-media';
 
 const isRevamp = document.body?.dataset.uiVariant === 'revamp' && document.getElementById('app-root') !== null;
 
 if (isRevamp) {
-	renderPage('page-edit-media', EditMediaPage);
+	import('../features/edit-media').then(({ EditMediaPage }) => {
+		renderPage('page-edit-media', EditMediaPage);
+	});
 } else {
 	renderPage('page-edit-media');
 }

--- a/frontend/src/features/add-media/single-upload/components/BasicDetailsForm.jsx
+++ b/frontend/src/features/add-media/single-upload/components/BasicDetailsForm.jsx
@@ -56,6 +56,7 @@ export function BasicDetailsForm({ singleUpload }) {
 
 			<YearChooserField
 				className="w-full"
+				id="year_produced"
 				name="year_produced"
 				label="Year Produced"
 				required

--- a/frontend/src/features/add-media/single-upload/components/OtherDetailsForm.jsx
+++ b/frontend/src/features/add-media/single-upload/components/OtherDetailsForm.jsx
@@ -224,6 +224,7 @@ export function OtherDetailsForm({
 
 			<Dropdown
 				className="w-full"
+				id="media_language"
 				name="media_language"
 				placeholder="Select media language"
 				label="Media Language"
@@ -237,6 +238,7 @@ export function OtherDetailsForm({
 
 			<Dropdown
 				className="w-full"
+				id="media_country"
 				name="media_country"
 				placeholder="Select media country"
 				label="Media Country"
@@ -251,6 +253,7 @@ export function OtherDetailsForm({
 			<div className="flex flex-col sm:flex-row gap-4 mt-3">
 				<CheckboxGroup
 					className="flex flex-col flex-1"
+					id="category"
 					label="Categories"
 					name="category"
 					required
@@ -273,6 +276,7 @@ export function OtherDetailsForm({
 			<div className="flex flex-col sm:flex-row gap-4 mt-3">
 				<CheckboxGroup
 					className="flex flex-col flex-1"
+					id="topics"
 					label="Topics"
 					name="topics"
 					required

--- a/frontend/src/features/add-media/single-upload/components/ThumbnailImageUpload.jsx
+++ b/frontend/src/features/add-media/single-upload/components/ThumbnailImageUpload.jsx
@@ -11,6 +11,7 @@ export function ThumbnailImageUpload({
 	onFrameSelect,
 	posterUrl = '',
 	selectedThumbnailFile,
+	showHeaderPreview = true,
 	spriteSecs = '',
 	spritesUrl = '',
 }) {
@@ -66,7 +67,7 @@ export function ThumbnailImageUpload({
 		<FieldGroup
 			title="Thumbnail Image Upload"
 			description="This image displays when your video isn’t autoplaying. Use the auto-generated thumbnail, upload a custom image, or choose a still frame from your video."
-			headerAside={headerPreview}
+			headerAside={showHeaderPreview ? headerPreview : null}
 		>
 			<ThumbnailUploadField
 				currentThumbnailTime={currentThumbnailTime}

--- a/frontend/src/features/edit-media/EditMediaPage.jsx
+++ b/frontend/src/features/edit-media/EditMediaPage.jsx
@@ -111,7 +111,8 @@ function EditMediaPageContent() {
 	function scrollToFirstError(errors) {
 		const firstField = ERROR_FIELD_ORDER.find((field) => field in errors);
 		const selector = ERROR_FIELD_SELECTORS[firstField] || '[aria-invalid="true"]';
-		const target = formRef.current?.querySelector(selector) || formRef.current?.querySelector('[aria-invalid="true"]');
+		const target =
+			formRef.current?.querySelector(selector) || formRef.current?.querySelector('[aria-invalid="true"]');
 
 		target?.scrollIntoView({ behavior: 'smooth', block: 'center' });
 		if (typeof target?.focus === 'function') {
@@ -176,7 +177,11 @@ function EditMediaPageContent() {
 							noValidate
 							onSubmit={submitForm}
 						>
-							<input type="hidden" name="csrfmiddlewaretoken" value={config.csrfToken || getCSRFToken() || ''} />
+							<input
+								type="hidden"
+								name="csrfmiddlewaretoken"
+								value={config.csrfToken || getCSRFToken() || ''}
+							/>
 
 							<BasicDetailsForm singleUpload={editState} />
 

--- a/frontend/src/features/edit-media/EditMediaPage.jsx
+++ b/frontend/src/features/edit-media/EditMediaPage.jsx
@@ -1,0 +1,239 @@
+import '../../static/css/tailwind.css';
+import '../../static/js/static_pages/styles/AddMediaPage.scss';
+
+import { useRef } from 'react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { BasicDetailsForm } from '../add-media/single-upload/components/BasicDetailsForm';
+import { OtherDetailsForm } from '../add-media/single-upload/components/OtherDetailsForm';
+import { ThumbnailImageUpload } from '../add-media/single-upload/components/ThumbnailImageUpload';
+import { TextAlert } from '../shared/components/TextAlert';
+import { getCSRFToken } from '../add-media/utils/helpers';
+import { maxWords, required, runValidators } from '../shared/utils/validators';
+import editMediaQueryClient from './queryClient';
+import {
+	AdvancedSettingsSection,
+	AdminSettingsSection,
+	EditMediaHeader,
+	EditMediaQuickPreview,
+	EditorialPolicyNotice,
+	FinalSettingsSection,
+	MediaUploadSection,
+	SubmitActions,
+} from './components';
+import { useEditMediaConfig } from './hooks/useEditMediaConfig';
+import { useEditMediaState } from './hooks/useEditMediaState';
+import { useReplacementUploadState } from './hooks/useReplacementUploadState';
+import { useSubmitEditMedia } from './hooks/useSubmitEditMedia';
+
+const CURRENT_YEAR = new Date().getFullYear();
+
+const ERROR_FIELD_ORDER = [
+	'title',
+	'summary',
+	'year_produced',
+	'website',
+	'media_language',
+	'media_country',
+	'category',
+	'topics',
+	'password',
+];
+
+const ERROR_FIELD_SELECTORS = {
+	title: '#title',
+	summary: '#summary',
+	year_produced: '#year_produced',
+	website: '#website',
+	media_language: '#media_language',
+	media_country: '#media_country',
+	category: '#category',
+	topics: '#topics',
+	password: '#password',
+};
+
+function normalizeErrors(fieldErrors) {
+	const nextErrors = {};
+	const messages = [];
+
+	for (const [field, value] of Object.entries(fieldErrors || {})) {
+		const text = Array.isArray(value) ? value.join(' ') : String(value);
+		nextErrors[field] = text;
+		messages.push(field === '__all__' ? text : `${field}: ${text}`);
+	}
+
+	return {
+		fieldErrors: nextErrors,
+		message: messages.join(' • ') || 'Please review your inputs and try again.',
+	};
+}
+
+function EditMediaPageContent() {
+	const { data: config } = useEditMediaConfig();
+	const formRef = useRef(null);
+	const editState = useEditMediaState(config);
+	const submitMutation = useSubmitEditMedia();
+	const { uploadBusy } = useReplacementUploadState();
+	const { categories, contentSensitivities, licenses, mediaCountries, mediaLanguages, topics } = config.options;
+
+	function validateForm() {
+		const errors = {};
+		const year = String(editState.yearProduced || '').trim();
+		const titleError = runValidators([required()], editState.title);
+		const summaryError = runValidators([required(), maxWords(80)], editState.summary);
+
+		if (titleError) {
+			errors.title = titleError;
+		}
+
+		if (summaryError) {
+			errors.summary = summaryError;
+		}
+
+		if (!year) {
+			errors.year_produced = 'This field is required';
+		} else if (!/^\d+$/.test(year) || Number(year) < 1 || Number(year) > CURRENT_YEAR) {
+			errors.year_produced = `Enter a year up to ${CURRENT_YEAR}`;
+		}
+		if (editState.website && !editState.website.startsWith('https://')) {
+			errors.website = 'Website should start with https://';
+		}
+		if (!editState.mediaLanguage) errors.media_language = 'Select a media language';
+		if (!editState.mediaCountry) errors.media_country = 'Select a media country';
+		if (!editState.category.length) errors.category = 'Select at least one category';
+		if (!editState.topics.length) errors.topics = 'Select at least one topic';
+		if (editState.mediaStatus === 'restricted' && !editState.password && !config.media?.hasPassword) {
+			errors.password = 'Password has to be set when state is Restricted.';
+		}
+
+		return errors;
+	}
+
+	function scrollToFirstError(errors) {
+		const firstField = ERROR_FIELD_ORDER.find((field) => field in errors);
+		const selector = ERROR_FIELD_SELECTORS[firstField] || '[aria-invalid="true"]';
+		const target = formRef.current?.querySelector(selector) || formRef.current?.querySelector('[aria-invalid="true"]');
+
+		target?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+		if (typeof target?.focus === 'function') {
+			target.focus({ preventScroll: true });
+		}
+	}
+
+	function submitForm(event) {
+		event.preventDefault();
+
+		if (uploadBusy) {
+			editState.setSubmitError('Please wait for the media file upload to complete before saving.');
+			return;
+		}
+
+		const errors = validateForm();
+		editState.setErrors(errors);
+		if (Object.keys(errors).length) {
+			editState.setSubmitError('Please review your inputs and try again.');
+			scrollToFirstError(errors);
+			return;
+		}
+
+		editState.setSubmitError('');
+		submitMutation.mutate(
+			{
+				form: formRef.current,
+				thumbnailFile: editState.selectedThumbnailFile,
+				thumbnailTime: editState.thumbnailTime,
+			},
+			{
+				onSuccess: (data) => {
+					window.location.assign(data.url);
+				},
+				onError: (error) => {
+					if (error.fieldErrors) {
+						const normalized = normalizeErrors(error.fieldErrors);
+						editState.setErrors(normalized.fieldErrors);
+						editState.setSubmitError(normalized.message);
+					} else {
+						editState.setSubmitError('Something went wrong while updating this media. Please try again.');
+					}
+				},
+			}
+		);
+	}
+
+	return (
+		<div className="add-media-feature @container/page mx-4 py-8 text-text-primary sm:mx-6 lg:mx-10">
+			<div className="mx-auto grid w-full max-w-[1120px] grid-cols-1 gap-8 @4xl/page:grid-cols-[minmax(0,1fr)_340px] @4xl/page:items-start">
+				<div className="min-w-0 @4xl/page:col-start-1">
+					<div className="flex flex-col gap-8">
+						<EditMediaHeader />
+						<EditorialPolicyNotice />
+
+						<form
+							ref={formRef}
+							action={config.editUrl || window.location.href}
+							method="post"
+							encType="multipart/form-data"
+							className="flex flex-col gap-8"
+							noValidate
+							onSubmit={submitForm}
+						>
+							<input type="hidden" name="csrfmiddlewaretoken" value={config.csrfToken || getCSRFToken() || ''} />
+
+							<BasicDetailsForm singleUpload={editState} />
+
+							{config.permissions?.canReplaceMedia ? (
+								<MediaUploadSection config={config} disabled={uploadBusy} />
+							) : null}
+
+							<ThumbnailImageUpload
+								currentThumbnailTime={config.media?.thumbnailTime ?? ''}
+								duration={config.media?.duration ?? ''}
+								friendlyToken={config.media?.friendlyToken ?? ''}
+								onFileChanged={(files) => editState.setSelectedThumbnailFile(files[0] ?? null)}
+								onFrameSelect={(seconds, frame) => editState.setThumbnailTime(seconds, frame)}
+								posterUrl={config.media?.posterUrl ?? ''}
+								selectedThumbnailFile={editState.selectedThumbnailFile}
+								showHeaderPreview={false}
+								spriteSecs={config.media?.spriteNumSecs ?? ''}
+								spritesUrl={config.media?.spritesUrl ?? ''}
+							/>
+
+							<OtherDetailsForm
+								categories={categories}
+								contentSensitivities={contentSensitivities}
+								licenses={licenses}
+								mediaCountries={mediaCountries}
+								mediaLanguages={mediaLanguages}
+								singleUpload={editState}
+								topics={topics}
+							/>
+
+							<FinalSettingsSection config={config} editState={editState} />
+							<AdvancedSettingsSection config={config} editState={editState} />
+							<AdminSettingsSection config={config} editState={editState} />
+
+							{editState.submitError ? (
+								<TextAlert iconName="infoCircle" className="text-text-danger">
+									{editState.submitError}
+								</TextAlert>
+							) : null}
+
+							<SubmitActions isSubmitting={submitMutation.isPending} uploadBusy={uploadBusy} />
+						</form>
+					</div>
+				</div>
+
+				<aside className="hidden min-w-0 @4xl/page:sticky @4xl/page:top-[calc(var(--header-height)+1rem)] @4xl/page:col-start-2 @4xl/page:row-start-1 @4xl/page:block @4xl/page:self-start">
+					<EditMediaQuickPreview config={config} editState={editState} className="min-w-0" />
+				</aside>
+			</div>
+		</div>
+	);
+}
+
+export function EditMediaPage() {
+	return (
+		<QueryClientProvider client={editMediaQueryClient}>
+			<EditMediaPageContent />
+		</QueryClientProvider>
+	);
+}

--- a/frontend/src/features/edit-media/components/AdminSettingsSection.jsx
+++ b/frontend/src/features/edit-media/components/AdminSettingsSection.jsx
@@ -1,0 +1,57 @@
+import { FieldGroup } from '../../add-media/single-upload/components/FieldGroup';
+import { CheckboxButton } from '../../shared/components/CheckboxButton';
+import { TextField } from '../../shared/components/TextField';
+
+export function AdminSettingsSection({ config, editState }) {
+	if (!config.permissions?.canUseAdminSettings) {
+		return null;
+	}
+
+	return (
+		<FieldGroup title="Admin Settings">
+			<div className="grid gap-5">
+				{config.fields?.includes('featured') ? (
+					<CheckboxButton
+						name="featured"
+						checked={editState.featured}
+						onChange={(event) => editState.setFeatured(event.target.checked)}
+					>
+						Featured
+					</CheckboxButton>
+				) : null}
+				{config.fields?.includes('is_reviewed') ? (
+					<CheckboxButton
+						name="is_reviewed"
+						checked={editState.isReviewed}
+						onChange={(event) => editState.setIsReviewed(event.target.checked)}
+					>
+						Reviewed
+					</CheckboxButton>
+				) : null}
+				{config.fields?.includes('reported_times') ? (
+					<TextField
+						className="w-full max-w-sm"
+						id="reported_times"
+						name="reported_times"
+						type="number"
+						label="Reported Times"
+						value={editState.reportedTimes}
+						onChange={(event) => editState.setReportedTimes(event.target.value)}
+						min="0"
+						step="1"
+					/>
+				) : null}
+				{config.fields?.includes('add_date') ? (
+					<TextField
+						className="w-full max-w-sm"
+						id="add_date"
+						name="add_date"
+						label="Publication Date"
+						value={editState.addDate}
+						onChange={(event) => editState.setAddDate(event.target.value)}
+					/>
+				) : null}
+			</div>
+		</FieldGroup>
+	);
+}

--- a/frontend/src/features/edit-media/components/AdvancedSettingsSection.jsx
+++ b/frontend/src/features/edit-media/components/AdvancedSettingsSection.jsx
@@ -1,0 +1,30 @@
+import { FieldGroup } from '../../add-media/single-upload/components/FieldGroup';
+import { Text } from '../../shared/components';
+import { CheckboxButton } from '../../shared/components/CheckboxButton';
+
+export function AdvancedSettingsSection({ config, editState }) {
+	if (!config.permissions?.canUseWhisperTranslate) {
+		return null;
+	}
+
+	return (
+		<FieldGroup title="Advanced Settings">
+			<div className="grid gap-3">
+				<Text variant="body-16-bold" className="m-0 text-text-strong">
+					Automatic Speech Recognition (Beta)
+				</Text>
+				<CheckboxButton
+					name="allow_whisper_transcribe_and_translate"
+					checked={editState.allowWhisperTranslate}
+					onChange={(event) => editState.setAllowWhisperTranslate(event.target.checked)}
+				>
+					Translate to English
+				</CheckboxButton>
+				<Text variant="body-12" className="m-0 text-text-muted">
+					To view or edit auto-generated subtitles, go to the media page and choose Edit Subtitles after
+					uploading the video file.
+				</Text>
+			</div>
+		</FieldGroup>
+	);
+}

--- a/frontend/src/features/edit-media/components/EditMediaHeader.jsx
+++ b/frontend/src/features/edit-media/components/EditMediaHeader.jsx
@@ -1,0 +1,14 @@
+import { Text } from '../../shared/components';
+
+export function EditMediaHeader() {
+	return (
+		<div className="flex flex-col gap-3">
+			<Text variant="h4" as="h1" className="m-0 text-text-strong">
+				Edit Media
+			</Text>
+			<Text variant="body-16" className="m-0 max-w-[720px] text-text-muted">
+				Update the media details, thumbnail, publishing settings, or upload a replacement video file.
+			</Text>
+		</div>
+	);
+}

--- a/frontend/src/features/edit-media/components/EditMediaQuickPreview.jsx
+++ b/frontend/src/features/edit-media/components/EditMediaQuickPreview.jsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+import { QuickPreview } from '../../upload-quick-preview';
+
+function findOptionLabel(options, value) {
+	const option = options.find((item) => String(item.value) === String(value));
+	return option?.label || '';
+}
+
+function firstValue(value) {
+	return Array.isArray(value) ? value[0] : value;
+}
+
+export function EditMediaQuickPreview({ config, editState, className = '' }) {
+	const [posterPreviewUrl, setPosterPreviewUrl] = useState('');
+
+	useEffect(() => {
+		if (
+			!editState.selectedThumbnailFile ||
+			typeof URL === 'undefined' ||
+			typeof URL.createObjectURL !== 'function'
+		) {
+			setPosterPreviewUrl('');
+			return undefined;
+		}
+
+		const url = URL.createObjectURL(editState.selectedThumbnailFile);
+		setPosterPreviewUrl(url);
+		return () => URL.revokeObjectURL(url);
+	}, [editState.selectedThumbnailFile]);
+
+	const categoryValue = firstValue(editState.category);
+	const categoryLabel = findOptionLabel(config.options.categories, categoryValue);
+	const countryLabel = findOptionLabel(config.options.mediaCountries, editState.mediaCountry);
+	const thumbnailFrame = posterPreviewUrl ? null : editState.thumbnailFrame;
+	const thumbnailUrl = posterPreviewUrl || (thumbnailFrame ? '' : config.media?.posterUrl || '');
+
+	return (
+		<QuickPreview
+			title={editState.title}
+			subtitle={editState.company}
+			country={countryLabel}
+			category={categoryLabel ? { title: categoryLabel } : null}
+			thumbnailUrl={thumbnailUrl}
+			thumbnailFrame={thumbnailFrame}
+			views={config.media?.views}
+			className={className}
+		/>
+	);
+}

--- a/frontend/src/features/edit-media/components/EditorialPolicyNotice.jsx
+++ b/frontend/src/features/edit-media/components/EditorialPolicyNotice.jsx
@@ -1,0 +1,22 @@
+import { Card, Text } from '../../shared/components';
+import { TextAlert } from '../../shared/components/TextAlert';
+
+export function EditorialPolicyNotice() {
+	return (
+		<Card className="px-6 py-5">
+			<TextAlert role="note">
+				<Text variant="body-16" color="description" className="m-0">
+					Please check our&nbsp;
+					<a
+						href="/editorial-policy"
+						className="text-text-accent no-underline underline-offset-2 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring-focus"
+					>
+						Editorial Policy
+					</a>
+					&nbsp;before uploading media. Any media that does not comply with the policy will be deleted from
+					Cinemata.org.
+				</Text>
+			</TextAlert>
+		</Card>
+	);
+}

--- a/frontend/src/features/edit-media/components/FinalSettingsSection.jsx
+++ b/frontend/src/features/edit-media/components/FinalSettingsSection.jsx
@@ -1,0 +1,120 @@
+import { FieldGroup } from '../../add-media/single-upload/components/FieldGroup';
+import { Text } from '../../shared/components';
+import { CheckboxButton } from '../../shared/components/CheckboxButton';
+import { DateChooserField } from '../../shared/components/DateChooserField';
+import { RadioButton } from '../../shared/components/RadioButton';
+import { TextField } from '../../shared/components/TextField';
+
+export function FinalSettingsSection({ config, editState }) {
+	return (
+		<FieldGroup title="Final Settings">
+			<div className="flex flex-col gap-5">
+				<CheckboxButton
+					name="enable_comments"
+					checked={editState.enableComments}
+					onChange={(event) => editState.setEnableComments(event.target.checked)}
+				>
+					Enable Comments
+				</CheckboxButton>
+
+				<CheckboxButton
+					name="allow_download"
+					checked={editState.allowDownload}
+					onChange={(event) => editState.setAllowDownload(event.target.checked)}
+				>
+					Allow Download
+				</CheckboxButton>
+
+				<div className="border-b border-b-border-divider" />
+
+				<fieldset className="m-0 border-0 p-0">
+					<legend className="body-body-16-regular mb-2 text-text-muted">Status</legend>
+					<div className="flex flex-wrap items-center gap-6">
+						{config.statusOptions.map((option) => (
+							<RadioButton
+								key={option.value}
+								name="state"
+								value={option.value}
+								controlClassName="bg-bg-surface-hover"
+								checked={editState.mediaStatus === option.value}
+								onChange={() => editState.setMediaStatus(option.value)}
+							>
+								{option.label}
+							</RadioButton>
+						))}
+					</div>
+				</fieldset>
+
+				{editState.mediaStatus === 'restricted' ? (
+					<TextField
+						className="w-full"
+						id="password"
+						name="password"
+						type="password"
+						label="Enter Password"
+						placeholder={config.media?.hasPassword ? 'Leave blank to keep the current password' : 'Write here...'}
+						value={editState.password}
+						onChange={(event) => editState.setPassword(event.target.value)}
+						invalid={Boolean(editState.errors.password)}
+						helperText={editState.errors.password || ''}
+						autoComplete="new-password"
+					/>
+				) : null}
+
+				<div className="border-b border-b-border-divider" />
+
+				<CheckboxButton
+					checked={editState.expireEnabled}
+					onChange={(event) => editState.setExpireEnabled(event.target.checked)}
+				>
+					Set Visibility Expiration
+				</CheckboxButton>
+				{editState.expireEnabled ? (
+					<div className="flex flex-col gap-4 sm:flex-row">
+						<DateChooserField
+							id="visibility_start"
+							name="visibility_start"
+							label="Enter Start Date"
+							value={editState.startDate}
+							onChange={editState.setStartDate}
+						/>
+						<DateChooserField
+							id="visibility_end"
+							name="visibility_end"
+							label="Enter End Date"
+							value={editState.endDate}
+							onChange={editState.setEndDate}
+						/>
+					</div>
+				) : null}
+
+				{config.permissions?.canUseEncryption ? (
+					<>
+						<div className="border-b border-b-border-divider" />
+						<div>
+							<span className="body-body-16-regular mb-2 block text-text-muted">Stream Protection</span>
+							<div className="flex flex-row items-start gap-2">
+								<CheckboxButton
+									name="is_encrypted"
+									className="mt-0.5"
+									aria-label="Encrypt this video's stream"
+									checked={editState.isEncrypted}
+									onChange={(event) => editState.setIsEncrypted(event.target.checked)}
+								/>
+								<div className="flex flex-col gap-2">
+									<Text className="m-0" variant="body-16">
+										Encrypt this video's stream
+									</Text>
+									<Text className="m-0" variant="body-12">
+										Only authorized viewers can watch the HLS stream. Changing this on processed
+										video will trigger re-encoding.
+									</Text>
+								</div>
+							</div>
+						</div>
+					</>
+				) : null}
+			</div>
+		</FieldGroup>
+	);
+}

--- a/frontend/src/features/edit-media/components/FinalSettingsSection.jsx
+++ b/frontend/src/features/edit-media/components/FinalSettingsSection.jsx
@@ -52,7 +52,9 @@ export function FinalSettingsSection({ config, editState }) {
 						name="password"
 						type="password"
 						label="Enter Password"
-						placeholder={config.media?.hasPassword ? 'Leave blank to keep the current password' : 'Write here...'}
+						placeholder={
+							config.media?.hasPassword ? 'Leave blank to keep the current password' : 'Write here...'
+						}
 						value={editState.password}
 						onChange={(event) => editState.setPassword(event.target.value)}
 						invalid={Boolean(editState.errors.password)}

--- a/frontend/src/features/edit-media/components/MediaUploadSection.jsx
+++ b/frontend/src/features/edit-media/components/MediaUploadSection.jsx
@@ -1,0 +1,223 @@
+import { useRef } from 'react';
+import { FieldGroup } from '../../add-media/single-upload/components/FieldGroup';
+import { Text } from '../../shared/components';
+import { MediaDropzone } from '../../shared/components/MediaDropzone';
+import { UploadMediaItem } from '../../shared/components/UploadMediaItem';
+import { getCSRFToken } from '../../add-media/utils/helpers';
+import { useReplacementUploadState } from '../hooks/useReplacementUploadState';
+
+function CurrentFileLink({ file }) {
+	if (!file?.url) {
+		return <span>No media file uploaded yet.</span>;
+	}
+
+	return (
+		<a href={file.url} target="_blank" rel="noreferrer" className="text-text-link hover:text-text-link-hover">
+			{file.name || file.url}
+		</a>
+	);
+}
+
+export function MediaUploadSection({ config, disabled }) {
+	const uploaderRef = useRef(null);
+	const { status, setStatus, resetStatus } = useReplacementUploadState();
+
+	function ensureUploader() {
+		if (uploaderRef.current) {
+			return uploaderRef.current;
+		}
+
+		if (!window.qq?.FineUploaderBasic) {
+			setStatus({ phase: 'error', name: '', progress: 0, error: 'FineUploader is not available.', size: null });
+			return null;
+		}
+
+		uploaderRef.current = new window.qq.FineUploaderBasic({
+			debug: false,
+			request: {
+				endpoint: config.uploadEndpoint,
+				customHeaders: { 'X-CSRFToken': getCSRFToken() || config.csrfToken || '' },
+			},
+			retry: {
+				enableAuto: true,
+				maxAutoAttempts: 2,
+			},
+			validation: {
+				itemLimit: 1,
+				sizeLimit: config.uploadMaxSize,
+				allowedExtensions: config.allowedExtensions || [],
+				acceptFiles: 'video/*',
+			},
+			chunking: {
+				enabled: true,
+				concurrent: { enabled: true },
+				success: { endpoint: config.uploadCompleteEndpoint },
+			},
+			callbacks: {
+				onSubmit: (id, name) => {
+					setStatus({ phase: 'uploading', name, progress: 0, error: '', size: null, id });
+				},
+				onProgress: (id, name, uploadedBytes, totalBytes) => {
+					const progress = totalBytes > 0 ? Math.round((uploadedBytes / totalBytes) * 100) : 0;
+					setStatus((current) => ({ ...current, id, name, progress }));
+				},
+				onComplete: (id, name, response) => {
+					if (response?.success) {
+						let size = null;
+						try {
+							size = uploaderRef.current?.getFile(id)?.size ?? null;
+						} catch (_error) {
+							size = null;
+						}
+						setStatus({ phase: 'complete', name, progress: 100, error: '', size, id });
+					} else {
+						setStatus({
+							phase: 'error',
+							name,
+							progress: 0,
+							error: 'Upload failed. Please try again.',
+							size: null,
+							id,
+						});
+					}
+				},
+				onError: (id, name, errorReason) => {
+					setStatus({
+						phase: 'error',
+						name,
+						progress: 0,
+						error: errorReason || 'Upload failed.',
+						size: null,
+						id,
+					});
+				},
+				onCancel: () => {
+					setStatus({ phase: 'cancelled', name: '', progress: 0, error: '', size: null });
+				},
+			},
+		});
+
+		return uploaderRef.current;
+	}
+
+	function handleFilesSelected(files) {
+		if (!files.length) return;
+		const uploader = ensureUploader();
+		uploader?.addFiles(files.slice(0, 1));
+	}
+
+	async function cancelPendingUpload() {
+		if (status.id !== undefined) {
+			uploaderRef.current?.cancel(status.id);
+		}
+
+		if (config.uploadCancelEndpoint) {
+			await fetch(config.uploadCancelEndpoint, {
+				method: 'POST',
+				credentials: 'same-origin',
+				headers: {
+					'Content-Type': 'application/json',
+					'X-CSRFToken': getCSRFToken() || config.csrfToken || '',
+				},
+			}).catch(() => null);
+		}
+
+		resetStatus();
+	}
+
+	function retryUpload() {
+		if (status.id === undefined || !uploaderRef.current?.retry) {
+			resetStatus();
+			return;
+		}
+
+		setStatus((current) => ({ ...current, phase: 'uploading', error: '' }));
+		uploaderRef.current.retry(status.id);
+	}
+
+	function pauseUpload() {
+		if (status.id === undefined || !uploaderRef.current?.pauseUpload) {
+			return;
+		}
+
+		const paused = uploaderRef.current.pauseUpload(status.id);
+		if (paused) {
+			setStatus((current) => ({ ...current, phase: 'paused', error: '' }));
+		}
+	}
+
+	function continueUpload() {
+		if (status.id === undefined || !uploaderRef.current?.continueUpload) {
+			return;
+		}
+
+		const continued = uploaderRef.current.continueUpload(status.id);
+		if (continued) {
+			setStatus((current) => ({ ...current, phase: 'uploading', error: '' }));
+		}
+	}
+
+	const hasUploadItem = ['uploading', 'paused', 'error', 'complete'].includes(status.phase);
+	const uploadItemStatus =
+		status.phase === 'complete'
+			? 'complete'
+			: status.phase === 'error'
+				? 'failed'
+				: status.phase === 'paused'
+					? 'paused'
+					: 'uploading';
+	const uploadItemStatusText =
+		status.phase === 'complete' ? 'Ready' : status.phase === 'error' ? status.error || 'Upload failed' : undefined;
+
+	return (
+		<FieldGroup
+			title="Media Upload"
+			description="Upload a replacement media file only when you want to change the original video. The new file is saved after you click Update Media."
+		>
+			<div className="rounded-ds-4 border border-border-subtle bg-bg-surface-muted p-4">
+				<Text variant="body-14-bold" className="m-0 text-text-strong">
+					Current file
+				</Text>
+				<Text variant="body-14" className="m-0 mt-1 text-text-muted">
+					<CurrentFileLink file={config.media?.currentMediaFile} />
+				</Text>
+			</div>
+
+			<div>
+				{hasUploadItem ? (
+					<>
+						<UploadMediaItem
+							className="mt-2"
+							title={status.name || 'Uploaded media'}
+							fileSize={status.size}
+							status={uploadItemStatus}
+							statusText={uploadItemStatusText}
+							progress={status.progress}
+							onCancel={cancelPendingUpload}
+							onContinue={continueUpload}
+							onDelete={cancelPendingUpload}
+							onPause={pauseUpload}
+							onRetry={retryUpload}
+							onReupload={resetStatus}
+						/>
+						{status.phase === 'complete' ? (
+							<Text variant="body-12" className="m-0 mt-3 text-text-muted">
+								Click Update Media below to save this replacement file.
+							</Text>
+						) : null}
+					</>
+				) : (
+					<MediaDropzone
+						accept="video/*"
+						multiple={false}
+						label="Drag & Drop File or"
+						buttonVariant="secondary"
+						buttonLabel="CHOOSE MEDIA"
+						disabled={disabled}
+						onFilesSelected={handleFilesSelected}
+					/>
+				)}
+			</div>
+		</FieldGroup>
+	);
+}

--- a/frontend/src/features/edit-media/components/MediaUploadSection.jsx
+++ b/frontend/src/features/edit-media/components/MediaUploadSection.jsx
@@ -106,13 +106,13 @@ export function MediaUploadSection({ config, disabled }) {
 		uploader?.addFiles(files.slice(0, 1));
 	}
 
-	async function cancelPendingUpload() {
+	async function clearReplacementUpload() {
 		if (status.id !== undefined) {
 			uploaderRef.current?.cancel(status.id);
 		}
 
 		if (config.uploadCancelEndpoint) {
-			await fetch(config.uploadCancelEndpoint, {
+			const response = await fetch(config.uploadCancelEndpoint, {
 				method: 'POST',
 				credentials: 'same-origin',
 				headers: {
@@ -120,6 +120,15 @@ export function MediaUploadSection({ config, disabled }) {
 					'X-CSRFToken': getCSRFToken() || config.csrfToken || '',
 				},
 			}).catch(() => null);
+
+			if (!response?.ok) {
+				setStatus((current) => ({
+					...current,
+					phase: 'error',
+					error: 'Could not remove the replacement upload. Please try again.',
+				}));
+				return;
+			}
 		}
 
 		resetStatus();
@@ -187,18 +196,18 @@ export function MediaUploadSection({ config, disabled }) {
 				{hasUploadItem ? (
 					<>
 						<UploadMediaItem
-							className="mt-2"
+							className="mt-2 p-2"
 							title={status.name || 'Uploaded media'}
 							fileSize={status.size}
 							status={uploadItemStatus}
 							statusText={uploadItemStatusText}
 							progress={status.progress}
-							onCancel={cancelPendingUpload}
+							onCancel={clearReplacementUpload}
 							onContinue={continueUpload}
-							onDelete={cancelPendingUpload}
+							onDelete={clearReplacementUpload}
 							onPause={pauseUpload}
 							onRetry={retryUpload}
-							onReupload={resetStatus}
+							onReupload={clearReplacementUpload}
 						/>
 						{status.phase === 'complete' ? (
 							<Text variant="body-12" className="m-0 mt-3 text-text-muted">

--- a/frontend/src/features/edit-media/components/MediaUploadSection.test.jsx
+++ b/frontend/src/features/edit-media/components/MediaUploadSection.test.jsx
@@ -1,0 +1,66 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MediaUploadSection } from './MediaUploadSection';
+import { REPLACEMENT_UPLOAD_QUERY_KEY } from '../hooks/useReplacementUploadState';
+
+const CONFIG = {
+	allowedExtensions: ['mp4'],
+	csrfToken: 'csrf-token',
+	media: {
+		currentMediaFile: {
+			name: 'current.mp4',
+			url: '/media/current.mp4',
+		},
+	},
+	uploadCancelEndpoint: '/upload/cancel/media-token/',
+	uploadCompleteEndpoint: '/upload/complete/',
+	uploadEndpoint: '/upload/',
+	uploadMaxSize: 1000,
+};
+
+function renderMediaUploadSection(status) {
+	const queryClient = new QueryClient({
+		defaultOptions: {
+			queries: {
+				retry: false,
+			},
+		},
+	});
+
+	queryClient.setQueryData(REPLACEMENT_UPLOAD_QUERY_KEY, status);
+
+	return render(
+		<QueryClientProvider client={queryClient}>
+			<MediaUploadSection config={CONFIG} />
+		</QueryClientProvider>
+	);
+}
+
+describe('MediaUploadSection', () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('keeps the staged replacement visible when server cancel fails', async () => {
+		const user = userEvent.setup();
+		vi.spyOn(window, 'fetch').mockResolvedValue({ ok: false });
+
+		renderMediaUploadSection({
+			phase: 'complete',
+			name: 'replacement.mp4',
+			progress: 100,
+			error: '',
+			size: 512,
+			id: 7,
+		});
+
+		await user.click(screen.getByRole('button', { name: 'Delete' }));
+
+		await waitFor(() => {
+			expect(screen.getByText('Could not remove the replacement upload. Please try again.')).toBeInTheDocument();
+		});
+		expect(screen.getByText('replacement.mp4')).toBeInTheDocument();
+		expect(screen.queryByLabelText('Choose media file')).not.toBeInTheDocument();
+	});
+});

--- a/frontend/src/features/edit-media/components/SubmitActions.jsx
+++ b/frontend/src/features/edit-media/components/SubmitActions.jsx
@@ -1,0 +1,19 @@
+import { Button } from '../../shared/components';
+
+export function SubmitActions({ isSubmitting, uploadBusy }) {
+	return (
+		<div className="flex flex-col-reverse gap-3 border-t border-border-divider pt-6 sm:flex-row sm:justify-end">
+			<Button
+				type="button"
+				variant="secondary-outline"
+				onClick={() => window.history.back()}
+				disabled={isSubmitting}
+			>
+				Cancel
+			</Button>
+			<Button type="submit" disabled={uploadBusy || isSubmitting}>
+				{uploadBusy ? 'Upload in progress...' : isSubmitting ? 'Updating...' : 'Update Media'}
+			</Button>
+		</div>
+	);
+}

--- a/frontend/src/features/edit-media/components/index.js
+++ b/frontend/src/features/edit-media/components/index.js
@@ -1,0 +1,8 @@
+export { AdvancedSettingsSection } from './AdvancedSettingsSection';
+export { AdminSettingsSection } from './AdminSettingsSection';
+export { EditMediaHeader } from './EditMediaHeader';
+export { EditMediaQuickPreview } from './EditMediaQuickPreview';
+export { EditorialPolicyNotice } from './EditorialPolicyNotice';
+export { FinalSettingsSection } from './FinalSettingsSection';
+export { MediaUploadSection } from './MediaUploadSection';
+export { SubmitActions } from './SubmitActions';

--- a/frontend/src/features/edit-media/hooks/useEditMediaConfig.js
+++ b/frontend/src/features/edit-media/hooks/useEditMediaConfig.js
@@ -1,0 +1,63 @@
+import { useQuery } from '@tanstack/react-query';
+
+const EMPTY_OPTIONS = {
+	categories: [],
+	contentSensitivities: [],
+	licenses: [],
+	mediaCountries: [],
+	mediaLanguages: [],
+	states: [],
+	topics: [],
+};
+
+const DEFAULT_STATUS_OPTIONS = [
+	{ value: 'public', label: 'Public' },
+	{ value: 'private', label: 'Private' },
+	{ value: 'restricted', label: 'Restricted' },
+	{ value: 'unlisted', label: 'Unlisted' },
+];
+
+export const EMPTY_EDIT_MEDIA_CONFIG = {
+	allowedExtensions: [],
+	csrfToken: '',
+	editUrl: window.location.href,
+	fields: [],
+	media: {},
+	options: EMPTY_OPTIONS,
+	permissions: {},
+	statusOptions: DEFAULT_STATUS_OPTIONS,
+	uploadCancelEndpoint: '',
+	uploadCompleteEndpoint: '',
+	uploadEndpoint: '',
+	uploadMaxSize: null,
+};
+
+export const EDIT_MEDIA_CONFIG_QUERY_KEY = ['edit-media', 'config'];
+
+function normalizeEditMediaConfig(config = {}) {
+	const options = { ...EMPTY_OPTIONS, ...(config.options || {}) };
+
+	return {
+		...EMPTY_EDIT_MEDIA_CONFIG,
+		...config,
+		fields: config.fields || EMPTY_EDIT_MEDIA_CONFIG.fields,
+		media: config.media || EMPTY_EDIT_MEDIA_CONFIG.media,
+		options,
+		permissions: config.permissions || EMPTY_EDIT_MEDIA_CONFIG.permissions,
+		statusOptions: options.states.length ? options.states : DEFAULT_STATUS_OPTIONS,
+	};
+}
+
+function getEditMediaConfig() {
+	return normalizeEditMediaConfig(window.MediaCMS?.editMediaPage);
+}
+
+export function useEditMediaConfig() {
+	return useQuery({
+		queryKey: EDIT_MEDIA_CONFIG_QUERY_KEY,
+		queryFn: getEditMediaConfig,
+		initialData: getEditMediaConfig,
+		staleTime: Infinity,
+		gcTime: Infinity,
+	});
+}

--- a/frontend/src/features/edit-media/hooks/useEditMediaState.js
+++ b/frontend/src/features/edit-media/hooks/useEditMediaState.js
@@ -1,0 +1,157 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+
+export const EDIT_MEDIA_STATE_QUERY_KEY = ['edit-media', 'state'];
+
+function firstLicenseFields(licenses, selectedLicenseId) {
+	const selected =
+		licenses.find((license) => String(license.id) === String(selectedLicenseId)) ?? licenses[0] ?? null;
+	return {
+		commercial: selected?.allowCommercial ?? 'yes',
+		derivatives: selected?.allowModifications ?? 'yes',
+	};
+}
+
+function createEditMediaState(config) {
+	const media = config.media || {};
+	const licenses = config.options.licenses;
+	const initialLicenseId = media.selectedLicenseId || licenses[0]?.id || '';
+
+	return {
+		title: media.title || '',
+		summary: media.summary || '',
+		description: media.description || '',
+		yearProduced: media.yearProduced || '',
+		company: media.company || '',
+		website: media.website || '',
+		mediaLanguage: media.mediaLanguage || '',
+		mediaCountry: media.mediaCountry || '',
+		category: media.category || [],
+		contentSensitivity: media.contentSensitivity || [],
+		topics: media.topics || [],
+		tags: media.tags || '',
+		licenseDialogOpen: false,
+		noLicense: media.noLicense ?? true,
+		selectedLicenseId: initialLicenseId,
+		selectedLicenseFields: firstLicenseFields(licenses, initialLicenseId),
+		allowDownload: media.allowDownload ?? true,
+		enableComments: media.enableComments ?? true,
+		isEncrypted: media.isEncrypted ?? false,
+		mediaStatus: media.mediaStatus || 'private',
+		password: '',
+		expireEnabled: Boolean(media.visibilityStart || media.visibilityEnd),
+		startDate: media.visibilityStart || '',
+		endDate: media.visibilityEnd || '',
+		featured: media.featured ?? false,
+		isReviewed: media.isReviewed ?? false,
+		reportedTimes: media.reportedTimes || '0',
+		addDate: media.addDate || '',
+		allowWhisperTranslate: media.allowWhisperTranslate ?? false,
+		selectedThumbnailFile: null,
+		lastSelectedThumbnailFile: '',
+		thumbnailTime: null,
+		thumbnailFrame: null,
+		errors: media.errors || {},
+		submitError: '',
+	};
+}
+
+function withoutError(errors, field) {
+	if (!(field in errors)) return errors;
+	const nextErrors = { ...errors };
+	delete nextErrors[field];
+	return nextErrors;
+}
+
+export function useEditMediaState(config) {
+	const queryClient = useQueryClient();
+	const licenses = config.options.licenses;
+	const queryKey = [...EDIT_MEDIA_STATE_QUERY_KEY, config.media?.friendlyToken || 'new'];
+	const initialState = () => createEditMediaState(config);
+	const { data: state = initialState() } = useQuery({
+		queryKey,
+		queryFn: initialState,
+		initialData: initialState,
+		staleTime: Infinity,
+		gcTime: Infinity,
+	});
+
+	function updateState(updater) {
+		queryClient.setQueryData(queryKey, (current) => {
+			const base = current || initialState();
+			return typeof updater === 'function' ? updater(base) : { ...base, ...updater };
+		});
+	}
+
+	function patch(next) {
+		updateState(next);
+	}
+
+	function patchAndClear(next, field) {
+		updateState((current) => ({
+			...current,
+			...next,
+			errors: withoutError(current.errors, field),
+		}));
+	}
+
+	return {
+		...state,
+		setTitle: (title) => patchAndClear({ title }, 'title'),
+		setSummary: (summary) => patchAndClear({ summary }, 'summary'),
+		setDescription: (description) => patch({ description }),
+		setYearProduced: (yearProduced) => patchAndClear({ yearProduced }, 'year_produced'),
+		setCompany: (company) => patch({ company }),
+		setWebsite: (website) => patchAndClear({ website }, 'website'),
+		setMediaLanguage: (mediaLanguage) => patchAndClear({ mediaLanguage }, 'media_language'),
+		setMediaCountry: (mediaCountry) => patchAndClear({ mediaCountry }, 'media_country'),
+		setCategory: (category) => patchAndClear({ category }, 'category'),
+		setContentSensitivity: (contentSensitivity) => patch({ contentSensitivity }),
+		setTopics: (topics) => patchAndClear({ topics }, 'topics'),
+		setTags: (tags) => patch({ tags }),
+		setLicenseDialogOpen: (licenseDialogOpen) => patch({ licenseDialogOpen }),
+		setNoLicense: (noLicense) =>
+			updateState((current) => ({
+				...current,
+				noLicense,
+				selectedLicenseId: noLicense ? current.selectedLicenseId : current.selectedLicenseId || licenses[0]?.id || '',
+			})),
+		setSelectedLicenseField: (field, value) =>
+			updateState((current) => ({
+				...current,
+				selectedLicenseFields: { ...current.selectedLicenseFields, [field]: value },
+			})),
+		applySelectedLicense: (selectedLicenseId) =>
+			patch({ selectedLicenseId, noLicense: false, licenseDialogOpen: false }),
+		setAllowDownload: (allowDownload) => patch({ allowDownload }),
+		setEnableComments: (enableComments) => patch({ enableComments }),
+		setIsEncrypted: (isEncrypted) => patch({ isEncrypted }),
+		setMediaStatus: (mediaStatus) =>
+			updateState((current) => ({
+				...current,
+				mediaStatus,
+				password: mediaStatus === 'restricted' ? current.password : '',
+				errors: mediaStatus === 'restricted' ? current.errors : withoutError(current.errors, 'password'),
+			})),
+		setPassword: (password) => patchAndClear({ password }, 'password'),
+		setExpireEnabled: (expireEnabled) =>
+			patch(expireEnabled ? { expireEnabled } : { expireEnabled, startDate: '', endDate: '' }),
+		setStartDate: (startDate) => patch({ startDate }),
+		setEndDate: (endDate) => patch({ endDate }),
+		setFeatured: (featured) => patch({ featured }),
+		setIsReviewed: (isReviewed) => patch({ isReviewed }),
+		setReportedTimes: (reportedTimes) => patch({ reportedTimes }),
+		setAddDate: (addDate) => patch({ addDate }),
+		setAllowWhisperTranslate: (allowWhisperTranslate) => patch({ allowWhisperTranslate }),
+		setSelectedThumbnailFile: (selectedThumbnailFile) =>
+			patch({
+				selectedThumbnailFile,
+				lastSelectedThumbnailFile: selectedThumbnailFile?.name ?? '',
+				thumbnailTime: null,
+				thumbnailFrame: null,
+			}),
+		setThumbnailTime: (thumbnailTime, thumbnailFrame = null) =>
+			patch({ thumbnailTime, thumbnailFrame, selectedThumbnailFile: null, lastSelectedThumbnailFile: '' }),
+		setErrors: (errors) => patch({ errors }),
+		setSubmitError: (submitError) => patch({ submitError }),
+	};
+}

--- a/frontend/src/features/edit-media/hooks/useEditMediaState.js
+++ b/frontend/src/features/edit-media/hooks/useEditMediaState.js
@@ -113,7 +113,9 @@ export function useEditMediaState(config) {
 			updateState((current) => ({
 				...current,
 				noLicense,
-				selectedLicenseId: noLicense ? current.selectedLicenseId : current.selectedLicenseId || licenses[0]?.id || '',
+				selectedLicenseId: noLicense
+					? current.selectedLicenseId
+					: current.selectedLicenseId || licenses[0]?.id || '',
 			})),
 		setSelectedLicenseField: (field, value) =>
 			updateState((current) => ({

--- a/frontend/src/features/edit-media/hooks/useReplacementUploadState.js
+++ b/frontend/src/features/edit-media/hooks/useReplacementUploadState.js
@@ -1,0 +1,40 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+
+export const REPLACEMENT_UPLOAD_QUERY_KEY = ['edit-media', 'replacement-upload'];
+
+export const EMPTY_REPLACEMENT_UPLOAD_STATE = {
+	phase: 'idle',
+	name: '',
+	progress: 0,
+	error: '',
+	size: null,
+};
+
+export function useReplacementUploadState() {
+	const queryClient = useQueryClient();
+	const { data: status = EMPTY_REPLACEMENT_UPLOAD_STATE } = useQuery({
+		queryKey: REPLACEMENT_UPLOAD_QUERY_KEY,
+		queryFn: () => EMPTY_REPLACEMENT_UPLOAD_STATE,
+		initialData: EMPTY_REPLACEMENT_UPLOAD_STATE,
+		staleTime: Infinity,
+		gcTime: Infinity,
+	});
+
+	function setStatus(nextStatus) {
+		queryClient.setQueryData(REPLACEMENT_UPLOAD_QUERY_KEY, (current) => {
+			const base = current || EMPTY_REPLACEMENT_UPLOAD_STATE;
+			return typeof nextStatus === 'function' ? nextStatus(base) : nextStatus;
+		});
+	}
+
+	function resetStatus() {
+		setStatus(EMPTY_REPLACEMENT_UPLOAD_STATE);
+	}
+
+	return {
+		status,
+		setStatus,
+		resetStatus,
+		uploadBusy: ['uploading', 'paused'].includes(status.phase),
+	};
+}

--- a/frontend/src/features/edit-media/hooks/useSubmitEditMedia.js
+++ b/frontend/src/features/edit-media/hooks/useSubmitEditMedia.js
@@ -1,0 +1,39 @@
+import { useMutation } from '@tanstack/react-query';
+
+export function useSubmitEditMedia() {
+	return useMutation({
+		mutationFn: async ({ form, thumbnailFile, thumbnailTime }) => {
+			const body = new FormData(form);
+			body.set('action', 'submit');
+			body.delete('uploaded_poster');
+			body.delete('thumbnail_time');
+
+			if (thumbnailFile) {
+				body.set('uploaded_poster', thumbnailFile);
+			} else if (thumbnailTime != null && thumbnailTime !== '') {
+				body.set('thumbnail_time', String(thumbnailTime));
+			}
+
+			const response = await fetch(form.action, {
+				method: 'POST',
+				body,
+				credentials: 'same-origin',
+				headers: { 'X-Requested-With': 'XMLHttpRequest' },
+			});
+			const data = await response.json().catch(() => null);
+
+			if (response.ok && data?.success) {
+				return data;
+			}
+
+			if (data?.errors) {
+				const error = new Error('Please review your inputs and try again.');
+				error.fieldErrors = data.errors;
+				error.status = response.status;
+				throw error;
+			}
+
+			throw new Error(`Unexpected response: ${response.status}`);
+		},
+	});
+}

--- a/frontend/src/features/edit-media/index.js
+++ b/frontend/src/features/edit-media/index.js
@@ -1,0 +1,1 @@
+export { EditMediaPage } from './EditMediaPage';

--- a/frontend/src/features/edit-media/queryClient.js
+++ b/frontend/src/features/edit-media/queryClient.js
@@ -1,0 +1,9 @@
+import { QueryClient } from '@tanstack/react-query';
+
+const editMediaQueryClient = new QueryClient({
+	defaultOptions: {
+		queries: { staleTime: 5 * 60_000, refetchOnWindowFocus: false, retry: 1 },
+	},
+});
+
+export default editMediaQueryClient;

--- a/frontend/src/features/shared/components/CheckboxGroup/CheckboxGroup.jsx
+++ b/frontend/src/features/shared/components/CheckboxGroup/CheckboxGroup.jsx
@@ -47,7 +47,7 @@ export function CheckboxGroup({
 	}
 
 	return (
-		<div className={className}>
+		<div id={groupId} className={className}>
 			{label ? (
 				<span id={labelId} className="body-body-16-regular mb-2 text-text-muted">
 					{label}

--- a/frontend/src/features/shared/components/ProgressBar/ProgressBar.jsx
+++ b/frontend/src/features/shared/components/ProgressBar/ProgressBar.jsx
@@ -1,4 +1,5 @@
 import { cn } from '../../utils/classNames';
+
 function clamp(value, min, max) {
 	return Math.min(Math.max(value, min), max);
 }

--- a/frontend/src/features/shared/components/UploadMediaItem/UploadMediaItem.jsx
+++ b/frontend/src/features/shared/components/UploadMediaItem/UploadMediaItem.jsx
@@ -27,7 +27,7 @@ const STATUS_CONFIG = {
 	paused: {
 		statusText: 'Paused',
 		statusClassName: 'text-text-muted',
-		progressClassName: 'bg-bg-secondary',
+		progressClassName: 'bg-cinemata-coral-reef-400p',
 		showProgress: true,
 		actions: [
 			{ key: 'continue', label: 'Continue', iconName: 'playCircle', type: 'warning' },
@@ -160,10 +160,12 @@ export function UploadMediaItem({
 	onReupload,
 	progress = 0,
 	status = 'uploading',
+	statusText,
 	thumbnailSrc = '',
 	title = 'Untitled media file',
 }) {
 	const config = STATUS_CONFIG[status] ?? STATUS_CONFIG.uploading;
+	const displayStatusText = statusText ?? config.statusText;
 	const progressPercent = status === 'complete' ? 100 : clampPercent(progress);
 	const fileSizeLabel = getFileSizeLabel(fileSize);
 	const sizeLabel = [`${progressPercent}%`, fileSizeLabel ? `(${fileSizeLabel})` : ''].filter(Boolean).join(' ');
@@ -285,7 +287,7 @@ export function UploadMediaItem({
 								)}
 								role={status === 'failed' ? 'status' : undefined}
 							>
-								{includeFineUploaderSelectors ? null : config.statusText}
+								{includeFineUploaderSelectors ? null : displayStatusText}
 							</Text>
 						</div>
 

--- a/frontend/src/features/shared/components/UploadMediaItem/UploadMediaItem.jsx
+++ b/frontend/src/features/shared/components/UploadMediaItem/UploadMediaItem.jsx
@@ -10,7 +10,7 @@ const STATUS_CONFIG = {
 	uploading: {
 		statusText: 'Uploading',
 		statusClassName: 'text-text-muted',
-		progressClassName: 'bg-cinemata-coral-reef-400p',
+		progressClassName: 'bg-bg-progress-bar-upload',
 		showProgress: true,
 		actions: [
 			{ key: 'pause', label: 'Pause', iconName: 'pause', type: 'warning' },
@@ -20,14 +20,14 @@ const STATUS_CONFIG = {
 	processing: {
 		statusText: 'Processing...',
 		statusClassName: 'text-text-muted',
-		progressClassName: 'bg-cinemata-coral-reef-400p',
+		progressClassName: 'bg-bg-progress-bar-upload',
 		showProgress: false,
 		actions: [{ key: 'cancel', label: 'Cancel', iconName: 'cancel', type: 'danger' }],
 	},
 	paused: {
 		statusText: 'Paused',
 		statusClassName: 'text-text-muted',
-		progressClassName: 'bg-cinemata-coral-reef-400p',
+		progressClassName: 'bg-bg-progress-bar-upload',
 		showProgress: true,
 		actions: [
 			{ key: 'continue', label: 'Continue', iconName: 'playCircle', type: 'warning' },

--- a/frontend/src/static/css/tailwind.css
+++ b/frontend/src/static/css/tailwind.css
@@ -1041,6 +1041,7 @@ body {
 	--bg-chip-active: var(--cinemata-sunset-horizon-400p);
 	--bg-chip: var(--cinemata-strait-blue-100);
 	--bg-tab-trigger-selected: var(--cinemata-strait-blue-200);
+	--bg-progress-bar-upload: var(--cinemata-coral-reef-400p);
 
 	/* Text */
 	--text-strong: var(--cinemata-pacific-deep-900);
@@ -1132,6 +1133,7 @@ body.dark_theme {
 	--bg-chip-active: var(--cinemata-sunset-horizon-400p);
 	--bg-chip: var(--cinemata-pacific-deep-700);
 	--bg-tab-trigger-selected: var(--cinemata-strait-blue-200);
+	--bg-progress-bar-upload: var(--cinemata-coral-reef-400p);
 
 	--text-strong: var(--cinemata-strait-blue-50);
 	--text-primary: var(--cinemata-strait-blue-50);
@@ -1220,6 +1222,7 @@ body.dark_theme {
 	--color-bg-chip-active: var(--bg-chip-active);
 	--color-bg-chip: var(--bg-chip);
 	--color-bg-tab-trigger-selected: var(--bg-tab-trigger-selected);
+	--color-bg-progress-bar-upload: var(--bg-progress-bar-upload);
 
 	/* Text */
 	--color-text-strong: var(--text-strong);

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -136,6 +136,7 @@ export default defineConfig({
 				history: 'src/entries/history.js',
 				liked: 'src/entries/liked.js',
 				'add-media': 'src/entries/add-media.js',
+				'edit-media': 'src/entries/edit-media.js',
 				error: 'src/entries/error.js',
 				'modern-demo': 'src/entries/modern-demo.js',
 				notifications: 'src/entries/notifications.js',

--- a/templates/cms/edit_media.html
+++ b/templates/cms/edit_media.html
@@ -53,6 +53,7 @@
 						</div>
 						<div class="media-uploader-section" style="
 							width: 100%;
+							height: 360px;
 							padding: 20px;
 							margin-top: 15px;
 							border: 2px dashed var(--input-border-color, var(--cinemata-neutral-300));

--- a/templates/cms/edit_media.html
+++ b/templates/cms/edit_media.html
@@ -16,7 +16,7 @@
 {% endblock externallinks %}
 
 {% block topimports %}
-{% vite_asset 'src/entries/add-media.js' %}
+{% vite_asset 'src/entries/edit-media.js' %}
 {% endblock topimports %}
 
 {% block innercontent %}

--- a/templates/cms/edit_media_revamp.html
+++ b/templates/cms/edit_media_revamp.html
@@ -1,0 +1,30 @@
+{% extends "base_modern.html" %}
+{% load static %}
+{% load django_vite %}
+
+{% block headtitle %}Edit Media - {{PORTAL_NAME}}{% endblock headtitle %}
+
+{% block externallinks %}
+{% if LOAD_FROM_CDN %}
+<link href="https://cdnjs.cloudflare.com/ajax/libs/file-uploader/5.13.0/fine-uploader.min.js" rel="preload" as="script" integrity="sha384-s4tTAUzowK9zROQxp/mYIe9Ah2IqXf8pSUWZAk4o2C/Ri/wSbqiEE1+F6AQIQaAz" crossorigin="anonymous">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/file-uploader/5.13.0/fine-uploader.min.js" integrity="sha384-s4tTAUzowK9zROQxp/mYIe9Ah2IqXf8pSUWZAk4o2C/Ri/wSbqiEE1+F6AQIQaAz" crossorigin="anonymous"></script>
+{% else %}
+<link href="{% static "lib/file-uploader/5.13.0/fine-uploader.min.js" %}" rel="preload" as="script">
+<script src="{% static "lib/file-uploader/5.13.0/fine-uploader.min.js" %}"></script>
+{% endif %}
+{% endblock externallinks %}
+
+{% block modernpageimports %}
+{% vite_asset 'src/entries/edit-media.js' %}
+{% endblock modernpageimports %}
+
+{% block content %}
+{{ edit_media_page_config|json_script:"edit-media-page-config" }}
+
+<script>
+	window.MediaCMS = window.MediaCMS || {};
+	window.MediaCMS.editMediaPage = JSON.parse(document.getElementById('edit-media-page-config').textContent);
+</script>
+
+<div id="app-root"></div>
+{% endblock content %}

--- a/tests/test_ui_variant.py
+++ b/tests/test_ui_variant.py
@@ -54,6 +54,13 @@ class ResolveTemplateTests(TestCase):
         self.assertEqual(result, "cms/add-media_revamp.html")
         self.assertEqual(request.ui_variant, "revamp")
 
+    @override_settings(UI_VARIANT_REVAMP_PAGES=["edit_media"])
+    def test_edit_media_revamp_when_allowlisted(self):
+        request = self._make_request()
+        result = resolve_template(request, "edit_media")
+        self.assertEqual(result, "cms/edit_media_revamp.html")
+        self.assertEqual(request.ui_variant, "revamp")
+
     @override_settings(UI_VARIANT_REVAMP_PAGES=["home"])
     def test_revamp_when_allowlisted_logged_in(self):
         request = self._make_request(is_staff=False)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Adds a revamped "Edit Media" page following the Modern Track pattern (React + Tailwind + TanStack Query), gated behind the existing UI variant allowlist (`UI_VARIANT_REVAMP_PAGES`). The new page reuses the add-media form components (BasicDetailsForm, OtherDetailsForm, ThumbnailImageUpload) and introduces a dedicated `edit-media` feature module with its own state hooks, submission mutation, and replacement-media upload section powered by FineUploader.

Key changes:
- **Backend (`files/views.py`)**: New `_edit_media_page_config()` builder serializes the existing `EditMediaForm` into a JSON config consumed by the React app; `edit_media()` now uses `resolve_template()` so the revamp template renders when the page is allowlisted. CSRF token is injected via `get_token()`.
- **UI variant (`cms/ui_variant.py`)**: Registers `edit_media` in `UI_VARIANT_PAGES` mapping to the legacy and revamp templates.
- **Templates**: New `cms/edit_media_revamp.html` extending `base_modern.html` and emitting the page config via `json_script`; legacy template now loads `edit-media.js` instead of `add-media.js`.
- **Frontend feature module** (`frontend/src/features/edit-media/`): New `EditMediaPage` plus components (`EditMediaHeader`, `EditorialPolicyNotice`, `MediaUploadSection`, `FinalSettingsSection`, `AdvancedSettingsSection`, `AdminSettingsSection`, `EditMediaQuickPreview`, `SubmitActions`) and hooks (`useEditMediaConfig`, `useEditMediaState`, `useReplacementUploadState`, `useSubmitEditMedia`) backed by a dedicated `QueryClient`.
- **Shared components**: `CheckboxGroup` now forwards a DOM `id`; `UploadMediaItem` accepts an explicit `statusText` override and uses the `cinemata-coral-reef-400` color for the paused progress bar; `ThumbnailImageUpload` gains a `showHeaderPreview` toggle (disabled on the edit page); add-media forms propagate `id` attributes used for error-scroll targeting.
- **Vite**: Registers the `edit-media` entry point.
- **Tests (`tests/test_ui_variant.py`)**: Adds a case asserting `edit_media` resolves to the revamp template when allowlisted.

## Related Issue
<!--- Please link to the issue here: -->
Fixes #777 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The legacy edit-media view was server-rendered with jQuery and inconsistent with the modernized add-media flow. This change brings the edit experience onto the Modern Track so editors get the same component library, validation, and upload UX as the add-media page, while preserving the original template for any environment where the revamp variant isn't enabled.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Added `test_edit_media_revamp_when_allowlisted` to `tests/test_ui_variant.py` verifying template resolution and `request.ui_variant` assignment; ran the Django test suite for that module (`python manage.py test tests.test_ui_variant`).
- Manually verified both variants locally with `UI_VARIANT_REVAMP_PAGES=["edit_media"]` enabled and disabled: legacy template still renders and submits correctly; revamp page hydrates from `window.MediaCMS.editMediaPage`, validates fields, scrolls to the first error, submits via the mutation, and surfaces server-returned field errors.
- Confirmed replacement media upload flow (dropzone → FineUploader chunked upload → Update Media) end-to-end, including cancel/retry/pause/continue.
- Verified the add-media page still renders correctly after the shared-component changes (id forwarding, `ThumbnailImageUpload` toggle).

## Screenshots (if appropriate):
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/ba154849-c958-49bd-923d-a917789ace20" />
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/b6b553de-d9a1-4aef-a24a-f91deb5184d7" />
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/b7d95735-3a47-4862-98b7-0edf64044bca" />
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/a8817a1b-09b9-4c80-b599-771002d8c933" />
<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/19977977-e0ea-4133-bacb-0e62700455f8" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):
- [x] I have not imported `flux` in a new component
- [x] If adding a new feature, I used Modern Track patterns
- [x] New features do not create new SCSS files (use Tailwind instead)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a refreshed edit-media experience with a dedicated page, quick preview, FineUploader-based replacement upload, and submit/cancel actions.
  * Introduced additional settings panels (final/admin/advanced) and an editorial policy notice.
  * Added legacy vs. revamp template switching for the edit-media page.
* **Bug Fixes**
  * Improved form accessibility and field identifiers (including checkbox group wrapper IDs and year field DOM IDs).
  * Improved quick preview thumbnail selection behavior.
* **Tests**
  * Added coverage for revamp template resolution of the edit-media page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->