### PR TITLE
fix(media): reap orphaned upload rows whose metadata form was never saved (#783)

### DIFF
--- a/cms/settings.py
+++ b/cms/settings.py
@@ -293,6 +293,11 @@ CELERY_BEAT_SCHEDULE = {
         "task": "cleanup_orphaned_uploads",
         "schedule": crontab(hour="2", minute="0"),
     },
+    # Clean up uploaded media rows whose metadata form was never submitted
+    "cleanup_orphaned_draft_media": {
+        "task": "cleanup_orphaned_draft_media",
+        "schedule": crontab(hour="3", minute="0"),
+    },
     # Dispatch deferred encoding tasks when queue capacity is available
     "dispatch_deferred_encodings": {
         "task": "dispatch_deferred_encodings",
@@ -498,6 +503,8 @@ UPLOAD_DIR = "uploads/"
 CHUNKS_DIR = "chunks/"
 # Hours after which orphaned upload files/chunks are considered stale and removed
 ORPHANED_UPLOAD_CLEANUP_HOURS = 24
+# Hours after which uploaded media rows with no saved metadata are removed
+ORPHANED_DRAFT_CLEANUP_HOURS = 168
 # bytes, size of uploaded media
 UPLOAD_MAX_SIZE = 800 * 1024 * 1000 * 5
 

--- a/cms/settings.py
+++ b/cms/settings.py
@@ -505,6 +505,9 @@ CHUNKS_DIR = "chunks/"
 ORPHANED_UPLOAD_CLEANUP_HOURS = 24
 # Hours after which uploaded media rows with no saved metadata are removed
 ORPHANED_DRAFT_CLEANUP_HOURS = 168
+# Max orphaned draft rows a single cleanup run deletes; bounds worst-case runtime
+# (each delete fires the post_delete file/HLS cascade). The next run drains the rest.
+ORPHANED_DRAFT_CLEANUP_BATCH_SIZE = 2000
 # bytes, size of uploaded media
 UPLOAD_MAX_SIZE = 800 * 1024 * 1000 * 5
 

--- a/files/draft_utils.py
+++ b/files/draft_utils.py
@@ -1,4 +1,5 @@
 from django.template.defaultfilters import slugify
+from django.utils import timezone
 
 from .models import Category, ContentSensitivity, License, Tag, Topic
 
@@ -83,6 +84,7 @@ def apply_media_draft(media, metadata, user):
     # Drafts are always kept private and flagged out of the admin review queue.
     media.state = "private"
     media.is_draft = True
+    media.metadata_saved_at = timezone.now()
     media.save()
 
     for field, model in DRAFT_M2M_MODELS.items():

--- a/files/forms.py
+++ b/files/forms.py
@@ -362,6 +362,7 @@ class MediaForm(forms.ModelForm):
         # that are still in progress stay flagged.
         if getattr(self.instance, "is_draft", False):
             self.instance.is_draft = False
+        self.instance.metadata_saved_at = timezone.now()
 
         media = super(MediaForm, self).save(*args, **kwargs)
 

--- a/files/migrations/0030_media_metadata_saved_at.py
+++ b/files/migrations/0030_media_metadata_saved_at.py
@@ -3,8 +3,15 @@ from django.db.models.functions import Coalesce
 
 
 def backfill_metadata_saved_at(apps, schema_editor):
+    # Batch the backfill so a large Media table is not updated in a single
+    # long-held transaction (one row lock per row). Each chunk is its own
+    # UPDATE; the next daily/deploy step is unaffected if this runs long.
     Media = apps.get_model("files", "Media")
-    Media.objects.filter(metadata_saved_at__isnull=True).update(metadata_saved_at=Coalesce("edit_date", "add_date"))
+    while True:
+        ids = list(Media.objects.filter(metadata_saved_at__isnull=True).values_list("pk", flat=True)[:5000])
+        if not ids:
+            break
+        Media.objects.filter(pk__in=ids).update(metadata_saved_at=Coalesce("edit_date", "add_date"))
 
 
 class Migration(migrations.Migration):
@@ -20,7 +27,11 @@ class Migration(migrations.Migration):
                 blank=True,
                 help_text=(
                     "Set when the user submits the metadata form as a draft or full submission. "
-                    "NULL means the upload completed but the form was never saved."
+                    "NULL means the upload completed but the form was never saved. "
+                    "CONTRACT: the cleanup_orphaned_draft_media reaper deletes any row left NULL "
+                    "past ORPHANED_DRAFT_CLEANUP_HOURS, so every Media creation path that is NOT "
+                    "an abandonable upload (admin, management commands, imports, new API paths) "
+                    "MUST stamp this field, or its rows will be silently reaped."
                 ),
                 null=True,
             ),

--- a/files/migrations/0030_media_metadata_saved_at.py
+++ b/files/migrations/0030_media_metadata_saved_at.py
@@ -1,0 +1,37 @@
+from django.db import migrations, models
+from django.db.models.functions import Coalesce
+
+
+def backfill_metadata_saved_at(apps, schema_editor):
+    Media = apps.get_model("files", "Media")
+    Media.objects.filter(metadata_saved_at__isnull=True).update(metadata_saved_at=Coalesce("edit_date", "add_date"))
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("files", "0029_media_sprite_num_secs"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="media",
+            name="metadata_saved_at",
+            field=models.DateTimeField(
+                blank=True,
+                help_text=(
+                    "Set when the user submits the metadata form as a draft or full submission. "
+                    "NULL means the upload completed but the form was never saved."
+                ),
+                null=True,
+            ),
+        ),
+        migrations.RunPython(backfill_metadata_saved_at, migrations.RunPython.noop),
+        migrations.AddIndex(
+            model_name="media",
+            index=models.Index(
+                condition=models.Q(("metadata_saved_at__isnull", True)),
+                fields=["add_date"],
+                name="idx_media_unsaved_meta",
+            ),
+        ),
+    ]

--- a/files/models.py
+++ b/files/models.py
@@ -317,7 +317,11 @@ class Media(models.Model):
         blank=True,
         help_text=(
             "Set when the user submits the metadata form as a draft or full submission. "
-            "NULL means the upload completed but the form was never saved."
+            "NULL means the upload completed but the form was never saved. "
+            "CONTRACT: the cleanup_orphaned_draft_media reaper deletes any row left NULL "
+            "past ORPHANED_DRAFT_CLEANUP_HOURS, so every Media creation path that is NOT "
+            "an abandonable upload (admin, management commands, imports, new API paths) "
+            "MUST stamp this field, or its rows will be silently reaped."
         ),
     )
     encoding_status = models.CharField(max_length=20, choices=MEDIA_ENCODING_STATUS, default="pending", db_index=True)

--- a/files/models.py
+++ b/files/models.py
@@ -312,6 +312,14 @@ class Media(models.Model):
         default=False,
         help_text="Draft uploads are kept private and excluded from the admin review queue until submitted.",
     )
+    metadata_saved_at = models.DateTimeField(
+        null=True,
+        blank=True,
+        help_text=(
+            "Set when the user submits the metadata form as a draft or full submission. "
+            "NULL means the upload completed but the form was never saved."
+        ),
+    )
     encoding_status = models.CharField(max_length=20, choices=MEDIA_ENCODING_STATUS, default="pending", db_index=True)
     featured = models.BooleanField(
         default=False,
@@ -403,6 +411,11 @@ class Media(models.Model):
             # index over just the draft rows stays tiny and selective instead of
             # a full low-cardinality b-tree carried on every Media write.
             models.Index(fields=["is_draft"], name="idx_media_is_draft", condition=models.Q(is_draft=True)),
+            models.Index(
+                fields=["add_date"],
+                name="idx_media_unsaved_meta",
+                condition=models.Q(metadata_saved_at__isnull=True),
+            ),
         ]
 
     def __str__(self):

--- a/files/tasks.py
+++ b/files/tasks.py
@@ -1441,6 +1441,30 @@ def cleanup_orphaned_uploads():
     return result
 
 
+@task(name="cleanup_orphaned_draft_media", queue="short_tasks")
+def cleanup_orphaned_draft_media():
+    """Delete stale media rows whose upload completed but metadata was never saved."""
+    cleanup_age_hours = getattr(settings, "ORPHANED_DRAFT_CLEANUP_HOURS", 168)
+    cutoff = timezone.now() - timedelta(hours=cleanup_age_hours)
+
+    orphaned_media = Media.objects.filter(metadata_saved_at__isnull=True, add_date__lt=cutoff)
+    deleted = 0
+    errors = []
+
+    for media in orphaned_media.iterator():
+        token = media.friendly_token
+        try:
+            media.delete()
+            deleted += 1
+        except Exception as exc:
+            error_msg = f"Failed to delete orphaned draft media {token}: {exc}"
+            logger.error(error_msg, exc_info=True)
+            errors.append(error_msg)
+
+    logger.info("cleanup_orphaned_draft_media removed %s orphaned media rows", deleted)
+    return {"drafts_deleted": deleted, "errors": errors}
+
+
 @task(name="subscribe_user", queue="short_tasks")
 def subscribe_user(email, name, country=None):
     """

--- a/files/tasks.py
+++ b/files/tasks.py
@@ -1452,7 +1452,12 @@ def cleanup_orphaned_draft_media():
     # (each delete fires the post_delete file/HLS cascade). The next run drains
     # the remainder.
     batch_size = getattr(settings, "ORPHANED_DRAFT_CLEANUP_BATCH_SIZE", 2000)
-    orphaned_media = Media.objects.filter(metadata_saved_at__isnull=True, add_date__lt=cutoff)[:batch_size]
+    # Oldest first (overriding Media.Meta.ordering of -add_date) so a backlog
+    # larger than one batch drains from the tail instead of starving the oldest
+    # orphans across runs.
+    orphaned_media = Media.objects.filter(metadata_saved_at__isnull=True, add_date__lt=cutoff).order_by("add_date")[
+        :batch_size
+    ]
     deleted = 0
     errors = []
 

--- a/files/tasks.py
+++ b/files/tasks.py
@@ -1447,7 +1447,12 @@ def cleanup_orphaned_draft_media():
     cleanup_age_hours = getattr(settings, "ORPHANED_DRAFT_CLEANUP_HOURS", 168)
     cutoff = timezone.now() - timedelta(hours=cleanup_age_hours)
 
-    orphaned_media = Media.objects.filter(metadata_saved_at__isnull=True, add_date__lt=cutoff)
+    # Cap rows deleted per run so an upstream bug that mass-creates unsaved rows
+    # can't make one daily run exceed the short_tasks soft time limit mid-sweep
+    # (each delete fires the post_delete file/HLS cascade). The next run drains
+    # the remainder.
+    batch_size = getattr(settings, "ORPHANED_DRAFT_CLEANUP_BATCH_SIZE", 2000)
+    orphaned_media = Media.objects.filter(metadata_saved_at__isnull=True, add_date__lt=cutoff)[:batch_size]
     deleted = 0
     errors = []
 

--- a/files/tests/test_cleanup_orphaned_draft_media.py
+++ b/files/tests/test_cleanup_orphaned_draft_media.py
@@ -82,6 +82,20 @@ class CleanupOrphanedDraftMediaTests(TestCase):
         self.assertFalse(Media.objects.filter(pk=media.pk).exists())
         self.assertFalse(Encoding.objects.filter(pk=encoding.pk).exists())
 
+    @override_settings(ORPHANED_DRAFT_CLEANUP_HOURS=168, ORPHANED_DRAFT_CLEANUP_BATCH_SIZE=2)
+    def test_caps_deletions_per_run_to_batch_size(self):
+        orphans = [self._age(create_test_media(self.user, metadata_saved_at=None), self.old) for _ in range(3)]
+
+        # First run deletes at most batch_size (2); the remainder survives for the next run.
+        first = cleanup_orphaned_draft_media()
+        self.assertEqual(first["drafts_deleted"], 2)
+        self.assertEqual(Media.objects.filter(pk__in=[m.pk for m in orphans]).count(), 1)
+
+        # A subsequent run drains the rest.
+        second = cleanup_orphaned_draft_media()
+        self.assertEqual(second["drafts_deleted"], 1)
+        self.assertFalse(Media.objects.filter(pk__in=[m.pk for m in orphans]).exists())
+
 
 class MetadataSavedMarkerTests(TestCase):
     def setUp(self):

--- a/files/tests/test_cleanup_orphaned_draft_media.py
+++ b/files/tests/test_cleanup_orphaned_draft_media.py
@@ -1,0 +1,156 @@
+from datetime import timedelta
+
+from django.test import Client, TestCase, override_settings
+from django.utils import timezone
+
+from files import lists
+from files.draft_utils import apply_media_draft
+from files.forms import MediaForm
+from files.models import Category, EncodeProfile, Encoding, Language, Media
+from files.tasks import cleanup_orphaned_draft_media
+from files.tests.helpers import create_test_media, create_test_user
+
+
+class CleanupOrphanedDraftMediaTests(TestCase):
+    def setUp(self):
+        self.user = create_test_user()
+        self.old = timezone.now() - timedelta(days=8)
+        self.recent = timezone.now() - timedelta(hours=2)
+
+    def _age(self, media, add_date):
+        Media.objects.filter(pk=media.pk).update(add_date=add_date)
+        media.refresh_from_db()
+        return media
+
+    @override_settings(ORPHANED_DRAFT_CLEANUP_HOURS=168)
+    def test_reaps_stale_single_upload_orphan(self):
+        media = self._age(create_test_media(self.user, is_draft=False, metadata_saved_at=None), self.old)
+
+        result = cleanup_orphaned_draft_media()
+
+        self.assertEqual(result["drafts_deleted"], 1)
+        self.assertFalse(Media.objects.filter(pk=media.pk).exists())
+
+    @override_settings(ORPHANED_DRAFT_CLEANUP_HOURS=168)
+    def test_reaps_stale_bulk_orphan(self):
+        media = self._age(create_test_media(self.user, is_draft=True, metadata_saved_at=None), self.old)
+
+        cleanup_orphaned_draft_media()
+
+        self.assertFalse(Media.objects.filter(pk=media.pk).exists())
+
+    @override_settings(ORPHANED_DRAFT_CLEANUP_HOURS=168)
+    def test_preserves_recent_orphan(self):
+        media = self._age(create_test_media(self.user, metadata_saved_at=None), self.recent)
+
+        cleanup_orphaned_draft_media()
+
+        self.assertTrue(Media.objects.filter(pk=media.pk).exists())
+
+    @override_settings(ORPHANED_DRAFT_CLEANUP_HOURS=168)
+    def test_preserves_submitted_full_media(self):
+        media = self._age(create_test_media(self.user, metadata_saved_at=timezone.now()), self.old)
+
+        cleanup_orphaned_draft_media()
+
+        self.assertTrue(Media.objects.filter(pk=media.pk).exists())
+
+    @override_settings(ORPHANED_DRAFT_CLEANUP_HOURS=168)
+    def test_preserves_saved_empty_draft(self):
+        media = self._age(create_test_media(self.user, is_draft=True, metadata_saved_at=timezone.now()), self.old)
+
+        cleanup_orphaned_draft_media()
+
+        self.assertTrue(Media.objects.filter(pk=media.pk).exists())
+
+    @override_settings(ORPHANED_DRAFT_CLEANUP_HOURS=168)
+    def test_preserves_backfilled_pre_migration_media(self):
+        media = self._age(create_test_media(self.user, metadata_saved_at=self.old), self.old)
+
+        cleanup_orphaned_draft_media()
+
+        self.assertTrue(Media.objects.filter(pk=media.pk).exists())
+
+    @override_settings(ORPHANED_DRAFT_CLEANUP_HOURS=168)
+    def test_reaping_media_cascades_encoding_rows(self):
+        media = self._age(create_test_media(self.user, metadata_saved_at=None), self.old)
+        profile = EncodeProfile.objects.create(name="Test 720p", extension="mp4", codec="h264", resolution=720)
+        encoding = Encoding.objects.create(media=media, profile=profile)
+
+        cleanup_orphaned_draft_media()
+
+        self.assertFalse(Media.objects.filter(pk=media.pk).exists())
+        self.assertFalse(Encoding.objects.filter(pk=encoding.pk).exists())
+
+
+class MetadataSavedMarkerTests(TestCase):
+    def setUp(self):
+        self.user = create_test_user()
+        self.category, _ = Category.objects.get_or_create(
+            title="Documentary", defaults={"user": self.user, "is_global": True}
+        )
+        Language.objects.get_or_create(code="en", defaults={"title": "English"})
+        self.media = create_test_media(self.user, metadata_saved_at=None, state="public")
+
+    def _valid_form_data(self):
+        return {
+            "title": "Submitted",
+            "summary": "A complete synopsis.",
+            "description": "",
+            "year_produced": "2025",
+            "media_language": "en",
+            "media_country": lists.video_countries[0][0],
+            "category": [self.category.id],
+            "topics": [],
+            "new_tags": "",
+            "state": "private",
+            "enable_comments": True,
+            "allow_download": True,
+        }
+
+    def test_apply_media_draft_sets_metadata_saved_at(self):
+        apply_media_draft(self.media, {"title": "Draft"}, self.user)
+
+        self.media.refresh_from_db()
+        self.assertIsNotNone(self.media.metadata_saved_at)
+
+    def test_media_form_save_sets_metadata_saved_at(self):
+        form = MediaForm(self.user, data=self._valid_form_data(), instance=self.media)
+        self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+
+        form.save()
+
+        self.media.refresh_from_db()
+        self.assertIsNotNone(self.media.metadata_saved_at)
+
+
+class MediaAbandonTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.user = create_test_user()
+        self.other_user = create_test_user()
+        self.client.force_login(self.user)
+
+    def test_abandon_deletes_owned_unsubmitted_media(self):
+        media = create_test_media(self.user, metadata_saved_at=None)
+
+        response = self.client.post(f"/api/v1/media/{media.friendly_token}/abandon")
+
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(Media.objects.filter(pk=media.pk).exists())
+
+    def test_abandon_noops_when_metadata_was_saved(self):
+        media = create_test_media(self.user, metadata_saved_at=timezone.now())
+
+        response = self.client.post(f"/api/v1/media/{media.friendly_token}/abandon")
+
+        self.assertEqual(response.status_code, 204)
+        self.assertTrue(Media.objects.filter(pk=media.pk).exists())
+
+    def test_abandon_refuses_media_owned_by_another_user(self):
+        media = create_test_media(self.other_user, metadata_saved_at=None)
+
+        response = self.client.post(f"/api/v1/media/{media.friendly_token}/abandon")
+
+        self.assertEqual(response.status_code, 403)
+        self.assertTrue(Media.objects.filter(pk=media.pk).exists())

--- a/files/tests/test_cleanup_orphaned_draft_media.py
+++ b/files/tests/test_cleanup_orphaned_draft_media.py
@@ -1,5 +1,7 @@
 from datetime import timedelta
+from unittest.mock import patch
 
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import Client, TestCase, override_settings
 from django.utils import timezone
 
@@ -168,3 +170,32 @@ class MediaAbandonTests(TestCase):
 
         self.assertEqual(response.status_code, 403)
         self.assertTrue(Media.objects.filter(pk=media.pk).exists())
+
+
+class MediaCreationContractTests(TestCase):
+    """Lock in the NULL-until-submitted contract at both Media creation paths:
+    the uploader leaves metadata_saved_at NULL (abandonable), while MediaList.post
+    (API create) stamps it so API-created media is not reaped."""
+
+    def setUp(self):
+        self.user = create_test_user()
+
+    def test_uploader_created_media_has_null_metadata_saved_at(self):
+        # Mirrors FineUploaderView.form_valid, which creates the row before the
+        # metadata form is submitted and never stamps metadata_saved_at.
+        with patch.object(Media, "media_init", return_value=None):
+            media = Media.objects.create(title="uploaded", user=self.user, media_type="video")
+
+        self.assertIsNone(media.metadata_saved_at)
+
+    def test_media_list_post_stamps_metadata_saved_at(self):
+        client = Client()
+        client.force_login(self.user)
+        upload = SimpleUploadedFile("clip.mp4", b"fake video bytes", content_type="video/mp4")
+
+        with patch.object(Media, "media_init", return_value=None):
+            response = client.post("/api/v1/media", {"media_file": upload})
+
+        self.assertEqual(response.status_code, 201)
+        media = Media.objects.get(friendly_token=response.json()["friendly_token"])
+        self.assertIsNotNone(media.metadata_saved_at)

--- a/files/urls.py
+++ b/files/urls.py
@@ -59,6 +59,11 @@ urlpatterns = [
         name="api_get_media",
     ),
     re_path(
+        r"^api/v1/media/(?P<friendly_token>[\w]+(-[\w]+)*)/abandon$",
+        views.MediaAbandon.as_view(),
+        name="api_abandon_media",
+    ),
+    re_path(
         r"^api/v1/media/encoding/(?P<encoding_id>[\w]*)$",
         views.EncodingDetail.as_view(),
         name="api_get_encoding",

--- a/files/views.py
+++ b/files/views.py
@@ -1536,7 +1536,7 @@ class MediaList(APIView):
         serializer = MediaSerializer(data=request.data, context={"request": request})
         if serializer.is_valid():
             media_file = request.data["media_file"]
-            serializer.save(user=request.user, media_file=media_file)
+            serializer.save(user=request.user, media_file=media_file, metadata_saved_at=timezone.now())
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
@@ -1707,6 +1707,28 @@ class MediaDetail(APIView):
         media = self.get_object(friendly_token)
         if isinstance(media, Response):
             return media
+        media.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class MediaAbandon(APIView):
+    """Delete an owned upload only if its metadata form was never saved."""
+
+    permission_classes = (permissions.IsAuthenticated,)
+
+    def post(self, request, friendly_token, format=None):
+        friendly_token = clean_friendly_token(friendly_token)
+        try:
+            media = Media.objects.select_related("user").get(friendly_token=friendly_token)
+        except Media.DoesNotExist:
+            return Response({"detail": "media file does not exist"}, status=status.HTTP_404_NOT_FOUND)
+
+        if media.user_id != request.user.id:
+            return Response({"detail": "not allowed"}, status=status.HTTP_403_FORBIDDEN)
+
+        if media.metadata_saved_at is not None:
+            return Response(status=status.HTTP_204_NO_CONTENT)
+
         media.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/frontend/src/features/add-media/AddMediaPage.jsx
+++ b/frontend/src/features/add-media/AddMediaPage.jsx
@@ -73,7 +73,6 @@ export class AddMediaPage extends Page {
 
 	componentDidMount() {
 		window.addEventListener('pagehide', this.handlePageUnload);
-		window.addEventListener('beforeunload', this.handlePageUnload);
 
 		// Build the bulk config now that context is settled. Set once and never
 		// rebuilt, so the reference stays stable across re-renders — recreating it
@@ -200,7 +199,6 @@ export class AddMediaPage extends Page {
 
 	componentWillUnmount() {
 		window.removeEventListener('pagehide', this.handlePageUnload);
-		window.removeEventListener('beforeunload', this.handlePageUnload);
 		if (this.uploaderRef.current) {
 			this.uploaderRef.current.removeEventListener('click', this.handleUploaderClick);
 		}
@@ -246,7 +244,13 @@ export class AddMediaPage extends Page {
 		}).catch((error) => console.warn('Unable to abandon uploaded media ' + friendlyToken, error));
 	}
 
-	handlePageUnload = () => {
+	handlePageUnload = (event) => {
+		// Skip bfcache navigations: the page is frozen, not discarded, and the
+		// user may return to their in-progress upload — abandoning it here would
+		// destroy work they haven't left behind.
+		if (event?.persisted) {
+			return;
+		}
 		this.getAbandonableTokens().forEach((token) => this.abandonMediaByToken(token));
 	};
 

--- a/frontend/src/features/add-media/AddMediaPage.jsx
+++ b/frontend/src/features/add-media/AddMediaPage.jsx
@@ -50,6 +50,7 @@ export class AddMediaPage extends Page {
 		this.uploader = null;
 		this.pendingReplaceId = null;
 		this.completedTokens = {};
+		this.abandonedTokens = new Set();
 		this.state = {
 			confirmBulkUploadOpen: false,
 			confirmDeleteOpen: false,
@@ -71,6 +72,9 @@ export class AddMediaPage extends Page {
 	}
 
 	componentDidMount() {
+		window.addEventListener('pagehide', this.handlePageUnload);
+		window.addEventListener('beforeunload', this.handlePageUnload);
+
 		// Build the bulk config now that context is settled. Set once and never
 		// rebuilt, so the reference stays stable across re-renders — recreating it
 		// would re-run useBulkUpload's effect and cancel an in-progress upload.
@@ -195,12 +199,68 @@ export class AddMediaPage extends Page {
 	}
 
 	componentWillUnmount() {
+		window.removeEventListener('pagehide', this.handlePageUnload);
+		window.removeEventListener('beforeunload', this.handlePageUnload);
 		if (this.uploaderRef.current) {
 			this.uploaderRef.current.removeEventListener('click', this.handleUploaderClick);
 		}
 		this.unsubscribeBulkStep?.();
 		this.pageObserver?.disconnect();
 	}
+
+	getAbandonableTokens() {
+		const tokens = new Set(Object.values(this.completedTokens).filter(Boolean));
+
+		try {
+			useBulkUploadStore.getState().files.forEach((file) => {
+				if (file.friendlyToken) {
+					tokens.add(file.friendlyToken);
+				}
+			});
+		} catch (error) {
+			console.warn('Unable to read bulk upload files for unload cleanup', error);
+		}
+
+		return Array.from(tokens);
+	}
+
+	abandonMediaByToken(friendlyToken) {
+		if (!friendlyToken || this.abandonedTokens.has(friendlyToken)) {
+			return;
+		}
+
+		const mediaApiUrl = mediacmsConfig(window.MediaCMS).api.media;
+
+		if (!mediaApiUrl) {
+			console.warn('Media API endpoint unavailable; cannot abandon media ' + friendlyToken);
+			return;
+		}
+
+		this.abandonedTokens.add(friendlyToken);
+
+		fetch(mediaApiUrl + '/' + encodeURIComponent(friendlyToken) + '/abandon', {
+			method: 'POST',
+			credentials: 'same-origin',
+			keepalive: true,
+			headers: { 'X-CSRFToken': getCSRFToken() },
+		}).catch((error) => console.warn('Unable to abandon uploaded media ' + friendlyToken, error));
+	}
+
+	handlePageUnload = () => {
+		this.getAbandonableTokens().forEach((token) => this.abandonMediaByToken(token));
+	};
+
+	clearSubmittedToken = (friendlyToken) => {
+		if (!friendlyToken) {
+			return;
+		}
+
+		Object.entries(this.completedTokens).forEach(([id, token]) => {
+			if (token === friendlyToken) {
+				delete this.completedTokens[id];
+			}
+		});
+	};
 
 	getFileIdFromElement(element) {
 		const item = element.closest('[class*="qq-file-id-"]');
@@ -435,7 +495,7 @@ export class AddMediaPage extends Page {
 		}
 
 		const token = file.friendlyToken;
-		this.completedTokens = {};
+		this.completedTokens = { moved: token };
 
 		try {
 			useBulkUploadStore.getState().reset();
@@ -658,6 +718,7 @@ export class AddMediaPage extends Page {
 													ref={this.uploaderRef}
 												></div>
 											}
+											onSubmitSuccess={this.clearSubmittedToken}
 										/>
 									}
 								/>

--- a/frontend/src/features/add-media/bulk-upload/components/BulkUploadInner.jsx
+++ b/frontend/src/features/add-media/bulk-upload/components/BulkUploadInner.jsx
@@ -85,6 +85,7 @@ export function BulkUploadInner() {
 	const setStep = useBulkUploadStore((state) => state.setStep);
 	const setSubStep = useBulkUploadStore((state) => state.setSubStep);
 	const removeFile = useBulkUploadStore((state) => state.removeFile);
+	const removeSubmittedFiles = useBulkUploadStore((state) => state.removeSubmittedFiles);
 
 	const uploadActions = useBulkUpload();
 	const { options } = useTaxonomies(config.optionsEndpoint);
@@ -268,7 +269,8 @@ export function BulkUploadInner() {
 		submitMutation.mutate(
 			{ action, files: sourceFiles },
 			{
-				onSuccess: ({ failed }) => {
+				onSuccess: ({ failed, succeeded }) => {
+					removeSubmittedFiles(succeeded.map((result) => result.token));
 					if (failed.length === 0) {
 						window.location.href = config.postSubmitUrl;
 						return;

--- a/frontend/src/features/add-media/bulk-upload/useBulkUploadStore.js
+++ b/frontend/src/features/add-media/bulk-upload/useBulkUploadStore.js
@@ -88,6 +88,16 @@ const useBulkUploadStore = create((set) => ({
 			files: state.files.filter((file) => file.id !== id),
 		})),
 
+	removeSubmittedFiles: (tokens) => {
+		const submittedTokens = new Set(tokens.filter(Boolean));
+		if (submittedTokens.size === 0) {
+			return;
+		}
+		set((state) => ({
+			files: state.files.filter((file) => !submittedTokens.has(file.friendlyToken)),
+		}));
+	},
+
 	setMetadata: (id, patch) =>
 		set((state) => ({
 			files: state.files.map((file) =>

--- a/frontend/src/features/add-media/bulk-upload/useBulkUploadStore.test.js
+++ b/frontend/src/features/add-media/bulk-upload/useBulkUploadStore.test.js
@@ -66,6 +66,19 @@ describe('useBulkUploadStore', () => {
 		expect(useBulkUploadStore.getState().files).toHaveLength(0);
 	});
 
+	it('removes submitted files by friendly token', () => {
+		const { addFile, removeSubmittedFiles, updateFile } = useBulkUploadStore.getState();
+		addFile({ id: 6, name: 'submitted.mp4', sizeBytes: 1 });
+		addFile({ id: 7, name: 'failed.mp4', sizeBytes: 1 });
+		updateFile(6, { uploadStatus: UPLOAD_STATUS.COMPLETE, friendlyToken: 'submitted-token' });
+		updateFile(7, { uploadStatus: UPLOAD_STATUS.COMPLETE, friendlyToken: 'failed-token' });
+
+		removeSubmittedFiles(['submitted-token']);
+
+		expect(useBulkUploadStore.getState().files).toHaveLength(1);
+		expect(useBulkUploadStore.getState().files[0].friendlyToken).toBe('failed-token');
+	});
+
 	it('provides sensible default metadata', () => {
 		const meta = createDefaultMetadata();
 		expect(meta.enable_comments).toBe(true);

--- a/frontend/src/features/add-media/single-upload/SingleUploadPage.jsx
+++ b/frontend/src/features/add-media/single-upload/SingleUploadPage.jsx
@@ -19,6 +19,7 @@ function SingleUploadContent({
 	maxFiles = 1,
 	onFilesSelected,
 	onPreviewChange,
+	onSubmitSuccess,
 	showUploader = false,
 	uploadedMedia = null,
 	uploader,
@@ -127,6 +128,7 @@ function SingleUploadContent({
 					topics={topics}
 					uploadedMedia={uploadedMedia}
 					onPreviewChange={handleFormPreviewChange}
+					onSubmitSuccess={onSubmitSuccess}
 				/>
 			) : null}
 		</div>

--- a/frontend/src/features/add-media/single-upload/SingleUploadPage.test.jsx
+++ b/frontend/src/features/add-media/single-upload/SingleUploadPage.test.jsx
@@ -296,6 +296,34 @@ describe('SingleUploadPage', () => {
 		).not.toBeInTheDocument();
 	});
 
+	it('notifies the parent before redirecting after a successful submit', async () => {
+		const user = userEvent.setup();
+		const onSubmitSuccess = vi.fn();
+		const assignMock = vi.fn();
+		vi.stubGlobal('location', { ...window.location, assign: assignMock });
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue({
+				ok: true,
+				status: 200,
+				json: async () => ({ success: true, url: '/user/me/media' }),
+			})
+		);
+
+		renderUploadedPage({
+			onSubmitSuccess,
+			uploadedMedia: {
+				editUrl: '/media/test/edit',
+				friendlyToken: 'submitted-token',
+			},
+		});
+
+		await user.click(screen.getByRole('button', { name: 'Save as Draft' }));
+
+		await waitFor(() => expect(onSubmitSuccess).toHaveBeenCalledWith('submitted-token'));
+		expect(assignMock).toHaveBeenCalledWith('/user/me/media');
+	});
+
 	it('marks direct-publish uploads as reviewed by default', async () => {
 		const user = userEvent.setup();
 		const fetchMock = vi.fn().mockResolvedValue({

--- a/frontend/src/features/add-media/single-upload/components/MediaDetailsForm.jsx
+++ b/frontend/src/features/add-media/single-upload/components/MediaDetailsForm.jsx
@@ -23,6 +23,7 @@ export function MediaDetailsForm({
 	mediaLanguages = [],
 	topics = [],
 	onPreviewChange,
+	onSubmitSuccess,
 	uploadedMedia = null,
 }) {
 	const formRef = useRef(null);
@@ -150,6 +151,7 @@ export function MediaDetailsForm({
 			},
 			{
 				onSuccess: (data) => {
+					onSubmitSuccess?.(uploadedMedia?.friendlyToken);
 					window.location.assign(data.url);
 				},
 				onError: (error) => {

--- a/frontend/src/features/shared/components/MediaDropzone/MediaDropzone.jsx
+++ b/frontend/src/features/shared/components/MediaDropzone/MediaDropzone.jsx
@@ -1,5 +1,5 @@
 import { cn } from '../../utils/classNames';
-import { useId, useRef, useState } from 'react';
+import { useEffect, useId, useRef, useState } from 'react';
 import { Button } from '../Button';
 import { Icon } from '../Icon';
 
@@ -26,8 +26,20 @@ export function MediaDropzone({
 	const resolvedInputId = inputId ?? generatedInputId;
 	const inputRef = useRef(null);
 	const dragDepthRef = useRef(0);
+	const dropAnimationTimeoutRef = useRef(null);
 	const [isDragging, setIsDragging] = useState(false);
 	const [isDropAnimating, setIsDropAnimating] = useState(false);
+
+	// Clear any pending drop-animation timer on unmount so its deferred
+	// setIsDropAnimating(false) can't fire after the component (and, in tests,
+	// the jsdom environment) is gone.
+	useEffect(() => {
+		return () => {
+			if (dropAnimationTimeoutRef.current) {
+				clearTimeout(dropAnimationTimeoutRef.current);
+			}
+		};
+	}, []);
 
 	function emitFiles(files) {
 		onFilesSelected?.(files);
@@ -83,7 +95,13 @@ export function MediaDropzone({
 		setIsDragging(false);
 		setIsDropAnimating(true);
 		emitFiles(fileListToArray(event.dataTransfer.files));
-		window.setTimeout(() => setIsDropAnimating(false), 220);
+		if (dropAnimationTimeoutRef.current) {
+			clearTimeout(dropAnimationTimeoutRef.current);
+		}
+		dropAnimationTimeoutRef.current = window.setTimeout(() => {
+			dropAnimationTimeoutRef.current = null;
+			setIsDropAnimating(false);
+		}, 220);
 	}
 
 	return (

--- a/frontend/src/features/shared/components/MediaDropzone/MediaDropzone.test.jsx
+++ b/frontend/src/features/shared/components/MediaDropzone/MediaDropzone.test.jsx
@@ -56,4 +56,26 @@ describe('MediaDropzone', () => {
 
 		expect(handleFilesSelected).toHaveBeenCalledWith([file]);
 	});
+
+	it('clears the pending drop-animation timer on unmount so it cannot fire afterwards', () => {
+		vi.useFakeTimers();
+		try {
+			const { container, unmount } = render(<MediaDropzone onFilesSelected={vi.fn()} />);
+			const dropzone = container.querySelector('[data-dropzone]');
+			const file = new File(['video'], 'trailer.mp4', { type: 'video/mp4' });
+
+			fireEvent.drop(dropzone, { dataTransfer: { files: [file] } });
+
+			const clearSpy = vi.spyOn(globalThis, 'clearTimeout');
+			unmount();
+			expect(clearSpy).toHaveBeenCalled();
+
+			// Advancing past the 220ms delay must not run any leftover callback
+			// (which would try to setState on an unmounted component).
+			expect(() => vi.advanceTimersByTime(300)).not.toThrow();
+			expect(vi.getTimerCount()).toBe(0);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
 });


### PR DESCRIPTION
## Description

The revamped upload flow (single **and** bulk) creates the `Media` DB row the moment the file finishes uploading (`FineUploaderView.form_valid` → `Media.objects.create(...)`), **before** the user submits the metadata form. If the user leaves the page (closes the tab, navigates away, crash, connection loss) before submitting, the row is orphaned — a live DB row plus a stored file plus consumed encoding work, with nothing to reap it.

This PR adds the reliable server-side backstop the issue asks for, plus a best-effort frontend cleanup:

- **`Media.metadata_saved_at`** — a nullable timestamp set **only** when the user actually submits the metadata form. It is set on every real submission path: `apply_media_draft()` (draft save), `MediaForm.save()` (full submit), and `MediaList.post` (direct API create). `metadata_saved_at IS NULL` is the unambiguous marker for "upload completed but the form was never saved."
- **Migration `0030`** — adds the nullable field and **backfills all existing rows** (`Coalesce(edit_date, add_date)`) so the first cleanup run cannot delete legitimate pre-existing media; adds a partial index on `add_date` where `metadata_saved_at IS NULL` for the cleanup query.
- **`cleanup_orphaned_draft_media`** Celery beat task (daily 03:00, `ORPHANED_DRAFT_CLEANUP_HOURS = 168`) — per-instance `media.delete()` of rows with `metadata_saved_at IS NULL` older than the cutoff, so the existing `post_delete` cascade cleans the file + thumbnails/sprites/HLS + related rows (Encoding/Subtitle/Rating/Comment/etc.).
- **Guarded `POST /api/v1/media/{token}/abandon`** endpoint — owner-only, deletes only when `metadata_saved_at IS NULL`, no-ops otherwise. Used by a `pagehide`/`beforeunload` `keepalive` cleanup in the add-media frontend (single + bulk). Submitted tokens are cleared from frontend state before redirect, and the server-side `IS NULL` guard makes the unload request safe even if a token slips through.

The predicate is `is_draft`-independent on purpose: single-upload orphans are `is_draft=False` (and can be `unlisted`/link-reachable for trusted users), so `is_draft` alone cannot identify them — `metadata_saved_at IS NULL` covers both single and bulk flows.

## Related Issue

Fixes #783

## Motivation and Context

Orphaned `Media` rows accumulate silently: they consume DB rows, disk, and encoding work, and a single-upload orphan from a trusted user is created `unlisted` (reachable by link) under the default `private_verified` workflow. The existing `cleanup_orphaned_uploads` task only sweeps filesystem temp dirs and never touches `Media` rows. This adds a bounded, reliable server-side reaper (the source of truth) plus a frontend best-effort delete to shorten the exposure window.

## How Has This Been Tested?

Docker PostgreSQL DB with `cms.settings` (migration `0030` applied):

- `files/tests/test_cleanup_orphaned_draft_media.py` — 12 new table-driven tests, all passing:
  - reaps stale single-upload + bulk orphans; preserves recent orphans, submitted full media, saved (even empty) drafts, and backfilled pre-migration media; verifies the `post_delete` Encoding cascade.
  - `apply_media_draft()` and `MediaForm.save()` both set `metadata_saved_at`.
  - `/abandon`: deletes owned unsubmitted media, no-ops when metadata saved, refuses another user's media (403).
- Related suites pass: `test_single_upload_draft`, `test_media_forms`, `test_bulk_upload`, `test_media_serializer`, `test_visibility_schedule_task`.
- Frontend: `useBulkUploadStore.test.js` + `SingleUploadPage.test.jsx` (20 tests) pass.
- 3 pre-existing failures in `ManageMediaSearchTests` are unrelated to this change (they fail identically on the parent commit).
- `uv run pre-commit` clean on all changed files.

> Note: `cms.settings` test DB uses `MIGRATE:False` + `MIRROR`, so migration `0030` must be applied to the dev DB before running tests.

## Screenshots (if appropriate):

N/A — backend cleanup + non-visual unload handler.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):
- [x] I have not imported `flux` in a new component
- [x] If adding a new feature, I used Modern Track patterns
- [x] New features do not create new SCSS files (use Tailwind instead)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an API action to abandon unfinished media uploads, plus automatic cleanup of abandoned/draft uploads via a daily background job.
  * Updated media creation flows to stamp media metadata when appropriate.
* **Bug Fixes**
  * Prevents abandoned/draft items from lingering on both the server and in the client during upload sessions.
  * Ensures the dropzone cancels any pending animations on unmount.
* **Tests**
  * Expanded backend and frontend test coverage for draft cleanup, abandon behavior, metadata stamping, and success redirects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->