### PR TITLE
Add Django observability instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 ![Homepage](images/1_1sBakvc.png)
 
 [Cinemata](https://cinemata.org) is an open-source video CMS for social issue filmmakers, human rights advocates, and civil society organisations across the Asia-Pacific region. It originated from [MediaCMS](https://github.com/mediacms-io/mediacms) but has since diverged into an independent codebase, now architecturally distinct, particularly on the frontend. Since its public release in 2021, Cinemata.org has grown to more than 7,300 films from 30+ countries.
- 
+
 The project is managed by [EngageMedia](https://engagemedia.org), an Asia-Pacific non-profit advocating for digital rights, open technology, and social issue films. The goal is to make Cinemata's work available to the public, so that more organisations can build and maintain their own community video platforms, free from surveillance capitalism, algorithmic manipulation, and corporate content takedowns.
- 
+
 In June 2026, the UN Special Rapporteur on freedom of opinion and expression, Irene Khan, named Cinemata in her final report to the Human Rights Council ([A/HRC/62/67](https://documents.un.org/), para. 96) as one of the infrastructural alternatives working to "de-oligarchize" information spaces, alongside the federated platform Mastodon and the data-standards project MyData Global. The report describes Cinemata as a non-profit platform for Asia-Pacific civic media, promoting regional solidarity across Indonesia, Malaysia, and the Philippines.
 
 ---
@@ -26,11 +26,11 @@ This makes CinemataCMS one of the few open-source video platforms with documente
 ## 🎨 UX Redesign in Partnership with Kumquat (Supported by OTF)
 
 CinemataCMS underwent a full UX research and redesign engagement with [Kumquat](https://kumquat.cc), a Cape Town-based design consultancy, supported by the [Open Technology Fund's UX & Discovery Lab](https://opentech.fund/labs/ux-lab/).
- 
+
 This was not a cosmetic refresh. The engagement was grounded in research with the communities Cinemata serves: activist filmmakers, curators, human rights documentarians, and civil society partners across Southeast Asia, many of whom operate under surveillance or in contexts where platform design choices have real safety implications.
- 
+
 **What the engagement covered:**
- 
+
 - **UX research**, with targeted interviews across filmmakers, curators, and partners; synthesis of existing survey data; audience archetypes and priority user journey mapping
 - **Privacy-first design system**, a base component library built with accessibility, neurodiversity-friendly layouts, and clear privacy affordances (opt-in participation, anonymity states, data minimisation cues)
 - **Full redesign of priority pages**, covering the homepage, film detail page, and editorial and discovery surfaces, with responsive desktop and mobile layouts
@@ -43,7 +43,7 @@ The redesigned interface launched at the first Cinemata Community Convening in M
 ## Key Features
 
 Cinemata-specific features built on top of the platform's MediaCMS origins:
- 
+
 - **OTF-audited security**: MFA, X-Accel-Redirect media protection, session hardening
 - **AES-128 HLS encryption**: encrypted stream segments, Cloudflare-cacheable with Django-gated key delivery
 - **AI transcription**: [Whisper.cpp](https://github.com/ggml-org/whisper.cpp) integration for English translation and subtitle generation
@@ -108,7 +108,7 @@ We're building a vibrant developer community. **Paid opportunities** are availab
 ## Potential Use Cases
 
 CinemataCMS is built for organisations that need to manage, showcase, and distribute video content with a focus on social impact, particularly where privacy, security, and sovereignty over content matter:
- 
+
 - **Human rights documentation**: NGOs and advocacy groups documenting sensitive situations, where secure hosting and access controls are essential
 - **Activist archiving**: community media groups preserving footage under threat of government censorship or platform removal
 - **Film festivals**: virtual and physical festivals hosting submissions and curated collections, including privacy-sensitive or politically sensitive work
@@ -131,9 +131,9 @@ The emphasis on privacy, security, and community engagement makes CinemataCMS pa
 
 ## Installation
 The instructions below have been tested on Ubuntu 22.04. Make sure no other services are running on the system (specifically no Nginx or PostgreSQL), as the installation script will install and configure them.
- 
+
 **Production install (as root):**
- 
+
 ```
 cd /home
 mkdir cinemata && cd cinemata
@@ -155,7 +155,7 @@ The installer runs database migrations and seeds django-waffle feature flag swit
 ## Roadmap
 
 ### ✅ Milestone 1: January – July 2025 (Completed)
- 
+
 - OTF security audit response and implementation
 - Full open-source release as CinemataCMS 2.0
 - Multi-Factor Authentication for admin accounts
@@ -164,21 +164,21 @@ The installer runs database migrations and seeds django-waffle feature flag swit
 - Comprehensive developer documentation and setup guides (Ubuntu, macOS, Windows, Docker)
 - Virtual developer showcase and learning session
 ### ✅ Milestone 2: February – June 2026 (Completed)
- 
+
 Shipped over five months and launched at the first Cinemata Community Convening in Manila, June 2026.
- 
+
 **Platform and frontend**
- 
+
 - Frontend modernisation: React 17 to 19, Webpack to Vite, dual-track architecture
 - AES-128 HLS encrypted streaming
 - Transcode and Celery concurrency optimisation
 **Notifications and community engagement**
- 
+
 - Notification system: bell icon UI, in-app notifications, email triggers
 - Renewed comment system with threading
 - Contributor role badges on media pages and comments
 **Filmmaker and curator tools**
- 
+
 - Scheduled visibility control (festival-window privacy)
 - Bulk upload for institutional partners
 - Community Impact recording (screenings, academic use, curation, playlist inclusion)
@@ -186,25 +186,25 @@ Shipped over five months and launched at the first Cinemata Community Convening 
 - Upload progress and encoding status
 - Profile and media management redesign
 **Search and interface**
- 
+
 - Search and discovery overhaul: multi-dimensional filters and a mobile-optimised search sheet
 - Full homepage and film detail page redesign (Kumquat, via OTF UX & Discovery Lab)
 - Privacy-first design system, responsive desktop and mobile layouts
 Some Milestone 2 work has complete backends but no frontend yet, and carries into Milestone 3: @mention wiring, the follow and subscribe UI, and notification preference toggles.
- 
+
 ### 📋 Milestone 3: July 2026 – June 2027 (In planning)
- 
+
 Milestone 3 is being planned in public with the Technology Working Group formed at the Manila Convening, following the [Cinemata Community Governance Document](https://cinemata.org). Funded capacity this cycle is modest, so the plan is organised into two tracks.
- 
+
 **Core Track** is committed work that ships regardless of further funding. The focus is stewardship: keeping the platform stable, fast, and observable for the 7,300+ films that depend on it.
- 
+
 - **Fix-first security and stability**: closing a set of fail-open gaps found during planning, where a protection appears active but is not, and nothing alerts. This includes an encryption bypass, an IP-masking bypass on one media path, a mention notification that leaks a restricted film's title, and a filmmaker-initiated takedown for Community Impact entries.
 - **Monitoring and visibility**: error tracking and alerting, so the team sees failures before filmmakers do.
 - **Performance and delivery**: adaptive bitrate streaming and homepage load improvements, aimed at the platform's Asia-Pacific audience.
 - **Finishing Milestone 2**: wiring the @mention frontend, the follow and subscribe UI, notification preference toggles, and Community Impact notifications.
 
 **Horizon Track** is designed and estimated now so that if further funding lands, development starts within weeks. Nothing on this track is promised.
- 
+
 - Social share cards for films
 - A collaborator and collaborative-playlist system, plus private and unlisted playlists
 - A swipeable discovery feed, framed around discovery rather than retention
@@ -212,7 +212,7 @@ Milestone 3 is being planned in public with the Technology Working Group formed 
 - Deployability for other organisations: a production Docker Compose setup and a documentation site
 - Progressive Web App capability as a near-term step ahead of any native mobile app
 The final Milestone 3 plan will be published on the Cinemata blog and tracked on a public GitHub Projects board.
- 
+
 ---
 
 ## History

--- a/cms/settings.py
+++ b/cms/settings.py
@@ -59,6 +59,7 @@ INSTALLED_APPS = [
     "django_vite",
     "django.contrib.staticfiles",
     "django.contrib.sites",
+    "django_prometheus",
     "rest_framework",
     "rest_framework.authtoken",
     "imagekit",
@@ -79,6 +80,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "django_prometheus.middleware.PrometheusBeforeMiddleware",
     "corsheaders.middleware.CorsMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
@@ -92,6 +94,7 @@ MIDDLEWARE = [
     "cms.middleware.MaintenanceTimingMiddleware",  # Track maintenance mode timing
     "maintenance_mode.middleware.MaintenanceModeMiddleware",
     "waffle.middleware.WaffleMiddleware",
+    "django_prometheus.middleware.PrometheusAfterMiddleware",
 ]
 
 ROOT_URLCONF = "cms.urls"
@@ -155,21 +158,57 @@ LOGS_DIR = os.path.join(BASE_DIR, "logs")
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
+    "formatters": {
+        "json": {
+            "()": "pythonjsonlogger.json.JsonFormatter",
+            "format": "%(asctime)s %(name)s %(levelname)s %(message)s",
+            "rename_fields": {
+                "asctime": "timestamp",
+                "levelname": "level",
+            },
+            "static_fields": {
+                "service": "cinematacms",
+            },
+        },
+        "plain": {
+            "format": "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        },
+    },
     "handlers": {
-        "file": {
-            "level": "ERROR",
+        "json_file": {
+            "level": "INFO",
+            "class": "logging.FileHandler",
+            "filename": os.path.join(LOGS_DIR, "app.json.log"),
+            "formatter": "json",
+        },
+        "legacy_file": {
+            "level": "INFO",
             "class": "logging.FileHandler",
             "filename": os.path.join(LOGS_DIR, "debug.log"),
+            "formatter": "plain",
         },
     },
     "loggers": {
+        "files": {"handlers": ["json_file", "legacy_file"], "level": "INFO"},
+        "users": {"handlers": ["json_file", "legacy_file"], "level": "INFO"},
+        "uploader": {"handlers": ["json_file", "legacy_file"], "level": "INFO"},
+        "actions": {"handlers": ["json_file", "legacy_file"], "level": "INFO"},
+        "celery": {"handlers": ["json_file"], "level": "WARNING"},
         "django": {
-            "handlers": ["file"],
-            "level": "ERROR",
+            "handlers": ["json_file", "legacy_file"],
+            "level": "INFO",
             "propagate": True,
         },
     },
+    "root": {
+        "handlers": ["json_file"],
+        "level": "INFO",
+    },
 }
+
+CELERY_WORKER_HIJACK_ROOT_LOGGER = False
+CELERY_WORKER_LOG_FORMAT = "%(message)s"
+CELERY_WORKER_TASK_LOG_FORMAT = "%(message)s"
 
 DATABASES = {
     "default": {
@@ -264,6 +303,8 @@ CELERY_RESULT_SERIALIZER = "json"
 CELERY_TIMEZONE = TIME_ZONE
 CELERY_SOFT_TIME_LIMIT = 2 * 60 * 60
 CELERY_WORKER_PREFETCH_MULTIPLIER = 1
+CELERY_WORKER_SEND_TASK_EVENTS = True
+CELERY_TASK_SEND_SENT_EVENT = True
 
 CELERY_BEAT_SCHEDULE = {
     #    'check_running_states': {

--- a/cms/settings.py
+++ b/cms/settings.py
@@ -188,14 +188,17 @@ LOGGING = {
             "formatter": "plain",
         },
     },
+    # Every logger below propagates to the root logger, which owns the sole
+    # json_file handler. Naming json_file here as well would write each record
+    # to app.json.log twice.
     "loggers": {
-        "files": {"handlers": ["json_file", "legacy_file"], "level": "INFO"},
-        "users": {"handlers": ["json_file", "legacy_file"], "level": "INFO"},
-        "uploader": {"handlers": ["json_file", "legacy_file"], "level": "INFO"},
-        "actions": {"handlers": ["json_file", "legacy_file"], "level": "INFO"},
-        "celery": {"handlers": ["json_file"], "level": "WARNING"},
+        "files": {"handlers": ["legacy_file"], "level": "INFO"},
+        "users": {"handlers": ["legacy_file"], "level": "INFO"},
+        "uploader": {"handlers": ["legacy_file"], "level": "INFO"},
+        "actions": {"handlers": ["legacy_file"], "level": "INFO"},
+        "celery": {"handlers": [], "level": "WARNING"},
         "django": {
-            "handlers": ["json_file", "legacy_file"],
+            "handlers": ["legacy_file"],
             "level": "INFO",
             "propagate": True,
         },

--- a/cms/wsgi.py
+++ b/cms/wsgi.py
@@ -4,4 +4,12 @@ from django.core.wsgi import get_wsgi_application
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "cms.settings")
 
+try:
+    import uwsgi
+    from prometheus_client.values import MultiProcessValue
+
+    MultiProcessValue(process_identifier=lambda: uwsgi.worker_id())
+except (ImportError, ModuleNotFoundError):
+    pass
+
 application = get_wsgi_application()

--- a/cms/wsgi.py
+++ b/cms/wsgi.py
@@ -4,12 +4,16 @@ from django.core.wsgi import get_wsgi_application
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "cms.settings")
 
+# Under uWSGI, key each worker's multiprocess metric files by uWSGI worker id
+# instead of the default pid. A respawned worker then reuses its predecessor's
+# files rather than leaving orphans behind in PROMETHEUS_MULTIPROC_DIR.
+# Must run before the first metric is constructed, hence before the WSGI app.
 try:
     import uwsgi
-    from prometheus_client.values import MultiProcessValue
+    from prometheus_client import values
 
-    MultiProcessValue(process_identifier=lambda: uwsgi.worker_id())
-except (ImportError, ModuleNotFoundError):
+    values.ValueClass = values.MultiProcessValue(process_identifier=uwsgi.worker_id)
+except ImportError:
     pass
 
 application = get_wsgi_application()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,9 +39,11 @@ dependencies = [
     "qrcode==8.2",
     "django-tinymce==5.0.0",
     "django-maintenance-mode==0.22.0",
+    "django-prometheus>=2.4.1",
     "django-vite>=3.1.0",
     "django-waffle>=4.2.0,<5.0",
     "prometheus-client>=0.25.0",
+    "python-json-logger>=3.0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -342,6 +342,7 @@ dependencies = [
     { name = "django-imagekit" },
     { name = "django-maintenance-mode" },
     { name = "django-mptt" },
+    { name = "django-prometheus" },
     { name = "django-recaptcha" },
     { name = "django-redis" },
     { name = "django-silk" },
@@ -360,6 +361,7 @@ dependencies = [
     { name = "prometheus-client" },
     { name = "psycopg2-binary" },
     { name = "python-dotenv" },
+    { name = "python-json-logger" },
     { name = "qrcode" },
     { name = "requests" },
     { name = "rpdb" },
@@ -395,6 +397,7 @@ requires-dist = [
     { name = "django-imagekit", specifier = "==6.1.0" },
     { name = "django-maintenance-mode", specifier = "==0.22.0" },
     { name = "django-mptt", specifier = "==0.18.0" },
+    { name = "django-prometheus", specifier = ">=2.4.1" },
     { name = "django-recaptcha", specifier = "==4.1.0" },
     { name = "django-redis", specifier = "==6.0.0" },
     { name = "django-silk", specifier = "==5.5.0" },
@@ -413,6 +416,7 @@ requires-dist = [
     { name = "prometheus-client", specifier = ">=0.25.0" },
     { name = "psycopg2-binary", specifier = "==2.9.12" },
     { name = "python-dotenv", specifier = "==1.2.2" },
+    { name = "python-json-logger", specifier = ">=3.0" },
     { name = "qrcode", specifier = "==8.2" },
     { name = "requests", specifier = "==2.33.1" },
     { name = "rpdb", specifier = "==0.2.0" },
@@ -735,6 +739,19 @@ wheels = [
 ]
 
 [[package]]
+name = "django-prometheus"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+    { name = "prometheus-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/c7/dc39c4c19f7b35e827a486d08376de1fad31c50decb26c56e32668314f13/django_prometheus-2.5.0.tar.gz", hash = "sha256:4837b3c3734d8350880839ab8235aafd250b668c348e159d4aecc3cbefeee53e", size = 26465, upload-time = "2026-05-26T19:04:00.77Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/5d/6ec3083ba69545696c962ae505a0e52e280e7592d4c278c2f3803cabb688/django_prometheus-2.5.0-py2.py3-none-any.whl", hash = "sha256:f15efb526cd53f9cf12da72dc55506322f5566b017a819ff27be1da302303134", size = 31801, upload-time = "2026-05-26T19:03:59.505Z" },
+]
+
+[[package]]
 name = "django-recaptcha"
 version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -822,7 +839,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1539,6 +1556,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f8/78/74ccf5a2de318703f5456d1809990408f4dc00e1e4cf96a97f7d936f834c/python_fsutil-0.16.1.tar.gz", hash = "sha256:4cc78b9a1e64011cb4fdaeba531e457e649a6a9a560424e841426e47f3a153ad", size = 30364, upload-time = "2026-04-07T17:36:18.481Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e2/f6/d382531651b720ceefb99013efb8dd01325de703e0ae5128e7cc92d556bc/python_fsutil-0.16.1-py3-none-any.whl", hash = "sha256:bda20802a19f6dc1bd221f6d2a79e0cd2b2c6eaf2b7c353a385c749917047442", size = 20989, upload-time = "2026-04-07T17:36:17.287Z" },
+]
+
+[[package]]
+name = "python-json-logger"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/ff/3cc9165fd44106973cd7ac9facb674a65ed853494592541d339bdc9a30eb/python_json_logger-4.1.0.tar.gz", hash = "sha256:b396b9e3ed782b09ff9d6e4f1683d46c83ad0d35d2e407c09a9ebbf038f88195", size = 17573, upload-time = "2026-03-29T04:39:56.805Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/be/0631a861af4d1c875f096c07d34e9a63639560a717130e7a87cbc82b7e3f/python_json_logger-4.1.0-py3-none-any.whl", hash = "sha256:132994765cf75bf44554be9aa49b06ef2345d23661a96720262716438141b6b2", size = 15021, upload-time = "2026-03-29T04:39:55.266Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Application-side observability for CinemataCMS. Deployment-side pieces (Fluent Bit, scrape config, nginx) stay in the deployment repo.

- registers `django_prometheus` plus its before/after middleware, so request counters and latency histograms are emitted
- `cms/wsgi.py` keys prometheus multiprocess metric files by uWSGI worker id instead of pid, so a respawned worker reuses its predecessor's files rather than orphaning them in `PROMETHEUS_MULTIPROC_DIR`
- switches Django and Celery logging to structured JSON in `logs/app.json.log`, keeping the existing `logs/debug.log` for the app loggers during the transition
- enables Celery task events, which celery-exporter needs

Two pieces listed in the issues are already on `main` and are not part of this diff: the `/metrics` URL pattern (`cms/urls.py`) and `PROMETHEUS_MULTIPROC_DIR` in the systemd units.

Note for whoever deploys this: `deploy/uwsgi.ini` does not set `--lazy-apps`, so uWSGI preforks and `cms/wsgi.py` runs in the master. Metrics constructed at import time land in the master's file until each worker constructs a new one. Worth revisiting when the scrape target goes live.

## Related Issue

Partially addresses #574 (Phase 3b: django-prometheus) and #576 (Phase 5: Cleanup & Structured Logging).

Deliberately not using a closing keyword: both issues also carry deployment-repo tasks (Fluent Bit config, VictoriaMetrics scrape target, nginx `/metrics` block, old stack removal) that this PR does not touch.

## Motivation and Context

The monitoring stack installer belongs in deployment-specific repos, but reusable application metrics and structured logging belong in the public CinemataCMS codebase, so downstream deployments do not carry fork-only observability drift.

## How Has This Been Tested?

Local Postgres 18 + Redis, dedicated `cinematacms_test` database.

**Full Django suite:** 688 tests, 687 pass, 144s.

The one failure, `tests.test_ui_variant.UIVariantViewTests.test_upload_revamp_when_allowlisted`, is pre-existing and unrelated: it asserts the Vite dev path `src/entries/add-media.js`, which only renders when `DJANGO_VITE.dev_mode` is on (`VITE_DEV_MODE`). It fails identically on `origin/main` with the same database, and passes with `VITE_DEV_MODE=1`.

**Duplicate JSON records.** One process, seven loggers, one unique marker, counting records in `app.json.log`:

| logger | before | after |
| --- | --- | --- |
| `files`, `users`, `uploader`, `actions`, `django.request`, `celery.worker` | 2 | 1 |
| third-party (propagate-only) | 1 | 1 |

`debug.log` still receives the five app loggers; `celery` below WARNING is still dropped.

**uWSGI multiprocess worker ids.** Real uWSGI, 3 workers, `PROMETHEUS_MULTIPROC_DIR` set, 12 requests, two instances compared side by side:

- discarding the `MultiProcessValue` return value: `counter_71043.db`, `counter_71049.db` — raw pids (workers were 71047-71049)
- assigning it to `values.ValueClass`: `counter_0.db`, `counter_2.db`, `counter_3.db` — worker ids

`/metrics` aggregates across workers correctly: 12 requests report as `12.0`, not one worker's share.

**Also run:** `uv run python manage.py check`, `uv run pre-commit run --all-files`.

**Not covered:** no production-like uWSGI deployment behind nginx, and no verification that a log collector parses `app.json.log` end to end.

## Screenshots (if appropriate):

N/A — no user-facing changes.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):

- [x] I have not imported `flux` in a new component
- [ ] If adding a new feature, I used Modern Track patterns
- [x] New features do not create new SCSS files (use Tailwind instead)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Prometheus metrics monitoring for application and background-task activity.
  * Enabled task lifecycle events for improved monitoring and observability.
  * Added structured JSON logging alongside legacy log output.

* **Documentation**
  * Cleaned up whitespace throughout the README without changing its content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->