### PR TITLE
fix(hls): version HLS output directory per generation to cache-bust segments

### DIFF
--- a/files/tasks.py
+++ b/files/tasks.py
@@ -62,6 +62,7 @@ logger = get_task_logger(__name__)
 # abandoned (e.g. a worker crashed mid-run). Generous enough to cover the
 # mp4hls remux of a typical video across all h264 encoding profiles.
 HLS_LOCK_TIMEOUT = 600
+HLS_PENDING_RETRY_TIMEOUT = HLS_LOCK_TIMEOUT * 2
 
 VALID_USER_ACTIONS = [action for action, name in USER_MEDIA_ACTIONS]
 
@@ -773,8 +774,11 @@ def create_hls(friendly_token):
     # runs for the same media are routine, not rare. Only the lock holder
     # writes output, updates hls_file, and runs cleanup.
     lock_key = f"create_hls_lock_{p}"
-    if not cache.add(lock_key, "1", timeout=HLS_LOCK_TIMEOUT):
-        logger.info("create_hls already running for media %s, skipping overlapping run", friendly_token)
+    pending_key = f"create_hls_pending_{p}"
+    lock_token = produce_friendly_token()
+    if not cache.add(lock_key, lock_token, timeout=HLS_LOCK_TIMEOUT):
+        cache.set(pending_key, "1", timeout=HLS_PENDING_RETRY_TIMEOUT)
+        logger.info("create_hls already running for media %s, queued follow-up run", friendly_token)
         return True
 
     try:
@@ -801,12 +805,33 @@ def create_hls(friendly_token):
             *encryption_flags,
             *files,
         ]
-        subprocess.run(cmd, capture_output=True)
+        try:
+            result = subprocess.run(cmd, capture_output=True, timeout=HLS_LOCK_TIMEOUT)
+        except subprocess.TimeoutExpired:
+            logger.error("mp4hls timed out for media %s, discarding partial output", friendly_token)
+            shutil.rmtree(output_dir, ignore_errors=True)
+            cache.set(pending_key, "1", timeout=HLS_PENDING_RETRY_TIMEOUT)
+            return True
+
+        if result.returncode != 0:
+            logger.error(
+                "mp4hls failed for media %s with return code %s, discarding partial output",
+                friendly_token,
+                result.returncode,
+            )
+            shutil.rmtree(output_dir, ignore_errors=True)
+            return True
 
         pp = os.path.join(output_dir, "master.m3u8")
         if not os.path.exists(pp):
             logger.error("mp4hls produced no master.m3u8 for media %s, discarding partial output", friendly_token)
             shutil.rmtree(output_dir, ignore_errors=True)
+            return True
+
+        if cache.get(lock_key) != lock_token:
+            logger.warning("create_hls lock expired for media %s, discarding stale output", friendly_token)
+            shutil.rmtree(output_dir, ignore_errors=True)
+            cache.set(pending_key, "1", timeout=HLS_PENDING_RETRY_TIMEOUT)
             return True
 
         # New URLs every regeneration: hls_file always changes, so the
@@ -831,7 +856,13 @@ def create_hls(friendly_token):
                     except OSError:
                         pass
     finally:
-        cache.delete(lock_key)
+        released_lock = False
+        if cache.get(lock_key) == lock_token:
+            cache.delete(lock_key)
+            released_lock = True
+        if cache.get(pending_key) and (released_lock or cache.get(lock_key) is None):
+            cache.delete(pending_key)
+            create_hls.apply_async(args=[friendly_token])
 
     return True
 

--- a/files/tasks.py
+++ b/files/tasks.py
@@ -55,9 +55,13 @@ from .models import (
 )
 from .query_cache import invalidate_media_cache
 from .sprites import generate_sprite_for_media
-from .storage_usage import schedule_refresh_media_storage_usage
 
 logger = get_task_logger(__name__)
+
+# How long a per-media create_hls lock is held before it is considered
+# abandoned (e.g. a worker crashed mid-run). Generous enough to cover the
+# mp4hls remux of a typical video across all h264 encoding profiles.
+HLS_LOCK_TIMEOUT = 600
 
 VALID_USER_ACTIONS = [action for action, name in USER_MEDIA_ACTIONS]
 
@@ -759,13 +763,25 @@ def create_hls(friendly_token):
         return False
 
     p = media.uid.hex
-    output_dir = os.path.join(settings.HLS_DIR, p)
+    uid_dir = os.path.join(settings.HLS_DIR, p)
     encodings = media.encodings.filter(profile__extension="mp4", status="success", chunk=False, profile__codec="h264")
-    if encodings:
-        existing_output_dir = None
-        if os.path.exists(output_dir):
-            existing_output_dir = output_dir
-            output_dir = os.path.join(settings.HLS_DIR, p + produce_friendly_token())
+    if not encodings:
+        return True
+
+    # Serialize regeneration per media: create_hls.delay fires once per
+    # successful h264 profile and again on encryption toggle, so overlapping
+    # runs for the same media are routine, not rare. Only the lock holder
+    # writes output, updates hls_file, and runs cleanup.
+    lock_key = f"create_hls_lock_{p}"
+    if not cache.add(lock_key, "1", timeout=HLS_LOCK_TIMEOUT):
+        logger.info("create_hls already running for media %s, skipping overlapping run", friendly_token)
+        return True
+
+    try:
+        version = produce_friendly_token()
+        output_dir = os.path.join(uid_dir, version)
+        os.makedirs(output_dir, exist_ok=True)
+
         files = [f.media_file.path for f in encodings if f.media_file]
         encryption_flags = []
         if media.is_encrypted:
@@ -786,19 +802,37 @@ def create_hls(friendly_token):
             *files,
         ]
         subprocess.run(cmd, capture_output=True)
-        if existing_output_dir:
-            # Replace old HLS output with new. Use shutil instead of
-            # `cp -rT` which is GNU-only and fails silently on macOS.
-            shutil.rmtree(existing_output_dir)
-            shutil.move(output_dir, existing_output_dir)
-            output_dir = existing_output_dir
+
         pp = os.path.join(output_dir, "master.m3u8")
-        if os.path.exists(pp):
-            if media.hls_file != pp:
-                media.hls_file = pp
-                media.save(update_fields=["hls_file"])
-            else:
-                schedule_refresh_media_storage_usage(media.id)
+        if not os.path.exists(pp):
+            logger.error("mp4hls produced no master.m3u8 for media %s, discarding partial output", friendly_token)
+            shutil.rmtree(output_dir, ignore_errors=True)
+            return True
+
+        # New URLs every regeneration: hls_file always changes, so the
+        # post_save signal on Media always fires the storage usage refresh.
+        media.hls_file = pp
+        media.save(update_fields=["hls_file"])
+
+        # Remove stale output: never delete the directory hls_file currently
+        # references (guards against a concurrently-committed newer run),
+        # but clear every other version directory plus legacy flat siblings.
+        current_dir = os.path.dirname(media.hls_file)
+        if os.path.isdir(uid_dir):
+            for entry in os.listdir(uid_dir):
+                entry_path = os.path.join(uid_dir, entry)
+                if entry_path == current_dir:
+                    continue
+                if os.path.isdir(entry_path):
+                    shutil.rmtree(entry_path, ignore_errors=True)
+                else:
+                    try:
+                        os.remove(entry_path)
+                    except OSError:
+                        pass
+    finally:
+        cache.delete(lock_key)
+
     return True
 
 

--- a/files/tasks.py
+++ b/files/tasks.py
@@ -58,10 +58,11 @@ from .sprites import generate_sprite_for_media
 
 logger = get_task_logger(__name__)
 
-# How long a per-media create_hls lock is held before it is considered
-# abandoned (e.g. a worker crashed mid-run). Generous enough to cover the
-# mp4hls remux of a typical video across all h264 encoding profiles.
-HLS_LOCK_TIMEOUT = 600
+# How long mp4hls may remux before the worker discards the partial output.
+MP4HLS_SUBPROCESS_TIMEOUT = 600
+# Keep the per-media create_hls lock longer than the subprocess timeout so a
+# valid near-timeout run can still save and clean up while holding its token.
+HLS_LOCK_TIMEOUT = MP4HLS_SUBPROCESS_TIMEOUT + 120
 HLS_PENDING_RETRY_TIMEOUT = HLS_LOCK_TIMEOUT * 2
 
 VALID_USER_ACTIONS = [action for action, name in USER_MEDIA_ACTIONS]
@@ -806,7 +807,7 @@ def create_hls(friendly_token):
             *files,
         ]
         try:
-            result = subprocess.run(cmd, capture_output=True, timeout=HLS_LOCK_TIMEOUT)
+            result = subprocess.run(cmd, capture_output=True, timeout=MP4HLS_SUBPROCESS_TIMEOUT)
         except subprocess.TimeoutExpired:
             logger.error("mp4hls timed out for media %s, discarding partial output", friendly_token)
             shutil.rmtree(output_dir, ignore_errors=True)
@@ -814,10 +815,12 @@ def create_hls(friendly_token):
             return True
 
         if result.returncode != 0:
+            stderr = result.stderr.decode("utf-8", errors="replace") if result.stderr else ""
             logger.error(
-                "mp4hls failed for media %s with return code %s, discarding partial output",
+                "mp4hls failed for media %s with return code %s, discarding partial output: %s",
                 friendly_token,
                 result.returncode,
+                stderr,
             )
             shutil.rmtree(output_dir, ignore_errors=True)
             return True

--- a/files/tasks.py
+++ b/files/tasks.py
@@ -64,6 +64,13 @@ MP4HLS_SUBPROCESS_TIMEOUT = 600
 # valid near-timeout run can still save and clean up while holding its token.
 HLS_LOCK_TIMEOUT = MP4HLS_SUBPROCESS_TIMEOUT + 120
 HLS_PENDING_RETRY_TIMEOUT = HLS_LOCK_TIMEOUT * 2
+# A subprocess timeout is often deterministic (input too large for the ceiling).
+# Retry it a bounded number of times with a delay instead of the immediate
+# overlap retry used for lock contention, so a bad input cannot loop a worker
+# for MP4HLS_SUBPROCESS_TIMEOUT seconds indefinitely.
+HLS_TIMEOUT_MAX_RETRIES = 2
+HLS_TIMEOUT_RETRY_DELAY = 60
+HLS_TIMEOUT_RETRY_KEY_TIMEOUT = HLS_PENDING_RETRY_TIMEOUT
 
 VALID_USER_ACTIONS = [action for action, name in USER_MEDIA_ACTIONS]
 
@@ -776,6 +783,7 @@ def create_hls(friendly_token):
     # writes output, updates hls_file, and runs cleanup.
     lock_key = f"create_hls_lock_{p}"
     pending_key = f"create_hls_pending_{p}"
+    timeout_retry_key = f"create_hls_timeout_retries_{p}"
     lock_token = produce_friendly_token()
     if not cache.add(lock_key, lock_token, timeout=HLS_LOCK_TIMEOUT):
         cache.set(pending_key, "1", timeout=HLS_PENDING_RETRY_TIMEOUT)
@@ -811,7 +819,28 @@ def create_hls(friendly_token):
         except subprocess.TimeoutExpired:
             logger.error("mp4hls timed out for media %s, discarding partial output", friendly_token)
             shutil.rmtree(output_dir, ignore_errors=True)
-            cache.set(pending_key, "1", timeout=HLS_PENDING_RETRY_TIMEOUT)
+            # Timeouts are usually deterministic, so bound the retries and delay
+            # them instead of the immediate overlap retry used for lock
+            # contention. This avoids looping a worker for
+            # MP4HLS_SUBPROCESS_TIMEOUT seconds on an input that never fits.
+            attempts = (cache.get(timeout_retry_key) or 0) + 1
+            if attempts <= HLS_TIMEOUT_MAX_RETRIES:
+                cache.set(timeout_retry_key, attempts, timeout=HLS_TIMEOUT_RETRY_KEY_TIMEOUT)
+                logger.info(
+                    "scheduling bounded timeout retry %s/%s for media %s in %ss",
+                    attempts,
+                    HLS_TIMEOUT_MAX_RETRIES,
+                    friendly_token,
+                    HLS_TIMEOUT_RETRY_DELAY,
+                )
+                create_hls.apply_async(args=[friendly_token], countdown=HLS_TIMEOUT_RETRY_DELAY)
+            else:
+                cache.delete(timeout_retry_key)
+                logger.error(
+                    "mp4hls timed out %s times for media %s, giving up and preserving last known-good hls_file",
+                    HLS_TIMEOUT_MAX_RETRIES,
+                    friendly_token,
+                )
             return True
 
         if result.returncode != 0:
@@ -858,6 +887,10 @@ def create_hls(friendly_token):
                         os.remove(entry_path)
                     except OSError:
                         pass
+
+        # A successful regeneration clears any prior timeout backoff so a media
+        # that once timed out (e.g. transient load) starts fresh next time.
+        cache.delete(timeout_retry_key)
     finally:
         released_lock = False
         if cache.get(lock_key) == lock_token:

--- a/files/tests/test_hls_cleanup.py
+++ b/files/tests/test_hls_cleanup.py
@@ -1,0 +1,89 @@
+"""
+Tests for cleanup_hls_directory_for_media, the media-replace HLS cleanup
+helper used by edit_media (issue #791).
+
+Covers removal of the versioned HLS_DIR/<uid> tree, the legacy flat layout,
+directory-traversal protection, and no-op cases.
+"""
+
+import os
+import tempfile
+
+from django.test import TestCase, override_settings
+
+from files.models import Media
+from files.tests.test_hls_encryption import create_test_media
+from files.views import cleanup_hls_directory_for_media
+from users.models import User
+
+
+class CleanupHlsDirectoryForMediaTests(TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.hls_dir = os.path.join(self.tmpdir.name, "hls")
+        os.makedirs(self.hls_dir, exist_ok=True)
+        self.override = override_settings(MEDIA_ROOT=self.tmpdir.name, HLS_DIR=self.hls_dir)
+        self.override.enable()
+        self.addCleanup(self.override.disable)
+        self.addCleanup(self.tmpdir.cleanup)
+
+        self.user = User.objects.create_user(username="owner", email="owner@example.com", password="pw")
+        self.media = create_test_media(self.user)
+
+    def _uid_dir(self):
+        return os.path.join(self.hls_dir, self.media.uid.hex)
+
+    def test_removes_versioned_hls_tree(self):
+        version_dir = os.path.join(self._uid_dir(), "abc123")
+        os.makedirs(version_dir, exist_ok=True)
+        master = os.path.join(version_dir, "master.m3u8")
+        with open(master, "wb") as f:
+            f.write(b"content")
+        Media.objects.filter(pk=self.media.pk).update(hls_file=master)
+        self.media.refresh_from_db()
+
+        cleanup_hls_directory_for_media(self.media)
+
+        self.assertFalse(os.path.exists(self._uid_dir()))
+
+    def test_removes_legacy_flat_hls_tree(self):
+        uid_dir = self._uid_dir()
+        os.makedirs(uid_dir, exist_ok=True)
+        master = os.path.join(uid_dir, "master.m3u8")
+        with open(master, "wb") as f:
+            f.write(b"content")
+        Media.objects.filter(pk=self.media.pk).update(hls_file=master)
+        self.media.refresh_from_db()
+
+        cleanup_hls_directory_for_media(self.media)
+
+        self.assertFalse(os.path.exists(uid_dir))
+
+    def test_hls_dir_unset_skips_cleanup_without_exception(self):
+        uid_dir = self._uid_dir()
+        os.makedirs(uid_dir, exist_ok=True)
+        with override_settings(HLS_DIR=None):
+            cleanup_hls_directory_for_media(self.media)
+        self.assertTrue(os.path.exists(uid_dir))
+
+    def test_no_hls_file_and_no_on_disk_dir_is_a_no_op(self):
+        # Should not raise even though nothing exists on disk.
+        cleanup_hls_directory_for_media(self.media)
+        self.assertFalse(os.path.exists(self._uid_dir()))
+
+    def test_other_media_uid_directory_untouched(self):
+        other_uid_dir = os.path.join(self.hls_dir, "0" * 32)
+        os.makedirs(other_uid_dir, exist_ok=True)
+        sentinel = os.path.join(other_uid_dir, "master.m3u8")
+        with open(sentinel, "wb") as f:
+            f.write(b"other media")
+
+        uid_dir = self._uid_dir()
+        os.makedirs(uid_dir, exist_ok=True)
+        with open(os.path.join(uid_dir, "master.m3u8"), "wb") as f:
+            f.write(b"this media")
+
+        cleanup_hls_directory_for_media(self.media)
+
+        self.assertFalse(os.path.exists(uid_dir))
+        self.assertTrue(os.path.exists(sentinel))

--- a/files/tests/test_hls_encryption.py
+++ b/files/tests/test_hls_encryption.py
@@ -398,7 +398,18 @@ class CreateHlsVersionedDirectoryTests(TestCase):
         uid_dir = os.path.join(self.hls_dir, self.media.uid.hex)
         self.assertEqual(os.listdir(uid_dir), [os.path.basename(os.path.dirname(good_hls_file))])
 
-    def test_mp4hls_timeout_discards_partial_output_and_schedules_retry(self):
+    @staticmethod
+    def _fake_timeout(command, capture_output, timeout=None):
+        output_dir = next(
+            (part.removeprefix("--output-dir=") for part in command if part.startswith("--output-dir=")),
+            None,
+        )
+        os.makedirs(output_dir, exist_ok=True)
+        with open(os.path.join(output_dir, "master.m3u8"), "wb") as master_file:
+            master_file.write(b"incomplete")
+        raise subprocess.TimeoutExpired(cmd=command, timeout=timeout)
+
+    def test_mp4hls_timeout_discards_partial_output_and_schedules_delayed_retry(self):
         from files import tasks
 
         with patch("files.tasks.subprocess.run", side_effect=self._fake_run_writing_master):
@@ -406,18 +417,8 @@ class CreateHlsVersionedDirectoryTests(TestCase):
         self.media.refresh_from_db()
         good_hls_file = self.media.hls_file
 
-        def fake_timeout(command, capture_output, timeout=None):
-            output_dir = next(
-                (part.removeprefix("--output-dir=") for part in command if part.startswith("--output-dir=")),
-                None,
-            )
-            os.makedirs(output_dir, exist_ok=True)
-            with open(os.path.join(output_dir, "master.m3u8"), "wb") as master_file:
-                master_file.write(b"incomplete")
-            raise subprocess.TimeoutExpired(cmd=command, timeout=timeout)
-
         with (
-            patch("files.tasks.subprocess.run", side_effect=fake_timeout),
+            patch("files.tasks.subprocess.run", side_effect=self._fake_timeout),
             patch("files.tasks.create_hls.apply_async") as mock_apply_async,
         ):
             self.assertTrue(tasks.create_hls(self.media.friendly_token))
@@ -426,7 +427,44 @@ class CreateHlsVersionedDirectoryTests(TestCase):
         self.assertEqual(self.media.hls_file, good_hls_file)
         uid_dir = os.path.join(self.hls_dir, self.media.uid.hex)
         self.assertEqual(os.listdir(uid_dir), [os.path.basename(os.path.dirname(good_hls_file))])
-        mock_apply_async.assert_called_once_with(args=[self.media.friendly_token])
+        # Timeout retries are bounded and delayed, not the immediate overlap retry.
+        mock_apply_async.assert_called_once_with(
+            args=[self.media.friendly_token],
+            countdown=tasks.HLS_TIMEOUT_RETRY_DELAY,
+        )
+
+    def test_mp4hls_timeout_retries_are_bounded(self):
+        from files import tasks
+
+        # Every run times out. The retry must stop after HLS_TIMEOUT_MAX_RETRIES
+        # so a deterministically-too-large input cannot loop a worker forever.
+        with patch("files.tasks.subprocess.run", side_effect=self._fake_timeout):
+            for _ in range(tasks.HLS_TIMEOUT_MAX_RETRIES + 3):
+                with patch("files.tasks.create_hls.apply_async") as mock_apply_async:
+                    self.assertTrue(tasks.create_hls(self.media.friendly_token))
+                # Record whether this attempt scheduled a follow-up run.
+                if mock_apply_async.call_count == 0:
+                    break
+
+        # After the bound is reached the retry key is cleared and no run queued.
+        timeout_retry_key = f"create_hls_timeout_retries_{self.media.uid.hex}"
+        self.assertIsNone(cache.get(timeout_retry_key))
+        self.assertEqual(mock_apply_async.call_count, 0)
+
+    def test_successful_generation_clears_timeout_backoff(self):
+        from files import tasks
+
+        timeout_retry_key = f"create_hls_timeout_retries_{self.media.uid.hex}"
+        with (
+            patch("files.tasks.subprocess.run", side_effect=self._fake_timeout),
+            patch("files.tasks.create_hls.apply_async"),
+        ):
+            self.assertTrue(tasks.create_hls(self.media.friendly_token))
+        self.assertEqual(cache.get(timeout_retry_key), 1)
+
+        with patch("files.tasks.subprocess.run", side_effect=self._fake_run_writing_master):
+            self.assertTrue(tasks.create_hls(self.media.friendly_token))
+        self.assertIsNone(cache.get(timeout_retry_key))
 
     def test_expired_lock_discards_stale_output_and_schedules_retry(self):
         from files import tasks

--- a/files/tests/test_hls_encryption.py
+++ b/files/tests/test_hls_encryption.py
@@ -10,6 +10,7 @@ Covers:
 """
 
 import os
+import subprocess
 import tempfile
 from unittest.mock import MagicMock, patch
 
@@ -396,6 +397,61 @@ class CreateHlsVersionedDirectoryTests(TestCase):
         self.assertEqual(self.media.hls_file, good_hls_file)
         uid_dir = os.path.join(self.hls_dir, self.media.uid.hex)
         self.assertEqual(os.listdir(uid_dir), [os.path.basename(os.path.dirname(good_hls_file))])
+
+    def test_mp4hls_timeout_discards_partial_output_and_schedules_retry(self):
+        from files import tasks
+
+        with patch("files.tasks.subprocess.run", side_effect=self._fake_run_writing_master):
+            self.assertTrue(tasks.create_hls(self.media.friendly_token))
+        self.media.refresh_from_db()
+        good_hls_file = self.media.hls_file
+
+        def fake_timeout(command, capture_output, timeout=None):
+            output_dir = next(
+                (part.removeprefix("--output-dir=") for part in command if part.startswith("--output-dir=")),
+                None,
+            )
+            os.makedirs(output_dir, exist_ok=True)
+            with open(os.path.join(output_dir, "master.m3u8"), "wb") as master_file:
+                master_file.write(b"incomplete")
+            raise subprocess.TimeoutExpired(cmd=command, timeout=timeout)
+
+        with (
+            patch("files.tasks.subprocess.run", side_effect=fake_timeout),
+            patch("files.tasks.create_hls.apply_async") as mock_apply_async,
+        ):
+            self.assertTrue(tasks.create_hls(self.media.friendly_token))
+
+        self.media.refresh_from_db()
+        self.assertEqual(self.media.hls_file, good_hls_file)
+        uid_dir = os.path.join(self.hls_dir, self.media.uid.hex)
+        self.assertEqual(os.listdir(uid_dir), [os.path.basename(os.path.dirname(good_hls_file))])
+        mock_apply_async.assert_called_once_with(args=[self.media.friendly_token])
+
+    def test_expired_lock_discards_stale_output_and_schedules_retry(self):
+        from files import tasks
+
+        with patch("files.tasks.subprocess.run", side_effect=self._fake_run_writing_master):
+            self.assertTrue(tasks.create_hls(self.media.friendly_token))
+        self.media.refresh_from_db()
+        good_hls_file = self.media.hls_file
+        lock_key = f"create_hls_lock_{self.media.uid.hex}"
+
+        def fake_run_after_lock_expired(command, capture_output, timeout=None):
+            cache.delete(lock_key)
+            return self._fake_run_writing_master(command, capture_output, timeout=timeout)
+
+        with (
+            patch("files.tasks.subprocess.run", side_effect=fake_run_after_lock_expired),
+            patch("files.tasks.create_hls.apply_async") as mock_apply_async,
+        ):
+            self.assertTrue(tasks.create_hls(self.media.friendly_token))
+
+        self.media.refresh_from_db()
+        self.assertEqual(self.media.hls_file, good_hls_file)
+        uid_dir = os.path.join(self.hls_dir, self.media.uid.hex)
+        self.assertEqual(os.listdir(uid_dir), [os.path.basename(os.path.dirname(good_hls_file))])
+        mock_apply_async.assert_called_once_with(args=[self.media.friendly_token])
 
     def test_concurrent_run_marks_pending_when_lock_held(self):
         from files import tasks

--- a/files/tests/test_hls_encryption.py
+++ b/files/tests/test_hls_encryption.py
@@ -292,7 +292,7 @@ class CreateHlsVersionedDirectoryTests(TestCase):
         )
 
     @staticmethod
-    def _fake_run_writing_master(command, capture_output):
+    def _fake_run_writing_master(command, capture_output, timeout=None):
         output_dir = next(
             (part.removeprefix("--output-dir=") for part in command if part.startswith("--output-dir=")),
             None,
@@ -303,7 +303,18 @@ class CreateHlsVersionedDirectoryTests(TestCase):
         return MagicMock(returncode=0)
 
     @staticmethod
-    def _fake_run_producing_nothing(command, capture_output):
+    def _fake_run_producing_nothing(command, capture_output, timeout=None):
+        return MagicMock(returncode=1)
+
+    @staticmethod
+    def _fake_run_failing_after_master(command, capture_output, timeout=None):
+        output_dir = next(
+            (part.removeprefix("--output-dir=") for part in command if part.startswith("--output-dir=")),
+            None,
+        )
+        os.makedirs(output_dir, exist_ok=True)
+        with open(os.path.join(output_dir, "master.m3u8"), "wb") as master_file:
+            master_file.write(b"incomplete")
         return MagicMock(returncode=1)
 
     def test_first_generation_writes_versioned_directory(self):
@@ -370,7 +381,23 @@ class CreateHlsVersionedDirectoryTests(TestCase):
         self.assertEqual(self.media.hls_file, good_hls_file)
         self.assertTrue(os.path.exists(good_hls_file))
 
-    def test_concurrent_run_skips_when_lock_held(self):
+    def test_mp4hls_nonzero_with_master_discards_partial_output(self):
+        from files import tasks
+
+        with patch("files.tasks.subprocess.run", side_effect=self._fake_run_writing_master):
+            self.assertTrue(tasks.create_hls(self.media.friendly_token))
+        self.media.refresh_from_db()
+        good_hls_file = self.media.hls_file
+
+        with patch("files.tasks.subprocess.run", side_effect=self._fake_run_failing_after_master):
+            self.assertTrue(tasks.create_hls(self.media.friendly_token))
+
+        self.media.refresh_from_db()
+        self.assertEqual(self.media.hls_file, good_hls_file)
+        uid_dir = os.path.join(self.hls_dir, self.media.uid.hex)
+        self.assertEqual(os.listdir(uid_dir), [os.path.basename(os.path.dirname(good_hls_file))])
+
+    def test_concurrent_run_marks_pending_when_lock_held(self):
         from files import tasks
 
         with patch("files.tasks.subprocess.run", side_effect=self._fake_run_writing_master):
@@ -380,17 +407,39 @@ class CreateHlsVersionedDirectoryTests(TestCase):
         dir_before = os.path.dirname(hls_file_before)
 
         lock_key = f"create_hls_lock_{self.media.uid.hex}"
+        pending_key = f"create_hls_pending_{self.media.uid.hex}"
         cache.add(lock_key, "1", timeout=tasks.HLS_LOCK_TIMEOUT)
         try:
-            with patch("files.tasks.subprocess.run", side_effect=self._fake_run_writing_master) as mock_run:
+            with (
+                patch("files.tasks.subprocess.run", side_effect=self._fake_run_writing_master) as mock_run,
+                patch("files.tasks.create_hls.apply_async") as mock_apply_async,
+            ):
                 self.assertTrue(tasks.create_hls(self.media.friendly_token))
             mock_run.assert_not_called()
+            mock_apply_async.assert_not_called()
+            self.assertEqual(cache.get(pending_key), "1")
         finally:
             cache.delete(lock_key)
+            cache.delete(pending_key)
 
         self.media.refresh_from_db()
         self.assertEqual(self.media.hls_file, hls_file_before)
         self.assertTrue(os.path.exists(dir_before))
+
+    def test_pending_overlap_schedules_follow_up_after_lock_release(self):
+        from files import tasks
+
+        pending_key = f"create_hls_pending_{self.media.uid.hex}"
+        cache.set(pending_key, "1", timeout=tasks.HLS_PENDING_RETRY_TIMEOUT)
+
+        with (
+            patch("files.tasks.subprocess.run", side_effect=self._fake_run_writing_master),
+            patch("files.tasks.create_hls.apply_async") as mock_apply_async,
+        ):
+            self.assertTrue(tasks.create_hls(self.media.friendly_token))
+
+        mock_apply_async.assert_called_once_with(args=[self.media.friendly_token])
+        self.assertIsNone(cache.get(pending_key))
 
     def test_removal_stays_within_uid_directory(self):
         from files import tasks

--- a/files/tests/test_hls_encryption.py
+++ b/files/tests/test_hls_encryption.py
@@ -6,11 +6,15 @@ Covers:
 - Media.ensure_encryption_key() generation and idempotency
 - Encryption toggle re-dispatching create_hls
 - create_hls task encryption flag injection
+- create_hls versioned output directory / cache-busting (issue #791)
 """
 
-from unittest.mock import patch
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
 
-from django.test import Client, TestCase
+from django.core.cache import cache
+from django.test import Client, TestCase, override_settings
 from django.urls import reverse
 
 from files.models import Media
@@ -251,3 +255,153 @@ class CreateHlsEncryptionFlagsTests(TestCase):
         self.assertTrue(key_uri.startswith("/"), f"Expected root-relative URI, got: {key_uri}")
         self.assertFalse(key_uri.startswith("http"), f"URI should not be absolute, got: {key_uri}")
         self.assertIn(media.friendly_token, key_uri)
+
+
+class CreateHlsVersionedDirectoryTests(TestCase):
+    """Tests create_hls writing to HLS_DIR/<uid>/<version>/ (issue #791)."""
+
+    def setUp(self):
+        from files.models import EncodeProfile, Encoding
+
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.hls_dir = os.path.join(self.tmpdir.name, "hls")
+        os.makedirs(self.hls_dir, exist_ok=True)
+        self.fake_mp4hls = os.path.join(self.tmpdir.name, "mp4hls")
+        with open(self.fake_mp4hls, "w", encoding="utf-8") as command_file:
+            command_file.write("#!/bin/sh\n")
+
+        self.override = override_settings(
+            MEDIA_ROOT=self.tmpdir.name,
+            HLS_DIR=self.hls_dir,
+            TEMP_DIRECTORY=self.tmpdir.name,
+            MP4HLS_COMMAND=self.fake_mp4hls,
+        )
+        self.override.enable()
+        self.addCleanup(self.override.disable)
+        self.addCleanup(self.tmpdir.cleanup)
+        cache.clear()
+
+        self.user = User.objects.create_user(username="owner", email="owner@example.com", password="pw")
+        self.profile = EncodeProfile.objects.create(name="h264_test", extension="mp4", codec="h264", resolution=720)
+        self.media = create_test_media(self.user)
+        self.encoding = Encoding.objects.create(
+            media=self.media,
+            profile=self.profile,
+            status="success",
+            media_file="encoded/fake.mp4",
+        )
+
+    @staticmethod
+    def _fake_run_writing_master(command, capture_output):
+        output_dir = next(
+            (part.removeprefix("--output-dir=") for part in command if part.startswith("--output-dir=")),
+            None,
+        )
+        os.makedirs(output_dir, exist_ok=True)
+        with open(os.path.join(output_dir, "master.m3u8"), "wb") as master_file:
+            master_file.write(b"content")
+        return MagicMock(returncode=0)
+
+    @staticmethod
+    def _fake_run_producing_nothing(command, capture_output):
+        return MagicMock(returncode=1)
+
+    def test_first_generation_writes_versioned_directory(self):
+        from files import tasks
+
+        with patch("files.tasks.subprocess.run", side_effect=self._fake_run_writing_master):
+            self.assertTrue(tasks.create_hls(self.media.friendly_token))
+
+        self.media.refresh_from_db()
+        uid_dir = os.path.join(self.hls_dir, self.media.uid.hex)
+        self.assertTrue(self.media.hls_file.startswith(uid_dir + os.sep))
+        self.assertNotEqual(os.path.dirname(self.media.hls_file), uid_dir)
+        self.assertTrue(os.path.exists(self.media.hls_file))
+
+    def test_regeneration_removes_previous_version_directory(self):
+        from files import tasks
+
+        with patch("files.tasks.subprocess.run", side_effect=self._fake_run_writing_master):
+            self.assertTrue(tasks.create_hls(self.media.friendly_token))
+        self.media.refresh_from_db()
+        first_dir = os.path.dirname(self.media.hls_file)
+
+        with patch("files.tasks.subprocess.run", side_effect=self._fake_run_writing_master):
+            self.assertTrue(tasks.create_hls(self.media.friendly_token))
+        self.media.refresh_from_db()
+        second_dir = os.path.dirname(self.media.hls_file)
+
+        self.assertNotEqual(first_dir, second_dir)
+        self.assertFalse(os.path.exists(first_dir))
+        self.assertTrue(os.path.exists(second_dir))
+
+        uid_dir = os.path.join(self.hls_dir, self.media.uid.hex)
+        self.assertEqual(os.listdir(uid_dir), [os.path.basename(second_dir)])
+
+    def test_regeneration_removes_legacy_flat_layout_siblings(self):
+        from files import tasks
+
+        uid_dir = os.path.join(self.hls_dir, self.media.uid.hex)
+        os.makedirs(uid_dir, exist_ok=True)
+        legacy_master = os.path.join(uid_dir, "master.m3u8")
+        with open(legacy_master, "wb") as f:
+            f.write(b"legacy")
+        Media.objects.filter(pk=self.media.pk).update(hls_file=legacy_master)
+
+        with patch("files.tasks.subprocess.run", side_effect=self._fake_run_writing_master):
+            self.assertTrue(tasks.create_hls(self.media.friendly_token))
+
+        self.assertFalse(os.path.exists(legacy_master))
+        self.media.refresh_from_db()
+        self.assertTrue(os.path.exists(self.media.hls_file))
+
+    def test_mp4hls_failure_leaves_previous_hls_file_untouched(self):
+        from files import tasks
+
+        with patch("files.tasks.subprocess.run", side_effect=self._fake_run_writing_master):
+            self.assertTrue(tasks.create_hls(self.media.friendly_token))
+        self.media.refresh_from_db()
+        good_hls_file = self.media.hls_file
+
+        with patch("files.tasks.subprocess.run", side_effect=self._fake_run_producing_nothing):
+            self.assertTrue(tasks.create_hls(self.media.friendly_token))
+
+        self.media.refresh_from_db()
+        self.assertEqual(self.media.hls_file, good_hls_file)
+        self.assertTrue(os.path.exists(good_hls_file))
+
+    def test_concurrent_run_skips_when_lock_held(self):
+        from files import tasks
+
+        with patch("files.tasks.subprocess.run", side_effect=self._fake_run_writing_master):
+            self.assertTrue(tasks.create_hls(self.media.friendly_token))
+        self.media.refresh_from_db()
+        hls_file_before = self.media.hls_file
+        dir_before = os.path.dirname(hls_file_before)
+
+        lock_key = f"create_hls_lock_{self.media.uid.hex}"
+        cache.add(lock_key, "1", timeout=tasks.HLS_LOCK_TIMEOUT)
+        try:
+            with patch("files.tasks.subprocess.run", side_effect=self._fake_run_writing_master) as mock_run:
+                self.assertTrue(tasks.create_hls(self.media.friendly_token))
+            mock_run.assert_not_called()
+        finally:
+            cache.delete(lock_key)
+
+        self.media.refresh_from_db()
+        self.assertEqual(self.media.hls_file, hls_file_before)
+        self.assertTrue(os.path.exists(dir_before))
+
+    def test_removal_stays_within_uid_directory(self):
+        from files import tasks
+
+        other_uid_dir = os.path.join(self.hls_dir, "0" * 32)
+        os.makedirs(other_uid_dir, exist_ok=True)
+        sentinel = os.path.join(other_uid_dir, "master.m3u8")
+        with open(sentinel, "wb") as f:
+            f.write(b"other media, do not touch")
+
+        with patch("files.tasks.subprocess.run", side_effect=self._fake_run_writing_master):
+            self.assertTrue(tasks.create_hls(self.media.friendly_token))
+
+        self.assertTrue(os.path.exists(sentinel))

--- a/files/tests/test_secure_media_hls_nesting.py
+++ b/files/tests/test_secure_media_hls_nesting.py
@@ -1,0 +1,110 @@
+"""
+Regression tests for SecureMediaView path resolution under the versioned
+HLS output layout (hls/<uid>/<version>/...) introduced for issue #791.
+
+_get_media_from_path's HLS branch matches parts[1] against media.uid
+regardless of how deeply the remaining path is nested (len(parts) >= 3),
+so no production code change was required here (KTD4). These tests prove
+that behavior holds for the new layout and stays enforced end-to-end.
+"""
+
+import os
+import tempfile
+
+from django.test import Client, TestCase, override_settings
+
+from files.secure_media_views import SecureMediaView
+from files.tests.helpers import create_test_media, create_test_user
+from files.token_utils import generate_token
+
+
+class GetMediaFromPathNestedHlsTests(TestCase):
+    databases = ["default"]
+
+    def setUp(self):
+        self.view = SecureMediaView()
+        self.user = create_test_user(username="hls_nesting_owner")
+        self.media = create_test_media(self.user, state="public")
+
+    def test_resolves_versioned_manifest_path(self):
+        path = f"hls/{self.media.uid.hex}/abc123/master.m3u8"
+        media, actual_path = self.view._get_media_from_path(path)
+        self.assertEqual(media, self.media)
+        self.assertIsNone(actual_path)
+
+    def test_resolves_deeply_nested_segment_path(self):
+        path = f"hls/{self.media.uid.hex}/abc123/media-1/stream.m3u8"
+        media, _ = self.view._get_media_from_path(path)
+        self.assertEqual(media, self.media)
+
+    def test_resolves_legacy_flat_path(self):
+        path = f"hls/{self.media.uid.hex}/master.m3u8"
+        media, _ = self.view._get_media_from_path(path)
+        self.assertEqual(media, self.media)
+
+    def test_unknown_uid_returns_none(self):
+        path = "hls/00000000000000000000000000000000/abc123/master.m3u8"
+        media, _ = self.view._get_media_from_path(path)
+        self.assertIsNone(media)
+
+
+class SecureMediaViewNestedHlsAccessTests(TestCase):
+    databases = ["default"]
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.hls_dir = os.path.join(self.tmpdir.name, "hls")
+        os.makedirs(self.hls_dir, exist_ok=True)
+        self.override = override_settings(
+            MEDIA_ROOT=self.tmpdir.name,
+            HLS_DIR=self.hls_dir,
+            USE_X_ACCEL_REDIRECT=False,
+        )
+        self.override.enable()
+        self.addCleanup(self.override.disable)
+        self.addCleanup(self.tmpdir.cleanup)
+
+        self.owner = create_test_user(username="hls_nesting_owner2")
+        self.client = Client()
+
+    def _write_manifest(self, media, version, filename="master.m3u8", content="#EXTM3U\nsegment0.ts\n"):
+        version_dir = os.path.join(self.hls_dir, media.uid.hex, version)
+        os.makedirs(version_dir, exist_ok=True)
+        manifest_path = os.path.join(version_dir, filename)
+        with open(manifest_path, "w", encoding="utf-8") as f:
+            f.write(content)
+        return f"hls/{media.uid.hex}/{version}/{filename}"
+
+    def test_private_media_denies_unauthorized_access_under_nested_path(self):
+        media = create_test_media(self.owner, state="private")
+        rel_path = self._write_manifest(media, "abc123")
+
+        response = self.client.get(f"/media/{rel_path}")
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_public_media_serves_manifest_under_nested_path(self):
+        media = create_test_media(self.owner, state="public")
+        rel_path = self._write_manifest(media, "abc123")
+
+        response = self.client.get(f"/media/{rel_path}")
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_restricted_media_rewritten_manifest_has_no_store_cache_control(self):
+        media = create_test_media(self.owner, state="restricted")
+        rel_path = self._write_manifest(media, "abc123")
+        token = generate_token(media.uid.hex)
+
+        response = self.client.get(f"/media/{rel_path}?token={token}")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("no-store", response["Cache-Control"])
+
+    def test_restricted_media_without_token_denies_access_under_nested_path(self):
+        media = create_test_media(self.owner, state="restricted")
+        rel_path = self._write_manifest(media, "abc123")
+
+        response = self.client.get(f"/media/{rel_path}")
+
+        self.assertEqual(response.status_code, 403)

--- a/files/tests/test_storage_usage.py
+++ b/files/tests/test_storage_usage.py
@@ -154,7 +154,7 @@ class StorageUsageTests(TestCase):
         self.assertEqual(self.media.storage_usage_bytes, 6)
         self.assertIn("Storage usage backfill complete", out.getvalue())
 
-    def test_create_hls_refreshes_storage_usage_when_hls_path_is_unchanged(self):
+    def test_create_hls_refreshes_storage_usage_on_regeneration(self):
         fake_mp4hls = os.path.join(self.tmpdir.name, "mp4hls")
         with open(fake_mp4hls, "w", encoding="utf-8") as command_file:
             command_file.write("#!/bin/sh\n")
@@ -163,11 +163,11 @@ class StorageUsageTests(TestCase):
         encoding = Encoding.objects.create(media=self.media, profile=self._profile(), status="success")
         self._attach_file(encoding, "media_file", "encoded.mp4", b"encoded")
 
-        hls_path = os.path.join(self.hls_dir, self.media.uid.hex, "master.m3u8")
-        os.makedirs(os.path.dirname(hls_path), exist_ok=True)
-        with open(hls_path, "wb") as master_file:
+        old_hls_path = os.path.join(self.hls_dir, self.media.uid.hex, "master.m3u8")
+        os.makedirs(os.path.dirname(old_hls_path), exist_ok=True)
+        with open(old_hls_path, "wb") as master_file:
             master_file.write(b"old")
-        Media.objects.filter(pk=self.media.pk).update(hls_file=hls_path)
+        Media.objects.filter(pk=self.media.pk).update(hls_file=old_hls_path)
 
         def fake_run(command, capture_output):
             output_dir = next(
@@ -184,10 +184,12 @@ class StorageUsageTests(TestCase):
         with (
             override_settings(MP4HLS_COMMAND=fake_mp4hls),
             patch("files.tasks.subprocess.run", side_effect=fake_run),
-            patch("files.tasks.schedule_refresh_media_storage_usage") as schedule_refresh,
+            patch("files.storage_usage.schedule_refresh_media_storage_usage") as schedule_refresh,
         ):
             self.assertTrue(tasks.create_hls(self.media.friendly_token))
 
         self.media.refresh_from_db()
-        self.assertEqual(self.media.hls_file, hls_path)
+        self.assertNotEqual(self.media.hls_file, old_hls_path)
+        self.assertTrue(os.path.exists(self.media.hls_file))
+        self.assertFalse(os.path.exists(old_hls_path))
         schedule_refresh.assert_called_once_with(self.media.id)

--- a/files/tests/test_storage_usage.py
+++ b/files/tests/test_storage_usage.py
@@ -169,7 +169,7 @@ class StorageUsageTests(TestCase):
             master_file.write(b"old")
         Media.objects.filter(pk=self.media.pk).update(hls_file=old_hls_path)
 
-        def fake_run(command, capture_output):
+        def fake_run(command, capture_output, timeout=None):
             output_dir = next(
                 (part.removeprefix("--output-dir=") for part in command if part.startswith("--output-dir=")),
                 None,

--- a/files/views.py
+++ b/files/views.py
@@ -978,6 +978,57 @@ def embed_old_media(request, user, video):
 #########################
 
 
+def cleanup_hls_directory_for_media(media):
+    """Remove all on-disk HLS output for `media`, versioned and legacy alike.
+
+    Targets HLS_DIR/<uid> directly rather than deriving the directory from
+    hls_file's parent: create_hls nests output one level deeper as
+    HLS_DIR/<uid>/<version>/, and hls_file's parent under that layout is
+    HLS_DIR/<uid>/<version> (not a direct child of HLS_DIR), which used to
+    make an older direct-child check silently skip cleanup. Targeting the
+    uid directory itself removes both the versioned tree and any legacy
+    flat-layout output in one pass, and works even if hls_file is empty.
+    """
+    hls_dir_setting = getattr(settings, "HLS_DIR", None)
+    if not hls_dir_setting:
+        logger.warning(f"HLS_DIR setting not configured, skipping HLS cleanup for media {media.friendly_token}")
+        return
+
+    try:
+        hls_base_dir = Path(hls_dir_setting).resolve()
+        hls_uid_dir = (hls_base_dir / media.uid.hex).resolve()
+
+        # Security checks:
+        # 1. Ensure the uid directory is within HLS_DIR
+        # 2. Ensure it's a direct child of HLS_DIR (not deeply nested)
+        # 3. Prevent directory traversal outside HLS_DIR
+        try:
+            is_within_hls_dir = hls_uid_dir.is_relative_to(hls_base_dir)
+        except AttributeError:
+            # Fallback for Python < 3.9
+            try:
+                is_within_hls_dir = hls_base_dir in hls_uid_dir.parents or hls_base_dir == hls_uid_dir
+            except ValueError:
+                is_within_hls_dir = False
+
+        is_direct_child = hls_uid_dir.parent == hls_base_dir
+
+        if is_within_hls_dir and is_direct_child:
+            if hls_uid_dir.exists():
+                shutil.rmtree(hls_uid_dir)
+        else:
+            logger.warning(
+                f"Attempted directory traversal or invalid HLS path: {hls_uid_dir} "
+                f"(expected direct child of {hls_base_dir}) "
+                f"for media {media.friendly_token}"
+            )
+    except Exception as e:
+        logger.error(
+            f"Failed to remove HLS directory for media {media.friendly_token} (hls_file={media.hls_file}): {e}",
+            exc_info=True,
+        )
+
+
 @login_required
 def edit_media(request):
     friendly_token = request.GET.get("m", "").strip()
@@ -1116,54 +1167,8 @@ def edit_media(request):
                             )
                     old_encodings.delete()
 
-                    # Delete old HLS files if they exist (with directory traversal protection)
-                    if media.hls_file:
-                        # Guard against missing HLS_DIR setting
-                        hls_dir_setting = getattr(settings, "HLS_DIR", None)
-                        if hls_dir_setting:
-                            try:
-                                # Build the full path relative to MEDIA_ROOT
-                                media_root = Path(settings.MEDIA_ROOT).resolve()
-                                hls_base_dir = Path(hls_dir_setting).resolve()
-                                hls_dir = (media_root / media.hls_file).parent.resolve()
-
-                                # Security checks:
-                                # 1. Ensure HLS_DIR is within MEDIA_ROOT
-                                # 2. Ensure hls_dir is a direct child of HLS_DIR (not deeply nested)
-                                # 3. Prevent directory traversal outside HLS_DIR
-                                try:
-                                    # Check if hls_dir is relative to hls_base_dir (Python 3.9+)
-                                    is_within_hls_dir = hls_dir.is_relative_to(hls_base_dir)
-                                except AttributeError:
-                                    # Fallback for Python < 3.9
-                                    try:
-                                        is_within_hls_dir = hls_base_dir in hls_dir.parents or hls_base_dir == hls_dir
-                                    except ValueError:
-                                        is_within_hls_dir = False
-
-                                # Additional check: ensure it's a direct subdirectory of HLS_DIR
-                                # (i.e., HLS_DIR/{uid}/, not HLS_DIR/../../etc/)
-                                is_direct_child = hls_dir.parent == hls_base_dir
-
-                                if is_within_hls_dir and is_direct_child:
-                                    if hls_dir.exists():
-                                        shutil.rmtree(hls_dir)
-                                else:
-                                    logger.warning(
-                                        f"Attempted directory traversal or invalid HLS path: {hls_dir} "
-                                        f"(expected direct child of {hls_base_dir}) "
-                                        f"for media {media.friendly_token}"
-                                    )
-                            except Exception as e:
-                                logger.error(
-                                    f"Failed to remove HLS directory for media {media.friendly_token} "
-                                    f"(hls_file={media.hls_file}): {e}",
-                                    exc_info=True,
-                                )
-                        else:
-                            logger.warning(
-                                f"HLS_DIR setting not configured, skipping HLS cleanup for media {media.friendly_token}"
-                            )
+                    # Delete old HLS files if they exist (with directory traversal protection).
+                    cleanup_hls_directory_for_media(media)
 
                     # Delete preview_file_path if it exists (with directory traversal protection)
                     if media.preview_file_path:

--- a/files/views.py
+++ b/files/views.py
@@ -988,6 +988,13 @@ def cleanup_hls_directory_for_media(media):
     make an older direct-child check silently skip cleanup. Targeting the
     uid directory itself removes both the versioned tree and any legacy
     flat-layout output in one pass, and works even if hls_file is empty.
+
+    Failure policy: best-effort, non-blocking, matching the sibling cleanup
+    blocks (original file, encodings, preview file) in the calling
+    media-replace flow. A failed rmtree is logged, not raised, so it never
+    aborts the replace; the next create_hls run writes a new versioned
+    subdirectory regardless, so any leftover directory is orphaned disk
+    usage rather than a correctness or cache-busting problem.
     """
     hls_dir_setting = getattr(settings, "HLS_DIR", None)
     if not hls_dir_setting:


### PR DESCRIPTION
## Description
HLS segment URLs stayed stable across `create_hls` regenerations, so caches (client, proxy, CDN) could keep serving stale segment bytes from a previous encoding run under the same URL. This was most visible when toggling encryption on a video: the manifest changed but old plaintext segments could still be served under the same path, producing `MEDIA_ERR_DECODE`.

Each `create_hls` run now writes into a version-scoped subdirectory `HLS_DIR/<uid>/<version>/` (version identifier from `produce_friendly_token()`) instead of the stable `HLS_DIR/<uid>/`, so every regeneration gets a fresh set of URLs.

Also hardens `create_hls` against concurrent/overlapping runs, `mp4hls` timeouts and non-zero exits, and stale-lock discard, and cleans up the whole `HLS_DIR/<uid>` tree (versioned and legacy flat layout) on media replace.

## Related Issue
Fixes #791

## Motivation and Context
Stale HLS segment caches caused clients to play back inconsistent audio/video (mismatched segments from different encoding runs), and broke encryption toggles with `MEDIA_ERR_DECODE`.

## How Has This Been Tested?
- Added/updated Django tests covering: versioned directory creation, legacy flat-layout compatibility, HLS cleanup on media replace (versioned and legacy layouts, traversal protection, other-media isolation), `SecureMediaView` path resolution and access control under the new nested layout (public/private/restricted, token access, `Cache-Control: no-store`), and `create_hls` race hardening (concurrent lock contention with pending-retry, `mp4hls` timeout/non-zero-exit discarding partial output, stale-lock discard).
- Ran the full `files` app test suite (`uv run python manage.py test files`) — all tests pass.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):
- [ ] I have not imported `flux` in a new component
- [ ] If adding a new feature, I used Modern Track patterns
- [ ] New features do not create new SCSS files (use Tailwind instead)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HLS regeneration now outputs manifests/segments into versioned directories for improved cache-busting and stream freshness.
  * Secure media now supports nested access for versioned HLS manifest paths.

* **Bug Fixes**
  * Prevents overlapping regeneration for the same media using per-media locking, with bounded retries on timeouts and safer handling of incomplete/failed output.
  * Media replacement cleanup now safely removes legacy and versioned HLS folders for the target media without affecting other media.

* **Tests**
  * Added and expanded coverage for versioned layout handling, secure nested access, regeneration failure modes, locking/pending behavior, and cleanup edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->