### PR TITLE
fix(media): correct last-frame resize and vertical-video squash in thumbnail selector

### DIFF
--- a/files/sprites.py
+++ b/files/sprites.py
@@ -145,7 +145,18 @@ def generate_sprite_for_media(media):
                 "-vframes",
                 "1",
                 "-vf",
-                f"scale={SPRITE_WIDTH}:{SPRITE_HEIGHT}",
+                # Fit the frame inside SPRITE_WIDTH x SPRITE_HEIGHT preserving aspect ratio, then
+                # pad to the exact box (letterbox/pillarbox). Two reasons:
+                #   1. A bare `scale=W:H` force-stretches non-16:9 sources (e.g. vertical 9:16
+                #      videos get horizontally squashed).
+                #   2. It guarantees EVERY tile is exactly SPRITE_HEIGHT tall, so the stacked
+                #      sheet is a clean rows*SPRITE_HEIGHT column. The client slices tiles on a
+                #      fixed SPRITE_HEIGHT grid; a tile that came back a few pixels short (e.g. a
+                #      frame near EOF) otherwise makes the last frame render resized.
+                (
+                    f"scale={SPRITE_WIDTH}:{SPRITE_HEIGHT}:force_original_aspect_ratio=decrease,"
+                    f"pad={SPRITE_WIDTH}:{SPRITE_HEIGHT}:(ow-iw)/2:(oh-ih)/2:color=black"
+                ),
                 "-y",
                 frame_path,
             ]

--- a/files/tests/test_video_sprite_backfill.py
+++ b/files/tests/test_video_sprite_backfill.py
@@ -106,6 +106,38 @@ class VideoSpriteBackfillTests(TestCase):
         self.assertEqual(media.sprite_num_secs, 10)
         self.assertEqual(result["sprite_num_secs"], 10)
 
+    def test_generate_sprite_letterboxes_tiles_to_exact_box(self):
+        # Tiles must preserve aspect ratio (so vertical videos aren't squashed) AND land on an
+        # exact SPRITE_WIDTH x SPRITE_HEIGHT box (so every row is the same height and the client's
+        # fixed-grid slice doesn't drift on the last frame). A bare `scale=W:H` does neither.
+        media = self._attach_media_file(create_test_media(self.user, duration=15))
+
+        vf_filters = []
+
+        def fake_run(command):
+            if command[0] == self.fake_ffmpeg:
+                vf_filters.append(command[command.index("-vf") + 1])
+                with open(command[-1], "wb") as frame_file:
+                    frame_file.write(b"frame")
+            else:
+                with open(command[-1], "wb") as sprite_file:
+                    sprite_file.write(b"sprite")
+            return {"out": "", "error": ""}
+
+        with (
+            patch("files.sprites.run_command", side_effect=fake_run),
+            patch("files.sprites.get_file_type", return_value="image"),
+        ):
+            result = generate_sprite_for_media(media)
+
+        self.assertTrue(result["ok"])
+        self.assertTrue(vf_filters)
+        for vf in vf_filters:
+            self.assertIn("force_original_aspect_ratio=decrease", vf)
+            self.assertIn("pad=160:90", vf)
+            # Guard against regressing to a bare force-stretch.
+            self.assertNotEqual(vf, "scale=160:90")
+
     @override_settings(SPRITE_NUM_SECS=10, SPRITE_MAX_TILES=100)
     def test_generate_sprite_caps_tile_count_for_long_videos(self):
         # A 27-minute video at 10s spacing would be 162 tiles. With max_tiles=100 the

--- a/frontend/src/features/shared/components/upload-media/ChooseFromVideo/FrameStrip.jsx
+++ b/frontend/src/features/shared/components/upload-media/ChooseFromVideo/FrameStrip.jsx
@@ -108,6 +108,7 @@ export function FrameStrip({
 									<SpriteFrame
 										index={frame.index}
 										label={`Select video frame at ${frame.mmss}`}
+										rowsInSheet={rowsInSheet}
 										selected={selected}
 										spritesUrl={spritesUrl}
 									/>

--- a/frontend/src/features/shared/components/upload-media/ChooseFromVideo/FrameStrip.test.jsx
+++ b/frontend/src/features/shared/components/upload-media/ChooseFromVideo/FrameStrip.test.jsx
@@ -76,4 +76,30 @@ describe('FrameStrip', () => {
 			expect(screen.getByText(/Frame preview is unavailable for this video/i)).toBeInTheDocument();
 		});
 	});
+
+	it('renders every frame — including the last — at the same size on a fixed grid', async () => {
+		// 450px natural height / 90 = 5 rows; duration 50 / 10 = 5 frames (indices 0..4).
+		// Unique URL so useSpriteFrames' per-URL rows cache doesn't short-circuit image load.
+		render(
+			<FrameStrip currentThumbnailTime="0" duration={50} spriteSecs={10} spritesUrl="/sprites-lastframe.jpg" />
+		);
+
+		act(() => {
+			MockImage.instances[0].onload();
+		});
+
+		await waitFor(() => expect(screen.getByRole('img', { name: /0:40/i })).toBeInTheDocument());
+
+		// The last frame (0:40) must not shrink relative to the first (0:00): same height, and a
+		// backgroundSize whose height is pinned to rows*scaledFrameHeight (not `auto`).
+		const first = screen.getByRole('img', { name: /video frame at 0:00/i });
+		const last = screen.getByRole('img', { name: /video frame at 0:40/i });
+
+		expect(last.style.height).toBe(first.style.height);
+		expect(last.style.backgroundSize).toBe(first.style.backgroundSize);
+		// Height is pinned to rows*scaledFrameHeight, not `auto` (the source of the last-frame drift).
+		expect(last.style.backgroundSize).not.toContain('auto');
+		const scaledFrameHeight = (90 * 78.421) / 160;
+		expect(last.style.backgroundSize).toBe(`78.421px ${5 * scaledFrameHeight}px`);
+	});
 });

--- a/frontend/src/features/shared/components/upload-media/ChooseFromVideo/SpriteFrame.jsx
+++ b/frontend/src/features/shared/components/upload-media/ChooseFromVideo/SpriteFrame.jsx
@@ -49,7 +49,7 @@ export function SpriteFrame({
 	// (a frame grabbed near EOF can), the sheet height is not a clean rows*90 and only the LAST
 	// frame drifts — it renders resized. Forcing an explicit height puts every row (last one
 	// included) on the same fixed grid, independent of the JPEG's trailing-row height.
-	const safeRows = Math.max(1, Number(rowsInSheet) || Number(index) + 1);
+	const safeRows = Math.max(1, Number(rowsInSheet) || Number(index) + 1 || 1);
 
 	return (
 		<span

--- a/frontend/src/features/shared/components/upload-media/ChooseFromVideo/SpriteFrame.jsx
+++ b/frontend/src/features/shared/components/upload-media/ChooseFromVideo/SpriteFrame.jsx
@@ -43,6 +43,13 @@ export function SpriteFrame({
 	// same content. Derive both from the source aspect ratio instead of a rounded constant.
 	const scale = width / SPRITE_SOURCE_WIDTH;
 	const scaledFrameHeight = SPRITE_SOURCE_HEIGHT * scale;
+	// Pin the background height to `rows * scaledFrameHeight` instead of `auto`. `auto` scales
+	// the sheet by its REAL natural height, but the offset math above assumes every row is
+	// exactly SPRITE_SOURCE_HEIGHT tall. If the last extracted tile came back a few pixels off
+	// (a frame grabbed near EOF can), the sheet height is not a clean rows*90 and only the LAST
+	// frame drifts — it renders resized. Forcing an explicit height puts every row (last one
+	// included) on the same fixed grid, independent of the JPEG's trailing-row height.
+	const safeRows = Math.max(1, Number(rowsInSheet) || Number(index) + 1);
 
 	return (
 		<span
@@ -59,7 +66,7 @@ export function SpriteFrame({
 				height: scaledFrameHeight,
 				backgroundImage: `url("${spritesUrl}")`,
 				backgroundPosition: `0 -${index * scaledFrameHeight}px`,
-				backgroundSize: `${width}px auto`,
+				backgroundSize: `${width}px ${safeRows * scaledFrameHeight}px`,
 			}}
 		/>
 	);


### PR DESCRIPTION
## Description
Fixes two rendering defects in the **"Choose from Video"** thumbnail selector (single + bulk upload):

1. **Last frame resized when selected.** In the frame strip and the header preview, selecting the *very last* frame of a clip made it render at a different size/proportion; earlier frames (including the first) were fine.
2. **Vertical videos squashed.** Non-16:9 sources (e.g. portrait 9:16) were horizontally stretched into the 16:9 sprite tiles.

**Fix A — frontend (last-frame resize):** `SpriteFrame` now pins `backgroundSize` height to `rows * scaledFrameHeight` instead of `auto`. `auto` scaled the sprite sheet by its *real* natural height, while the slice-offset math assumes every row is exactly `SPRITE_HEIGHT` (90px). When the final extracted tile came back a few pixels off 90px, the sheet height wasn't a clean `rows*90`, so only the last row drifted and rendered resized. Pinning the height puts every row on the same fixed grid, independent of the JPEG's trailing-row height. `FrameStrip` now threads `rowsInSheet` into the strip variant. This fixes **existing** sprite sheets with no regeneration needed.

**Fix B — backend (squashing + malformed sheets):** Sprite tile extraction changed from a bare `scale=160:90` (force-stretch) to `scale=160:90:force_original_aspect_ratio=decrease,pad=160:90:(ow-iw)/2:(oh-ih)/2:color=black`. This preserves aspect ratio (letterbox/pillarbox instead of squashing) **and** guarantees every tile is exactly `SPRITE_HEIGHT` tall, so the stacked sheet is always a clean `rows*90` column. Applies to newly generated / `--force`-regenerated sprites.

## Related Issue
Refs #541

## Motivation and Context
Both issues were reported during QA of the "Choose from Video" feature (#541). The last-frame resize was called out as blocking sign-off; the vertical-video squashing was noted as related. Fix A resolves the QA blocker immediately for all existing sprites, and Fix B corrects the source data going forward (and pairs with the sprite backfill work).

## How Has This Been Tested?
- **Frontend:** `npx vitest run src/features/shared/components/upload-media src/features/add-media` → **79/79 pass**. Added a `FrameStrip` test asserting first / middle / **last** frames share the same height and a pinned (non-`auto`) `backgroundSize`.
- **Backend:** `python manage.py test files.tests.test_video_sprite_backfill --settings=cms.settings` → **20/20 pass**. Added a test asserting the extraction filter letterboxes (`force_original_aspect_ratio=decrease` + `pad=160:90`) and never regresses to bare `scale=160:90`.
- `pre-commit` clean (ruff, ruff-format, prettier, django-upgrade).

## Screenshots (if appropriate):
<img width="1027" height="422" alt="image" src="https://github.com/user-attachments/assets/8034fdfb-f5b3-4861-b2b8-ae1a48e491c6" />
<img width="707" height="468" alt="image" src="https://github.com/user-attachments/assets/ee69329a-7467-4332-8246-90be48411b72" />


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):
- [x] I have not imported `flux` in a new component
- [x] If adding a new feature, I used Modern Track patterns
- [x] New features do not create new SCSS files (use Tailwind instead)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Video frame thumbnails now stay aligned to a consistent grid size, including the last frame.
  * Sprite generation now preserves aspect ratio while fitting every tile into the exact expected box, improving results for non-standard video sizes.
  * Frame previews now render with more reliable sizing and spacing, reducing stretched or uneven thumbnail displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->