### PR TITLE
fix(migrations): resolve conflicting 0031 leaf nodes in files app

### DIFF
--- a/files/migrations/0032_privatejournalnote.py
+++ b/files/migrations/0032_privatejournalnote.py
@@ -7,7 +7,7 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("files", "0030_media_metadata_saved_at"),
+        ("files", "0031_playlist_curator_note"),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]
 


### PR DESCRIPTION
## Description
Two migrations in the `files` app share the number `0031` and both declare `0030_media_metadata_saved_at` as their dependency:

- `0031_playlist_curator_note.py` (adds `Playlist.curator_note`)
- `0031_privatejournalnote.py` (creates the `PrivateJournalNote` model)

This produces two leaf nodes in the migration graph. Django refuses to run migrations against a branched, unmerged history (`Conflicting migrations detected; multiple leaf nodes`).

This PR linearizes the history by renumbering the private journal migration to `0032` and pointing its dependency at `0031_playlist_curator_note`:

```
0030_media_metadata_saved_at
  -> 0031_playlist_curator_note
    -> 0032_privatejournalnote
```

## Related Issue
N/A (migration sequence conflict introduced by two merged branches on `main`).

## Motivation and Context
With two `0031` leaf nodes, `manage.py migrate` fails and a fresh database cannot be built. The two migrations are independent (a field added to `Playlist` versus a new model), so ordering them one after the other is safe and introduces no schema difference.

## How Has This Been Tested?
- `manage.py makemigrations --check --dry-run files` reports no conflict and no missing migrations.
- `manage.py migrate files` applies the full chain cleanly, ending with `0031_playlist_curator_note` then `0032_privatejournalnote`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
