### PR TITLE
fix(hls): let mp4hls create its own output directory, and version HLS URLs by generation

### DIFF
--- a/files/models.py
+++ b/files/models.py
@@ -1111,6 +1111,19 @@ class Media(models.Model):
         return None
 
     @cached_property
+    def hls_version(self):
+        """Version token for HLS URLs, taken from the per-generation output directory.
+
+        create_hls writes every generation to HLS_DIR/<uid>/<version>/, so this changes
+        exactly when the HLS output changes. media_version cannot be used here: it derives
+        from edit_date, and create_hls saves hls_file with update_fields, which never
+        writes the auto_now edit_date.
+        """
+        if not self.hls_file:
+            return None
+        return os.path.basename(os.path.dirname(self.hls_file))
+
+    @cached_property
     def hls_info(self):
         res = {}
         if self.hls_file:
@@ -1120,19 +1133,19 @@ class Media(models.Model):
                 m3u8_obj = m3u8.load(hls_file)
                 if os.path.exists(hls_file):
                     base_url = helpers.url_from_path(hls_file)
-                    res["master_file"] = helpers.build_versioned_url(base_url, self.media_version)
+                    res["master_file"] = helpers.build_versioned_url(base_url, self.hls_version)
                     for iframe_playlist in m3u8_obj.iframe_playlists:
                         uri = os.path.join(p, iframe_playlist.uri)
                         if os.path.exists(uri):
                             resolution = iframe_playlist.iframe_stream_info.resolution[1]
                             base_url = helpers.url_from_path(uri)
-                            res[f"{resolution}_iframe"] = helpers.build_versioned_url(base_url, self.media_version)
+                            res[f"{resolution}_iframe"] = helpers.build_versioned_url(base_url, self.hls_version)
                     for playlist in m3u8_obj.playlists:
                         uri = os.path.join(p, playlist.uri)
                         if os.path.exists(uri):
                             resolution = playlist.stream_info.resolution[1]
                             base_url = helpers.url_from_path(uri)
-                            res[f"{resolution}_playlist"] = helpers.build_versioned_url(base_url, self.media_version)
+                            res[f"{resolution}_playlist"] = helpers.build_versioned_url(base_url, self.hls_version)
         return res
 
     @property

--- a/files/tasks.py
+++ b/files/tasks.py
@@ -793,7 +793,9 @@ def create_hls(friendly_token):
     try:
         version = produce_friendly_token()
         output_dir = os.path.join(uid_dir, version)
-        os.makedirs(output_dir, exist_ok=True)
+        # mp4hls creates output_dir itself with os.mkdir and exits 1 if it
+        # already exists (unless --force), so only the parent may be created here.
+        os.makedirs(uid_dir, exist_ok=True)
 
         files = [f.media_file.path for f in encodings if f.media_file]
         encryption_flags = []

--- a/files/tests/test_hls_encryption.py
+++ b/files/tests/test_hls_encryption.py
@@ -548,3 +548,81 @@ class CreateHlsVersionedDirectoryTests(TestCase):
             self.assertTrue(tasks.create_hls(self.media.friendly_token))
 
         self.assertTrue(os.path.exists(sentinel))
+
+
+class HlsInfoVersionParameterTests(TestCase):
+    """The ?v= on HLS URLs must track the HLS generation, not edit_date (issue #791).
+
+    create_hls commits the new playlist with save(update_fields=["hls_file"]), which
+    never writes the auto_now edit_date. A ?v= derived from edit_date therefore stays
+    frozen across regenerations and busts nothing.
+    """
+
+    def setUp(self):
+        from files.models import EncodeProfile, Encoding
+
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.hls_dir = os.path.join(self.tmpdir.name, "hls")
+        os.makedirs(self.hls_dir, exist_ok=True)
+        self.fake_mp4hls = os.path.join(self.tmpdir.name, "mp4hls")
+        with open(self.fake_mp4hls, "w", encoding="utf-8") as command_file:
+            command_file.write("#!/bin/sh\n")
+
+        self.override = override_settings(
+            MEDIA_ROOT=self.tmpdir.name,
+            HLS_DIR=self.hls_dir,
+            TEMP_DIRECTORY=self.tmpdir.name,
+            MP4HLS_COMMAND=self.fake_mp4hls,
+        )
+        self.override.enable()
+        self.addCleanup(self.override.disable)
+        self.addCleanup(self.tmpdir.cleanup)
+        cache.clear()
+
+        self.user = User.objects.create_user(username="owner2", email="owner2@example.com", password="pw")
+        self.profile = EncodeProfile.objects.create(name="h264_v", extension="mp4", codec="h264", resolution=720)
+        self.media = create_test_media(self.user)
+        Encoding.objects.create(
+            media=self.media,
+            profile=self.profile,
+            status="success",
+            media_file="encoded/fake.mp4",
+        )
+
+    @staticmethod
+    def _fake_run_writing_master(command, capture_output, timeout=None):
+        output_dir = next(
+            (part.removeprefix("--output-dir=") for part in command if part.startswith("--output-dir=")),
+            None,
+        )
+        os.makedirs(output_dir, exist_ok=True)
+        with open(os.path.join(output_dir, "master.m3u8"), "w", encoding="utf-8") as master_file:
+            master_file.write("#EXTM3U\n#EXT-X-VERSION:4\n")
+        return MagicMock(returncode=0)
+
+    def _generate_and_read_master_url(self):
+        from files import tasks
+
+        cache.clear()
+        with patch("files.tasks.subprocess.run", side_effect=self._fake_run_writing_master):
+            self.assertTrue(tasks.create_hls(self.media.friendly_token))
+        # Re-fetch: hls_info and hls_version are cached_property.
+        fresh = Media.objects.get(pk=self.media.pk)
+        return fresh, fresh.hls_info["master_file"]
+
+    def test_version_param_is_the_generation_directory(self):
+        fresh, master_url = self._generate_and_read_master_url()
+        version_dir = os.path.basename(os.path.dirname(fresh.hls_file))
+        self.assertEqual(fresh.hls_version, version_dir)
+        self.assertIn(f"?v={version_dir}", master_url)
+
+    def test_version_param_changes_on_regeneration(self):
+        first, first_url = self._generate_and_read_master_url()
+        second, second_url = self._generate_and_read_master_url()
+
+        self.assertNotEqual(first.hls_file, second.hls_file)
+        self.assertNotEqual(first_url, second_url)
+
+        # The regression: edit_date does not move, so a media_version-derived ?v=
+        # would have been identical across both generations.
+        self.assertEqual(first.media_version, second.media_version)


### PR DESCRIPTION
Follow-up to #792. That PR versioned the HLS output directory per generation to cache-bust segments. Two defects in it prevent HLS from being produced at all, and prevent the `?v=` parameter from changing.

Both were found on a staging deployment: every video encoded after #792 landed had `encoding_status = success` but an empty `hls_file`.

## 1. `mp4hls` never runs successfully

`create_hls` pre-creates the versioned output directory and then passes that same directory to `mp4hls`:

```python
output_dir = os.path.join(uid_dir, version)
os.makedirs(output_dir, exist_ok=True)
...
cmd = [settings.MP4HLS_COMMAND, f"--output-dir={output_dir}", ...]
```

Bento4's `mp4hls` refuses to write into a directory that already exists. In `Bento4/utils/mp4utils.py`, `MakeNewDir` calls `os.mkdir` and does `sys.exit(1)` when the target is present, unless `--force` is passed — and it is not passed here:

```python
MakeNewDir(dir=options.output_dir, exit_if_exists=not options.force_output, severity=severity)
```

So every run fails:

```
mp4hls failed for media oxQ1angZU with return code 1, discarding partial output:
ERROR: directory ".../media_files/hls/5f36ef4b.../Kkf7bPVDg" already exists
```

`create_hls` then discards the output and returns `True`, so nothing retries and no task is marked failed. `media.hls_file` is left empty and HLS is silently never generated.

Reproduced directly against the Bento4 binary:

| output directory | return code | result |
|---|---|---|
| pre-created (current `main`) | 1 | `ERROR: directory ... already exists` |
| fresh, parent exists (this PR) | 0 | `master.m3u8` produced |

**Fix:** create only the parent `uid_dir` and leave the versioned directory to `mp4hls`. The parent is still required because `MakeNewDir` uses `os.mkdir`, which does not create parents.

Note this is masked in the existing tests because they stub `subprocess.run` with a fake that calls `os.makedirs(output_dir, exist_ok=True)` itself, so the real refusal is never exercised.

## 2. The `?v=` parameter on HLS URLs never changes

`hls_info` builds its URLs with `build_versioned_url(base_url, self.media_version)`, and `media_version` derives from `edit_date`, which is an `auto_now` field. `create_hls` commits the new playlist with:

```python
media.save(update_fields=["hls_file"])
```

Because `update_fields` does not list `edit_date`, Django never writes the `auto_now` value, so `edit_date` is frozen and `?v=` is byte-identical across regenerations. Measured before and after a regeneration on staging:

```
before: /media/hls/aeb0.../A7dBFOTsY/master.m3u8?v=1783824094488
after:  /media/hls/aeb0.../xsANKCo5t/master.m3u8?v=1783824094488
```

The path changes, so #792's cache-busting still works — but the `?v=` contributes nothing. That matters because it looks like a working cache-buster, and anyone who later concludes the versioned path is redundant "since there is already a `?v=`" reintroduces the original stale-segment bug.

**Fix:** add `Media.hls_version`, taken from the per-generation output directory, and use it for the master, variant and iframe URLs. It changes exactly when the HLS output changes. `media_version` is left alone for poster, thumbnail, sprite and encoding URLs, which live at stable paths that are overwritten in place and still need it.

## Why the stale-cache problem is real

Worth recording, since it is the justification for #792. These files are served with `cache-control: max-age=31536000`. After deleting a version directory from the origin disk, the old segment URL still returned `200` with the full 757,280 bytes of video from the CDN edge (`cf-cache-status: HIT`). Under the pre-#792 stable path, a regeneration would have written new bytes to the same URL and the edge would have kept serving the old ones for up to a year.

## Verification

Deployed to staging and confirmed through the browser network panel:

- All five affected videos regenerated; each now has `hls_file` set and the full chain returns 200: master playlist, variant playlist, and `segment-0.ts`.
- All HLS URLs for a media share one generation token, and it changes on every regeneration (`xsANKCo5t` → `gBJrnF5K6`), while `media_version` stays frozen — confirming the old parameter was dead.
- Encrypted media still carry `#EXT-X-KEY:METHOD=AES-128,URI="/api/v1/keys/<token>"`, and the key endpoint returns the expected 16 bytes.
- Poster and thumbnail URLs still use `media_version`, unchanged.

## Tests

Existing HLS suites pass (46 tests). Adds `HlsInfoVersionParameterTests` covering that the `?v=` equals the generation directory and changes across regenerations, with an explicit assertion that `media_version` does not — which is the regression.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HLS playlist URL versioning so regenerated streaming outputs receive updated cache-busting URLs.
  * Prevented stale HLS playlists from being served after regeneration, even when media metadata remains unchanged.
  * Improved HLS output generation reliability by allowing the processing tool to create each new output directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->