### PR TITLE
Add Django observability instrumentation

### DIFF
--- a/cms/settings.py
+++ b/cms/settings.py
@@ -59,6 +59,7 @@ INSTALLED_APPS = [
     "django_vite",
     "django.contrib.staticfiles",
     "django.contrib.sites",
+    "django_prometheus",
     "rest_framework",
     "rest_framework.authtoken",
     "imagekit",
@@ -79,6 +80,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "django_prometheus.middleware.PrometheusBeforeMiddleware",
     "corsheaders.middleware.CorsMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
@@ -92,6 +94,7 @@ MIDDLEWARE = [
     "cms.middleware.MaintenanceTimingMiddleware",  # Track maintenance mode timing
     "maintenance_mode.middleware.MaintenanceModeMiddleware",
     "waffle.middleware.WaffleMiddleware",
+    "django_prometheus.middleware.PrometheusAfterMiddleware",
 ]
 
 ROOT_URLCONF = "cms.urls"
@@ -155,21 +158,57 @@ LOGS_DIR = os.path.join(BASE_DIR, "logs")
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
+    "formatters": {
+        "json": {
+            "()": "pythonjsonlogger.json.JsonFormatter",
+            "format": "%(asctime)s %(name)s %(levelname)s %(message)s",
+            "rename_fields": {
+                "asctime": "timestamp",
+                "levelname": "level",
+            },
+            "static_fields": {
+                "service": "cinematacms",
+            },
+        },
+        "plain": {
+            "format": "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        },
+    },
     "handlers": {
-        "file": {
-            "level": "ERROR",
+        "json_file": {
+            "level": "INFO",
+            "class": "logging.FileHandler",
+            "filename": os.path.join(LOGS_DIR, "app.json.log"),
+            "formatter": "json",
+        },
+        "legacy_file": {
+            "level": "INFO",
             "class": "logging.FileHandler",
             "filename": os.path.join(LOGS_DIR, "debug.log"),
+            "formatter": "plain",
         },
     },
     "loggers": {
+        "files": {"handlers": ["json_file", "legacy_file"], "level": "INFO"},
+        "users": {"handlers": ["json_file", "legacy_file"], "level": "INFO"},
+        "uploader": {"handlers": ["json_file", "legacy_file"], "level": "INFO"},
+        "actions": {"handlers": ["json_file", "legacy_file"], "level": "INFO"},
+        "celery": {"handlers": ["json_file"], "level": "WARNING"},
         "django": {
-            "handlers": ["file"],
-            "level": "ERROR",
+            "handlers": ["json_file", "legacy_file"],
+            "level": "INFO",
             "propagate": True,
         },
     },
+    "root": {
+        "handlers": ["json_file"],
+        "level": "INFO",
+    },
 }
+
+CELERY_WORKER_HIJACK_ROOT_LOGGER = False
+CELERY_WORKER_LOG_FORMAT = "%(message)s"
+CELERY_WORKER_TASK_LOG_FORMAT = "%(message)s"
 
 DATABASES = {
     "default": {
@@ -264,6 +303,8 @@ CELERY_RESULT_SERIALIZER = "json"
 CELERY_TIMEZONE = TIME_ZONE
 CELERY_SOFT_TIME_LIMIT = 2 * 60 * 60
 CELERY_WORKER_PREFETCH_MULTIPLIER = 1
+CELERY_WORKER_SEND_TASK_EVENTS = True
+CELERY_TASK_SEND_SENT_EVENT = True
 
 CELERY_BEAT_SCHEDULE = {
     #    'check_running_states': {

--- a/cms/wsgi.py
+++ b/cms/wsgi.py
@@ -4,4 +4,12 @@ from django.core.wsgi import get_wsgi_application
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "cms.settings")
 
+try:
+    import uwsgi
+    from prometheus_client.values import MultiProcessValue
+
+    MultiProcessValue(process_identifier=lambda: uwsgi.worker_id())
+except (ImportError, ModuleNotFoundError):
+    pass
+
 application = get_wsgi_application()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,9 +39,11 @@ dependencies = [
     "qrcode==8.2",
     "django-tinymce==5.0.0",
     "django-maintenance-mode==0.22.0",
+    "django-prometheus>=2.4.1",
     "django-vite>=3.1.0",
     "django-waffle>=4.2.0,<5.0",
     "prometheus-client>=0.25.0",
+    "python-json-logger>=3.0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -342,6 +342,7 @@ dependencies = [
     { name = "django-imagekit" },
     { name = "django-maintenance-mode" },
     { name = "django-mptt" },
+    { name = "django-prometheus" },
     { name = "django-recaptcha" },
     { name = "django-redis" },
     { name = "django-silk" },
@@ -360,6 +361,7 @@ dependencies = [
     { name = "prometheus-client" },
     { name = "psycopg2-binary" },
     { name = "python-dotenv" },
+    { name = "python-json-logger" },
     { name = "qrcode" },
     { name = "requests" },
     { name = "rpdb" },
@@ -395,6 +397,7 @@ requires-dist = [
     { name = "django-imagekit", specifier = "==6.1.0" },
     { name = "django-maintenance-mode", specifier = "==0.22.0" },
     { name = "django-mptt", specifier = "==0.18.0" },
+    { name = "django-prometheus", specifier = ">=2.4.1" },
     { name = "django-recaptcha", specifier = "==4.1.0" },
     { name = "django-redis", specifier = "==6.0.0" },
     { name = "django-silk", specifier = "==5.5.0" },
@@ -413,6 +416,7 @@ requires-dist = [
     { name = "prometheus-client", specifier = ">=0.25.0" },
     { name = "psycopg2-binary", specifier = "==2.9.12" },
     { name = "python-dotenv", specifier = "==1.2.2" },
+    { name = "python-json-logger", specifier = ">=3.0" },
     { name = "qrcode", specifier = "==8.2" },
     { name = "requests", specifier = "==2.33.1" },
     { name = "rpdb", specifier = "==0.2.0" },
@@ -735,6 +739,19 @@ wheels = [
 ]
 
 [[package]]
+name = "django-prometheus"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+    { name = "prometheus-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/c7/dc39c4c19f7b35e827a486d08376de1fad31c50decb26c56e32668314f13/django_prometheus-2.5.0.tar.gz", hash = "sha256:4837b3c3734d8350880839ab8235aafd250b668c348e159d4aecc3cbefeee53e", size = 26465, upload-time = "2026-05-26T19:04:00.77Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/5d/6ec3083ba69545696c962ae505a0e52e280e7592d4c278c2f3803cabb688/django_prometheus-2.5.0-py2.py3-none-any.whl", hash = "sha256:f15efb526cd53f9cf12da72dc55506322f5566b017a819ff27be1da302303134", size = 31801, upload-time = "2026-05-26T19:03:59.505Z" },
+]
+
+[[package]]
 name = "django-recaptcha"
 version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -822,7 +839,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1539,6 +1556,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f8/78/74ccf5a2de318703f5456d1809990408f4dc00e1e4cf96a97f7d936f834c/python_fsutil-0.16.1.tar.gz", hash = "sha256:4cc78b9a1e64011cb4fdaeba531e457e649a6a9a560424e841426e47f3a153ad", size = 30364, upload-time = "2026-04-07T17:36:18.481Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e2/f6/d382531651b720ceefb99013efb8dd01325de703e0ae5128e7cc92d556bc/python_fsutil-0.16.1-py3-none-any.whl", hash = "sha256:bda20802a19f6dc1bd221f6d2a79e0cd2b2c6eaf2b7c353a385c749917047442", size = 20989, upload-time = "2026-04-07T17:36:17.287Z" },
+]
+
+[[package]]
+name = "python-json-logger"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/ff/3cc9165fd44106973cd7ac9facb674a65ed853494592541d339bdc9a30eb/python_json_logger-4.1.0.tar.gz", hash = "sha256:b396b9e3ed782b09ff9d6e4f1683d46c83ad0d35d2e407c09a9ebbf038f88195", size = 17573, upload-time = "2026-03-29T04:39:56.805Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/be/0631a861af4d1c875f096c07d34e9a63639560a717130e7a87cbc82b7e3f/python_json_logger-4.1.0-py3-none-any.whl", hash = "sha256:132994765cf75bf44554be9aa49b06ef2345d23661a96720262716438141b6b2", size = 15021, upload-time = "2026-03-29T04:39:55.266Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description
Adds reusable Django-side observability instrumentation for CinemataCMS:

- registers django-prometheus and wraps request middleware so request counters and latency histograms are emitted
- configures prometheus-client multiprocess worker IDs for uWSGI
- switches Django/Celery logging to structured JSON while keeping the legacy debug.log during transition
- enables Celery task events needed by celery-exporter metrics

## Related Issue
Supports deployment-specific observability rollouts.

## Motivation and Context
The monitoring stack installer belongs in deployment-specific repos, but reusable application metrics and structured logging should live in the public CinemataCMS codebase so downstream deployments do not carry fork-only observability drift.

## How Has This Been Tested?
- uv run python -m py_compile cms/settings.py cms/wsgi.py cms/urls.py
- uv run python -c "from pythonjsonlogger.json import JsonFormatter; import django_prometheus; print('ok')"
- uv run python manage.py check
- uv run pre-commit run --all-files

Note: local manage.py check emits the existing missing Whisper model warning on this machine.

## Types of changes
- [ ] Bug fix (non-breaking change fixes an issue)
- [x] New feature (non-breaking change adds functionality)
- [ ] Breaking change (fix or feature would cause existing functionality change)
- [ ] Documentation update

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I updated documentation accordingly.
- [ ] I added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features)
- [x] I have not imported flux in a new component
- [x] New features do not create new SCSS files