### PR TITLE
feat(profile): contact tab, bionote breaks, impact-by-film, my notes, playlist restyle (#807, #808, #809, #810, #797)

### DIFF
--- a/docs/modern-track-color-system.md
+++ b/docs/modern-track-color-system.md
@@ -552,6 +552,18 @@ The full-screen flash/message overlay defines a parallel feature set on `.auth-m
 >
 > `*.stories.jsx` and `*.test.jsx` files contain color fixtures but are not part of the production styling path; they are excluded here.
 
+### profile — My Notes (features/profile)
+
+The profile **My Notes** tab renders each film-note card with a film thumbnail (with a **film duration pill** at the bottom-right) and the latest note timestamp beside a standalone vertical divider (per `jeremy-tasks/design/notes-in-profile/notes-in-profile.svg`). The pill is a light chip and the divider uses the exported `#1A3F61` line color, both constant across themes, so purpose-based tokens are defined in the global layer (light `body` + dark `body.dark_theme` + `@theme inline`):
+
+| Token | Light | Dark | Role |
+|-------|-------|------|------|
+| `bg-bg-note-thumbnail-duration` | `strait-blue-50` | `strait-blue-50` | Film duration pill background on the note thumbnail (theme-invariant light chip) |
+| `text-text-note-thumbnail-duration` | `pacific-deep-900` | `pacific-deep-900` | Film duration text on the pill |
+| `border-border-note-divider` | `pacific-deep-600p` | `pacific-deep-600p` | Standalone vertical divider in profile note entries |
+
+Named by purpose (the duration pill, the note divider), not by hue. `border-divider` was close but is intentionally theme-adaptive, whereas the exported note divider is constant; `text-on-chrome` is the closest to the pill's light fill but is a text color. The note thumbnail's empty/loading fill reuses the existing theme-aware `bg-bg-skeleton` (consistent with `FilmRow` / `ImpactFilmRow`).
+
 ---
 
 # 4. Consistency observations & remaining work

--- a/frontend/src/features/profile/components/ProfilePage.jsx
+++ b/frontend/src/features/profile/components/ProfilePage.jsx
@@ -7,6 +7,7 @@ import { ProfileHeader } from './ProfileHeader';
 import { ProfileTabs } from './ProfileTabs';
 import { SectionHeading } from './SectionHeading';
 import { AboutSection } from './sections/AboutSection';
+import { ContactSection } from './sections/ContactSection';
 import { ImpactSection } from './sections/ImpactSection';
 import { ManageUploadsSection } from './sections/ManageUploadsSection';
 import { MediaSection } from './sections/MediaSection';
@@ -21,6 +22,7 @@ const SECTIONS = {
 	playlists: PlaylistsSection,
 	notes: NotesSection,
 	impact: ImpactSection,
+	contact: ContactSection,
 	history: (props) => <OwnerMediaSection {...props} action="history" />,
 	liked: (props) => <OwnerMediaSection {...props} action="liked" />,
 };

--- a/frontend/src/features/profile/components/sections/AboutSection.jsx
+++ b/frontend/src/features/profile/components/sections/AboutSection.jsx
@@ -4,14 +4,10 @@ import { Icon, Link, Text } from '../../../shared/components';
 import { useAuthorPlaylists } from '../../hooks/useAuthorPlaylists';
 import { useOwnerMedia } from '../../hooks/useOwnerMedia';
 import { normalizeMediaList } from '../../utils/media';
+import { normalizeList } from '../../utils/list';
 import { MediaGrid } from '../MediaGrid';
 import { ProfileSectionHeader } from '../ProfileSectionHeader';
 import { SimilarProfiles } from '../SimilarProfiles';
-
-function normalizeList(data) {
-	if (Array.isArray(data)) return data;
-	return Array.isArray(data?.results) ? data.results : [];
-}
 
 function getSafeExternalUrl(value) {
 	try {

--- a/frontend/src/features/profile/components/sections/AboutSection.jsx
+++ b/frontend/src/features/profile/components/sections/AboutSection.jsx
@@ -151,7 +151,7 @@ export function AboutSection({ author }) {
 					<ProfileSectionHeader icon="profileBionote" title="Bionote" />
 					{sanitizedBiography ? (
 						<div
-							className="body-body-14-regular mt-4 space-y-3 text-text-primary sm:ml-[57px] [&_a]:text-text-link [&_p]:m-0"
+							className="body-body-14-regular mt-4 space-y-3 whitespace-pre-line text-text-primary sm:ml-[57px] [&_a]:text-text-link [&_p]:m-0"
 							dangerouslySetInnerHTML={{ __html: sanitizedBiography }}
 						/>
 					) : (

--- a/frontend/src/features/profile/components/sections/AboutSection.security.test.jsx
+++ b/frontend/src/features/profile/components/sections/AboutSection.security.test.jsx
@@ -29,4 +29,17 @@ describe('AboutSection biography security', () => {
 		expect(container).toHaveTextContent('Filmmaker');
 		expect(container.querySelector('[onerror]')).toBeNull();
 	});
+
+	it('preserves plain-text paragraph breaks in the biography', () => {
+		const author = { ...AUTHOR, description: 'First paragraph.\n\nSecond paragraph.' };
+		const { container } = render(
+			<QueryClientProvider client={profileQueryClient}>
+				<AboutSection author={author} />
+			</QueryClientProvider>
+		);
+
+		const bio = container.querySelector('.whitespace-pre-line');
+		expect(bio).not.toBeNull();
+		expect(bio.textContent).toContain('First paragraph.\n\nSecond paragraph.');
+	});
 });

--- a/frontend/src/features/profile/components/sections/ContactSection.jsx
+++ b/frontend/src/features/profile/components/sections/ContactSection.jsx
@@ -48,7 +48,7 @@ export function ContactSection({ author }) {
 				className="w-full"
 			/>
 
-			<div className="field-shell w-full px-0 pt-4">
+			<div className="field-shell w-full rounded px-0 pt-4 transition-shadow duration-200 focus-within:ring-2 focus-within:ring-ring-focus">
 				<label htmlFor="contact-message" className="body-body-16-regular mb-2 block">
 					Message
 					<span aria-hidden="true" className="text-text-danger">

--- a/frontend/src/features/profile/components/sections/ContactSection.jsx
+++ b/frontend/src/features/profile/components/sections/ContactSection.jsx
@@ -1,0 +1,86 @@
+import { useState } from 'react';
+import { Button, Text, TextAlert, TextField } from '../../../shared/components';
+import { apiFetch } from '../../../shared/utils/api';
+
+const IDLE = 'idle';
+const SENDING = 'sending';
+const SUCCESS = 'success';
+const ERROR = 'error';
+
+export function ContactSection({ author }) {
+	const [subject, setSubject] = useState('');
+	const [body, setBody] = useState('');
+	const [status, setStatus] = useState(IDLE);
+
+	const recipientName = author.name || author.username;
+	const canSubmit = status !== SENDING && subject.trim() !== '' && body.trim() !== '';
+
+	async function handleSubmit(event) {
+		event.preventDefault();
+		if (!canSubmit) return;
+
+		setStatus(SENDING);
+		try {
+			const response = await apiFetch(`/api/v1/users/${encodeURIComponent(author.username)}/contact`, {
+				method: 'POST',
+				body: { subject: subject.trim(), body: body.trim() },
+			});
+			if (!response.ok) {
+				setStatus(ERROR);
+				return;
+			}
+			setSubject('');
+			setBody('');
+			setStatus(SUCCESS);
+		} catch {
+			setStatus(ERROR);
+		}
+	}
+
+	return (
+		<form className="flex max-w-2xl flex-col gap-4" onSubmit={handleSubmit} noValidate>
+			<TextField
+				label="Subject"
+				name="subject"
+				required
+				value={subject}
+				onChange={(event) => setSubject(event.target.value)}
+				className="w-full"
+			/>
+
+			<div className="field-shell w-full px-0 pt-4">
+				<label htmlFor="contact-message" className="body-body-16-regular mb-2 block">
+					Message
+					<span aria-hidden="true" className="text-text-danger">
+						{' '}
+						*
+					</span>
+				</label>
+				<textarea
+					id="contact-message"
+					name="body"
+					required
+					rows={8}
+					value={body}
+					onChange={(event) => setBody(event.target.value)}
+					className="body-body-16-regular w-full resize-y border-0 bg-transparent text-text-strong outline-none placeholder:text-text-muted"
+				/>
+			</div>
+
+			{status === SUCCESS ? (
+				<TextAlert iconName="check">
+					Your message was sent to {recipientName}. A copy is in your inbox.
+				</TextAlert>
+			) : null}
+			{status === ERROR ? (
+				<Text as="p" variant="body-14" className="m-0 text-text-danger" role="alert">
+					Your message could not be sent. Please try again.
+				</Text>
+			) : null}
+
+			<Button type="submit" variant="primary" disabled={!canSubmit} className="w-fit">
+				{status === SENDING ? 'Sending…' : 'Send Message'}
+			</Button>
+		</form>
+	);
+}

--- a/frontend/src/features/profile/components/sections/ContactSection.jsx
+++ b/frontend/src/features/profile/components/sections/ContactSection.jsx
@@ -15,6 +15,12 @@ export function ContactSection({ author }) {
 	const recipientName = author.name || author.username;
 	const canSubmit = status !== SENDING && subject.trim() !== '' && body.trim() !== '';
 
+	// Clear a lingering success/error banner once the user starts a new message,
+	// so it never sits above a half-typed follow-up.
+	function clearStatusOnEdit() {
+		if (status === SUCCESS || status === ERROR) setStatus(IDLE);
+	}
+
 	async function handleSubmit(event) {
 		event.preventDefault();
 		if (!canSubmit) return;
@@ -44,7 +50,10 @@ export function ContactSection({ author }) {
 				name="subject"
 				required
 				value={subject}
-				onChange={(event) => setSubject(event.target.value)}
+				onChange={(event) => {
+					setSubject(event.target.value);
+					clearStatusOnEdit();
+				}}
 				className="w-full"
 			/>
 
@@ -62,7 +71,10 @@ export function ContactSection({ author }) {
 					required
 					rows={8}
 					value={body}
-					onChange={(event) => setBody(event.target.value)}
+					onChange={(event) => {
+						setBody(event.target.value);
+						clearStatusOnEdit();
+					}}
 					className="body-body-16-regular w-full resize-y border-0 bg-transparent text-text-strong outline-none placeholder:text-text-muted"
 				/>
 			</div>

--- a/frontend/src/features/profile/components/sections/ContactSection.test.jsx
+++ b/frontend/src/features/profile/components/sections/ContactSection.test.jsx
@@ -1,0 +1,51 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ContactSection } from './ContactSection';
+
+const AUTHOR = { username: 'jen', name: 'Jen Tarnate' };
+
+describe('ContactSection', () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('disables submit until both fields are filled', () => {
+		render(<ContactSection author={AUTHOR} />);
+
+		const submit = screen.getByRole('button', { name: /send message/i });
+		expect(submit).toBeDisabled();
+
+		fireEvent.change(screen.getByLabelText(/subject/i), { target: { value: 'Hello' } });
+		expect(submit).toBeDisabled();
+
+		fireEvent.change(screen.getByLabelText(/message/i), { target: { value: 'A question' } });
+		expect(submit).not.toBeDisabled();
+	});
+
+	it('posts the message to the contact endpoint and shows success', async () => {
+		const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true, json: async () => ({}) });
+
+		render(<ContactSection author={AUTHOR} />);
+		fireEvent.change(screen.getByLabelText(/subject/i), { target: { value: 'Hello' } });
+		fireEvent.change(screen.getByLabelText(/message/i), { target: { value: 'A question' } });
+		fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+
+		await waitFor(() => expect(screen.getByText(/your message was sent to jen/i)).toBeInTheDocument());
+
+		const [url, options] = fetchMock.mock.calls[0];
+		expect(url).toBe('/api/v1/users/jen/contact');
+		expect(options.method).toBe('POST');
+		expect(JSON.parse(options.body)).toEqual({ subject: 'Hello', body: 'A question' });
+	});
+
+	it('shows an error when the request fails', async () => {
+		vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: false, json: async () => ({}) });
+
+		render(<ContactSection author={AUTHOR} />);
+		fireEvent.change(screen.getByLabelText(/subject/i), { target: { value: 'Hello' } });
+		fireEvent.change(screen.getByLabelText(/message/i), { target: { value: 'A question' } });
+		fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+
+		await waitFor(() => expect(screen.getByText(/could not be sent/i)).toBeInTheDocument());
+	});
+});

--- a/frontend/src/features/profile/components/sections/ImpactFilmGroup.jsx
+++ b/frontend/src/features/profile/components/sections/ImpactFilmGroup.jsx
@@ -1,0 +1,91 @@
+import { Icon, Text } from '../../../shared/components';
+import { getImpactIconConfig } from '../../../video-viewer/components/community-impact/impactIcons';
+import { formatImpactDate, getSafeHref } from '../../../video-viewer/components/community-impact/utils/formatDate';
+import { ImpactFilmRow } from './ImpactFilmRow';
+
+// Categories shown as labelled rows beneath each film, in the order the ticket
+// wireframe specifies. "saves" is a summary-only category and "curated" is
+// excluded server-side, so neither appears here. Icons/labels reuse the media
+// page's impact config so the two surfaces stay visually consistent.
+const CATEGORY_KEYS = ['screening', 'featured', 'academic'];
+
+function entryList(bucket) {
+	if (Array.isArray(bucket)) return bucket;
+	return Array.isArray(bucket?.entries) ? bucket.entries : [];
+}
+
+function ImpactEntry({ entry }) {
+	const href = getSafeHref(entry?.url);
+	const date = formatImpactDate(entry?.event_date || entry?.add_date);
+	const title = entry?.title || '';
+
+	return (
+		<li className="flex min-w-0 flex-col gap-1 border-b border-border-divider py-3 last:border-b-0">
+			{href ? (
+				<a
+					href={href}
+					target="_blank"
+					rel="noreferrer"
+					className="w-fit text-text-primary no-underline hover:text-text-link-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-ring-focus body-body-14-medium"
+				>
+					{title}
+				</a>
+			) : (
+				<span className="text-text-primary body-body-14-medium">{title}</span>
+			)}
+			{entry?.details ? (
+				<p className="m-0 break-words text-text-muted body-body-12-regular">{entry.details}</p>
+			) : null}
+			{date ? (
+				<time className="text-text-muted body-body-12-regular" dateTime={entry?.event_date || entry?.add_date}>
+					{date}
+				</time>
+			) : null}
+		</li>
+	);
+}
+
+function CategoryRow({ categoryKey, entries }) {
+	const config = getImpactIconConfig(categoryKey);
+
+	return (
+		<section className="rounded-lg bg-bg-surface-muted p-4">
+			<div className="flex items-center gap-3">
+				<span
+					className={`inline-flex h-size-32 w-size-32 shrink-0 items-center justify-center rounded-full ${config.iconShellClassName}`}
+					aria-hidden="true"
+				>
+					<Icon name={config.iconName} size="sm" decorative />
+				</span>
+				<Text as="h4" variant="body-12-medium" className="m-0 text-text-muted uppercase">
+					{config.label}
+				</Text>
+			</div>
+			<ul className="mt-2 flex list-none flex-col p-0">
+				{entries.map((entry, index) => (
+					<ImpactEntry key={entry?.uid || index} entry={entry} />
+				))}
+			</ul>
+		</section>
+	);
+}
+
+export function ImpactFilmGroup({ film, index = 0 }) {
+	const impact = film?.impact || {};
+	const rows = CATEGORY_KEYS.map((key) => ({ key, entries: entryList(impact[key]) })).filter(
+		(row) => row.entries.length > 0
+	);
+
+	if (!rows.length) return null;
+
+	return (
+		<section className="flex flex-col gap-4 rounded-lg border border-border-default p-4">
+			<ImpactFilmRow media={film.media} index={index} />
+			<div className="flex flex-col gap-3">
+				{rows.map((row) => (
+					<CategoryRow key={row.key} categoryKey={row.key} entries={row.entries} />
+				))}
+			</div>
+		</section>
+	);
+}

--- a/frontend/src/features/profile/components/sections/ImpactFilmRow.jsx
+++ b/frontend/src/features/profile/components/sections/ImpactFilmRow.jsx
@@ -1,0 +1,66 @@
+import { formatDuration } from '../../../shared/utils/formatDuration';
+import { formatCount, getMediaCountry, getMediaDescription } from '../../../playlist/utils/playlist';
+
+/**
+ * Read-only film header for the profile Impact tab. Mirrors the Playlist page
+ * FilmRow layout (thumbnail, title, uploader, country, views, synopsis) but
+ * without the owner reorder/menu controls — impact entries render beneath it.
+ */
+export function ImpactFilmRow({ media }) {
+	const title = media?.title || 'Untitled video';
+	const author = media?.author_name || media?.user || 'Cinemata member';
+	const country = getMediaCountry(media);
+	const description = getMediaDescription(media);
+	const duration = formatDuration(media?.duration);
+	const metadata = [country, formatCount(media?.views || 0, 'view')].filter(Boolean).join(' · ');
+
+	return (
+		<div className="grid grid-cols-1 gap-x-4 gap-y-3 @2xl:grid-cols-[220px_minmax(0,1fr)] @2xl:items-start">
+			<a
+				href={media?.url || '#'}
+				className="relative block aspect-video w-full shrink-0 overflow-hidden rounded-ds-6 bg-bg-skeleton no-underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring-focus @2xl:w-[220px]"
+				aria-label={`Open ${title}`}
+			>
+				{media?.thumbnail_url ? (
+					<img
+						src={media.thumbnail_url}
+						alt=""
+						width="344"
+						height="194"
+						loading="lazy"
+						decoding="async"
+						className="h-full w-full object-cover"
+					/>
+				) : (
+					<span className="flex h-full w-full items-center justify-center text-text-muted body-body-12-regular">
+						No thumbnail
+					</span>
+				)}
+				{duration ? (
+					<span className="absolute right-1 bottom-1 rounded-ds-2 bg-bg-overlay-dark/80 px-1 py-0.5 text-text-on-chrome body-body-12-medium">
+						{duration}
+					</span>
+				) : null}
+			</a>
+
+			<div className="flex min-w-0 flex-col gap-2">
+				<a
+					href={media?.url || '#'}
+					className="line-clamp-2 text-text-strong no-underline hover:text-text-link-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-ring-focus body-body-16-medium"
+				>
+					{title}
+				</a>
+				<a
+					href={media?.author_profile || '#'}
+					className="line-clamp-1 w-fit text-text-link no-underline hover:text-text-link-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-ring-focus body-body-12-regular"
+				>
+					{author}
+				</a>
+				{metadata ? <p className="m-0 text-text-muted body-body-12-regular">{metadata}</p> : null}
+				{description ? (
+					<p className="m-0 line-clamp-3 break-words text-text-primary body-body-14-regular">{description}</p>
+				) : null}
+			</div>
+		</div>
+	);
+}

--- a/frontend/src/features/profile/components/sections/ImpactFilmRow.jsx
+++ b/frontend/src/features/profile/components/sections/ImpactFilmRow.jsx
@@ -1,12 +1,14 @@
-import { formatDuration } from '../../../shared/utils/formatDuration';
 import { formatCount, getMediaCountry, getMediaDescription } from '../../../playlist/utils/playlist';
+import { formatDuration } from '../../../shared/utils/formatDuration';
 
 /**
- * Read-only film header for the profile Impact tab. Mirrors the Playlist page
- * FilmRow layout (thumbnail, title, uploader, country, views, synopsis) but
- * without the owner reorder/menu controls — impact entries render beneath it.
+ * Read-only film-row header for the profile Impact tab. Faithfully mirrors the
+ * Playlist page FilmRow layout — order number, thumbnail with a duration pill,
+ * title, uploader, country · views, and a dedicated Synopsis column — but
+ * without the owner reorder/share menu. Impact entries render beneath it.
  */
-export function ImpactFilmRow({ media }) {
+export function ImpactFilmRow({ media, index = 0 }) {
+	const url = media?.url || '#';
 	const title = media?.title || 'Untitled video';
 	const author = media?.author_name || media?.user || 'Cinemata member';
 	const country = getMediaCountry(media);
@@ -15,11 +17,15 @@ export function ImpactFilmRow({ media }) {
 	const metadata = [country, formatCount(media?.views || 0, 'view')].filter(Boolean).join(' · ');
 
 	return (
-		<div className="grid grid-cols-1 gap-x-4 gap-y-3 @2xl:grid-cols-[220px_minmax(0,1fr)] @2xl:items-start">
+		<div className="grid grid-cols-1 gap-x-4 gap-y-3 sm:grid-cols-[24px_180px_minmax(140px,0.8fr)_minmax(0,1.2fr)] sm:items-start lg:grid-cols-[24px_220px_200px_minmax(0,1fr)] lg:gap-x-5">
+			<span className="hidden text-center text-text-muted body-body-14-regular sm:block sm:self-center">
+				{index + 1}
+			</span>
+
 			<a
-				href={media?.url || '#'}
-				className="relative block aspect-video w-full shrink-0 overflow-hidden rounded-ds-6 bg-bg-skeleton no-underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring-focus @2xl:w-[220px]"
+				href={url}
 				aria-label={`Open ${title}`}
+				className="relative block aspect-video w-full max-w-[220px] shrink-0 overflow-hidden rounded-ds-6 bg-bg-skeleton no-underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring-focus sm:w-[180px] sm:max-w-none lg:w-[220px]"
 			>
 				{media?.thumbnail_url ? (
 					<img
@@ -45,21 +51,29 @@ export function ImpactFilmRow({ media }) {
 
 			<div className="flex min-w-0 flex-col gap-2">
 				<a
-					href={media?.url || '#'}
-					className="line-clamp-2 text-text-strong no-underline hover:text-text-link-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-ring-focus body-body-16-medium"
+					href={url}
+					className="line-clamp-3 text-text-strong no-underline hover:text-text-link-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-ring-focus body-body-16-medium"
 				>
 					{title}
 				</a>
 				<a
 					href={media?.author_profile || '#'}
-					className="line-clamp-1 w-fit text-text-link no-underline hover:text-text-link-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-ring-focus body-body-12-regular"
+					className="line-clamp-2 w-fit text-text-link no-underline hover:text-text-link-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-ring-focus body-body-12-regular"
 				>
 					{author}
 				</a>
 				{metadata ? <p className="m-0 text-text-muted body-body-12-regular">{metadata}</p> : null}
+			</div>
+
+			<div className="min-w-0">
+				<p className="m-0 mb-3 text-text-muted body-body-14-regular">Synopsis</p>
 				{description ? (
-					<p className="m-0 line-clamp-3 break-words text-text-primary body-body-14-regular">{description}</p>
-				) : null}
+					<p className="m-0 line-clamp-6 break-words text-text-primary body-body-14-regular sm:line-clamp-3">
+						{description}
+					</p>
+				) : (
+					<p className="m-0 text-text-muted body-body-14-regular">No synopsis available.</p>
+				)}
 			</div>
 		</div>
 	);

--- a/frontend/src/features/profile/components/sections/ImpactSection.jsx
+++ b/frontend/src/features/profile/components/sections/ImpactSection.jsx
@@ -1,7 +1,9 @@
 import { Text } from '../../../shared/components';
-import { CommunityImpactSection } from '../../../video-viewer/components/community-impact';
 import { useAuthorImpact } from '../../hooks/useAuthorImpact';
-import { ImpactFilmRow } from './ImpactFilmRow';
+import { ImpactFilmGroup } from './ImpactFilmGroup';
+
+// Categories surfaced on the profile Impact tab (matches ImpactFilmGroup).
+const DISPLAY_CATEGORIES = ['screening', 'featured', 'academic'];
 
 function normalizeFilms(data) {
 	if (Array.isArray(data?.films)) return data.films;
@@ -12,6 +14,15 @@ function filmKey(film, index) {
 	return film?.media?.friendly_token || film?.media?.url || index;
 }
 
+function hasDisplayableEntries(film) {
+	const impact = film?.impact || {};
+	return DISPLAY_CATEGORIES.some((key) => {
+		const bucket = impact[key];
+		const entries = Array.isArray(bucket) ? bucket : bucket?.entries;
+		return Array.isArray(entries) && entries.length > 0;
+	});
+}
+
 export function ImpactSection({ author }) {
 	const { data, isLoading, isError } = useAuthorImpact(author.username);
 
@@ -20,7 +31,7 @@ export function ImpactSection({ author }) {
 	}
 	if (isError) return <Text className="text-text-danger">Community impact could not be loaded.</Text>;
 
-	const films = normalizeFilms(data);
+	const films = normalizeFilms(data).filter(hasDisplayableEntries);
 	if (!films.length) {
 		return (
 			<Text as="p" variant="body-14" className="m-0 text-text-muted">
@@ -32,15 +43,7 @@ export function ImpactSection({ author }) {
 	return (
 		<div className="flex flex-col gap-8">
 			{films.map((film, index) => (
-				<section
-					key={filmKey(film, index)}
-					className="flex flex-col gap-4 rounded-lg border border-border-default p-4"
-				>
-					<ImpactFilmRow media={film.media} />
-					{/* Header/description omitted: the tab-level heading already
-					    labels this section. */}
-					<CommunityImpactSection entries={film.impact || {}} canAdd={false} title="" description="" />
-				</section>
+				<ImpactFilmGroup key={filmKey(film, index)} film={film} index={index} />
 			))}
 		</div>
 	);

--- a/frontend/src/features/profile/components/sections/ImpactSection.jsx
+++ b/frontend/src/features/profile/components/sections/ImpactSection.jsx
@@ -1,6 +1,16 @@
 import { Text } from '../../../shared/components';
 import { CommunityImpactSection } from '../../../video-viewer/components/community-impact';
 import { useAuthorImpact } from '../../hooks/useAuthorImpact';
+import { ImpactFilmRow } from './ImpactFilmRow';
+
+function normalizeFilms(data) {
+	if (Array.isArray(data?.films)) return data.films;
+	return [];
+}
+
+function filmKey(film, index) {
+	return film?.media?.friendly_token || film?.media?.url || index;
+}
 
 export function ImpactSection({ author }) {
 	const { data, isLoading, isError } = useAuthorImpact(author.username);
@@ -10,12 +20,28 @@ export function ImpactSection({ author }) {
 	}
 	if (isError) return <Text className="text-text-danger">Community impact could not be loaded.</Text>;
 
+	const films = normalizeFilms(data);
+	if (!films.length) {
+		return (
+			<Text as="p" variant="body-14" className="m-0 text-text-muted">
+				{author.name || author.username} has no community impact entries yet.
+			</Text>
+		);
+	}
+
 	return (
-		<CommunityImpactSection
-			entries={data || {}}
-			canAdd={false}
-			title="Community Impact"
-			description="Screenings, playlists, and discussions that show how this creator's work is reaching people."
-		/>
+		<div className="flex flex-col gap-8">
+			{films.map((film, index) => (
+				<section
+					key={filmKey(film, index)}
+					className="flex flex-col gap-4 rounded-lg border border-border-default p-4"
+				>
+					<ImpactFilmRow media={film.media} />
+					{/* Header/description omitted: the tab-level heading already
+					    labels this section. */}
+					<CommunityImpactSection entries={film.impact || {}} canAdd={false} title="" description="" />
+				</section>
+			))}
+		</div>
 	);
 }

--- a/frontend/src/features/profile/components/sections/ManageUploadsSection.jsx
+++ b/frontend/src/features/profile/components/sections/ManageUploadsSection.jsx
@@ -1,14 +1,8 @@
-import { Link, Text } from '../../../shared/components';
+import { Link } from '../../../shared/components';
 
 export function ManageUploadsSection() {
 	return (
 		<div className="flex flex-col items-start gap-4">
-			<Text as="h3" variant="h6-bold" className="m-0 text-text-primary">
-				Your upload workspace
-			</Text>
-			<Text as="p" variant="body-14" className="m-0 max-w-2xl text-text-muted">
-				Open the upload manager to edit film details, visibility, processing, and publishing settings.
-			</Text>
 			<Link href="/manage/uploads" variant="primary">
 				Manage Uploads
 			</Link>

--- a/frontend/src/features/profile/components/sections/NoteEntry.jsx
+++ b/frontend/src/features/profile/components/sections/NoteEntry.jsx
@@ -1,4 +1,3 @@
-import { Icon } from '../../../shared/components';
 import { formatDuration } from '../../../shared/utils/formatDuration';
 import { formatClock, formatTimestamp } from '../../../video-viewer/private-journal/utils/journalMedia';
 
@@ -40,7 +39,7 @@ export function NoteEntry({ note, noteCount = 1 }) {
 	const noteCountLabel = `${noteCount} ${noteCount === 1 ? 'Note' : 'Notes'}`;
 
 	return (
-		<li className="grid w-full max-w-[360px] min-w-0 grid-cols-1 gap-y-[16px] sm:max-w-none sm:grid-cols-[220px_16px_36px_17px_1px_33px_minmax(0,1fr)_24px]">
+		<li className="grid w-full max-w-[360px] min-w-0 grid-cols-1 gap-y-[16px] sm:max-w-none sm:grid-cols-[220px_16px_36px_17px_1px_33px_minmax(0,1fr)]">
 			<a
 				href={href}
 				aria-label={`Open ${title} at ${noteTime}`}
@@ -68,7 +67,7 @@ export function NoteEntry({ note, noteCount = 1 }) {
 				) : null}
 			</a>
 
-			<div className="col-span-full grid min-w-0 grid-cols-[36px_17px_1px_33px_minmax(0,1fr)_24px] sm:col-start-3 sm:col-end-9 sm:row-start-1">
+			<div className="col-span-full grid min-w-0 grid-cols-[36px_17px_1px_33px_minmax(0,1fr)] sm:col-start-3 sm:col-end-8 sm:row-start-1">
 				<a
 					href={href}
 					className="col-start-1 self-start text-text-accent no-underline hover:text-text-link-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-ring-focus body-body-14-medium"
@@ -93,13 +92,6 @@ export function NoteEntry({ note, noteCount = 1 }) {
 						</p>
 					) : null}
 				</div>
-
-				<span
-					className="col-start-6 flex h-[24px] w-[24px] items-start justify-center text-text-primary"
-					aria-hidden="true"
-				>
-					<Icon name="threeDots" size={22} decorative />
-				</span>
 			</div>
 
 			<div className="col-span-full sm:col-start-1 sm:row-start-2">

--- a/frontend/src/features/profile/components/sections/NoteEntry.jsx
+++ b/frontend/src/features/profile/components/sections/NoteEntry.jsx
@@ -1,0 +1,121 @@
+import { Icon } from '../../../shared/components';
+import { formatDuration } from '../../../shared/utils/formatDuration';
+import { formatClock, formatTimestamp } from '../../../video-viewer/private-journal/utils/journalMedia';
+
+// Deep-link back into the film at the note's timestamp: /view?m=<token>&t=<seconds>.
+function noteHref(media) {
+	const seconds = Math.max(0, Math.floor(Number(media?.timestamp_seconds) || 0));
+	const base = media?.url || (media?.friendly_token ? `/view?m=${encodeURIComponent(media.friendly_token)}` : '#');
+	if (base === '#') return base;
+	const separator = base.includes('?') ? '&' : '?';
+	return `${base}${separator}t=${seconds}`;
+}
+
+function filmHref(media) {
+	return media?.url || (media?.friendly_token ? `/view?m=${encodeURIComponent(media.friendly_token)}` : '#');
+}
+
+function formatDay(value) {
+	const date = value instanceof Date ? value : new Date(value);
+	if (Number.isNaN(date.getTime())) return '';
+	const today = new Date();
+	const startOfToday = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+	const startOfDate = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+	const dayDelta = Math.round((startOfToday - startOfDate) / 86400000);
+	if (dayDelta === 0) return 'Today';
+	if (dayDelta === 1) return 'Yesterday';
+	return date.toLocaleDateString([], { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+export function NoteEntry({ note, noteCount = 1 }) {
+	const media = note?.media || {};
+	const seconds = Math.max(0, Math.floor(Number(note?.timestamp_seconds) || 0));
+	const href = noteHref({ ...media, timestamp_seconds: seconds });
+	const allNotesHref = filmHref(media);
+	const title = media.title || 'Untitled film';
+	const noteTime = formatTimestamp(seconds);
+	const duration = formatDuration(media.duration);
+	const dayLabel = formatDay(note?.add_date || note?.edit_date);
+	const clockLabel = formatClock(note?.add_date || note?.edit_date);
+	const noteCountLabel = `${noteCount} ${noteCount === 1 ? 'Note' : 'Notes'}`;
+
+	return (
+		<li className="grid w-full max-w-[360px] min-w-0 grid-cols-1 gap-y-[16px] sm:max-w-none sm:grid-cols-[220px_16px_36px_17px_1px_33px_minmax(0,1fr)_24px]">
+			<a
+				href={href}
+				aria-label={`Open ${title} at ${noteTime}`}
+				className="relative col-span-full block aspect-[360/202] w-full overflow-hidden rounded-ds-6 bg-bg-skeleton no-underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring-focus sm:col-span-1 sm:aspect-auto sm:h-[123px] sm:w-[220px]"
+			>
+				{media.thumbnail_url ? (
+					<img
+						src={media.thumbnail_url}
+						alt=""
+						width="220"
+						height="123"
+						loading="lazy"
+						decoding="async"
+						className="h-full w-full object-cover"
+					/>
+				) : (
+					<span className="flex h-full w-full items-center justify-center text-text-muted body-body-12-regular">
+						No thumbnail
+					</span>
+				)}
+				{duration ? (
+					<span className="absolute right-[4px] bottom-[4px] inline-flex h-[18px] min-w-[33px] items-center justify-center rounded-ds-2 bg-bg-note-thumbnail-duration px-[4px] text-text-note-thumbnail-duration body-body-12-medium">
+						{duration}
+					</span>
+				) : null}
+			</a>
+
+			<div className="col-span-full grid min-w-0 grid-cols-[36px_17px_1px_33px_minmax(0,1fr)_24px] sm:col-start-3 sm:col-end-9 sm:row-start-1">
+				<a
+					href={href}
+					className="col-start-1 self-start text-text-accent no-underline hover:text-text-link-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-ring-focus body-body-14-medium"
+				>
+					{noteTime}
+				</a>
+
+				<span aria-hidden="true" className="col-start-3 block h-[97px] w-px bg-border-note-divider" />
+
+				<div className="col-start-5 min-w-0">
+					<div className="flex items-center gap-[12px] text-text-muted body-body-14-regular">
+						<span>Last Note</span>
+					</div>
+					<p className="m-0 mt-[12px] line-clamp-2 break-words whitespace-pre-line text-text-primary body-body-16-regular">
+						{note?.text || ''}
+					</p>
+					{dayLabel || clockLabel ? (
+						<p className="m-0 mt-[28px] flex items-center gap-[18px] text-text-muted body-body-14-regular">
+							{dayLabel ? <span>{dayLabel}</span> : null}
+							{dayLabel && clockLabel ? <span aria-hidden="true">•</span> : null}
+							{clockLabel ? <span>{clockLabel}</span> : null}
+						</p>
+					) : null}
+				</div>
+
+				<span
+					className="col-start-6 flex h-[24px] w-[24px] items-start justify-center text-text-primary"
+					aria-hidden="true"
+				>
+					<Icon name="threeDots" size={22} decorative />
+				</span>
+			</div>
+
+			<div className="col-span-full sm:col-start-1 sm:row-start-2">
+				<a
+					href={href}
+					className="line-clamp-1 text-text-primary no-underline hover:text-text-link-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-ring-focus body-body-16-medium"
+				>
+					{title}
+				</a>
+				<a
+					href={allNotesHref}
+					className="mt-[6px] block text-text-accent no-underline hover:text-text-link-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-ring-focus body-body-14-medium"
+				>
+					View all {noteCountLabel} on this Film
+				</a>
+			</div>
+		</li>
+	);
+}

--- a/frontend/src/features/profile/components/sections/NotesSection.jsx
+++ b/frontend/src/features/profile/components/sections/NotesSection.jsx
@@ -1,17 +1,75 @@
 import { Icon, Text } from '../../../shared/components';
+import { useAuthorNotes } from '../../hooks/useAuthorNotes';
+import { NoteEntry } from './NoteEntry';
 
-export function NotesSection() {
+function mediaKey(note) {
+	const media = note?.media || {};
+	return media.friendly_token || media.url || media.title || note.uid;
+}
+
+function noteTime(note) {
+	const value = new Date(note?.add_date || note?.edit_date || 0).getTime();
+	return Number.isNaN(value) ? 0 : value;
+}
+
+function latestNotesByFilm(notes) {
+	const groups = new Map();
+
+	for (const note of notes) {
+		const key = mediaKey(note);
+		const current = groups.get(key);
+		if (!current) {
+			groups.set(key, { note, noteCount: 1 });
+			continue;
+		}
+
+		current.noteCount += 1;
+		if (noteTime(note) > noteTime(current.note)) {
+			current.note = note;
+		}
+	}
+
+	return Array.from(groups.values()).sort((a, b) => noteTime(b.note) - noteTime(a.note));
+}
+
+function EmptyNotes() {
 	return (
 		<div className="flex min-h-[280px] flex-col items-center justify-center gap-4 py-8 text-center">
 			<span className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-bg-surface-muted text-text-muted">
-				<Icon name="note" size="md" decorative />
+				<Icon name="notes" size="md" decorative />
 			</span>
 			<Text as="h3" variant="h6-bold" className="m-0 text-text-primary">
-				Notes are coming soon
+				No notes yet
 			</Text>
 			<Text as="p" variant="body-14" className="m-0 max-w-md text-text-muted">
-				Your private, time-stamped film notes will appear here when the notes feature is ready.
+				Your private, time-stamped notes on films across Cinemata will appear here. Add notes while watching a
+				film to keep track of key moments.
 			</Text>
 		</div>
+	);
+}
+
+export function NotesSection({ author }) {
+	// Notes are private and owner-only; never fetch another user's notes.
+	const isOwner = Boolean(author?.is_owner);
+	const { data, isLoading, isError } = useAuthorNotes(author?.username, isOwner);
+
+	if (!isOwner) return <EmptyNotes />;
+
+	if (isLoading) {
+		return <div className="h-64 animate-pulse rounded-xl bg-bg-skeleton" aria-label="Loading notes" />;
+	}
+	if (isError) return <Text className="text-text-danger">Your notes could not be loaded.</Text>;
+
+	const notes = Array.isArray(data?.results) ? data.results : [];
+	if (!notes.length) return <EmptyNotes />;
+	const filmNotes = latestNotesByFilm(notes);
+
+	return (
+		<ul className="-mx-4 grid list-none grid-cols-1 justify-items-center gap-y-[48px] p-0 sm:mx-0 xl:grid-cols-[repeat(2,564px)] xl:justify-items-start xl:gap-x-[33px] xl:gap-y-[37px]">
+			{filmNotes.map(({ note, noteCount }) => (
+				<NoteEntry key={mediaKey(note)} note={note} noteCount={noteCount} />
+			))}
+		</ul>
 	);
 }

--- a/frontend/src/features/profile/components/sections/NotesSection.jsx
+++ b/frontend/src/features/profile/components/sections/NotesSection.jsx
@@ -2,34 +2,9 @@ import { Icon, Text } from '../../../shared/components';
 import { useAuthorNotes } from '../../hooks/useAuthorNotes';
 import { NoteEntry } from './NoteEntry';
 
-function mediaKey(note) {
+function noteKey(note) {
 	const media = note?.media || {};
 	return media.friendly_token || media.url || media.title || note.uid;
-}
-
-function noteTime(note) {
-	const value = new Date(note?.add_date || note?.edit_date || 0).getTime();
-	return Number.isNaN(value) ? 0 : value;
-}
-
-function latestNotesByFilm(notes) {
-	const groups = new Map();
-
-	for (const note of notes) {
-		const key = mediaKey(note);
-		const current = groups.get(key);
-		if (!current) {
-			groups.set(key, { note, noteCount: 1 });
-			continue;
-		}
-
-		current.noteCount += 1;
-		if (noteTime(note) > noteTime(current.note)) {
-			current.note = note;
-		}
-	}
-
-	return Array.from(groups.values()).sort((a, b) => noteTime(b.note) - noteTime(a.note));
 }
 
 function EmptyNotes() {
@@ -61,14 +36,15 @@ export function NotesSection({ author }) {
 	}
 	if (isError) return <Text className="text-text-danger">Your notes could not be loaded.</Text>;
 
-	const notes = Array.isArray(data?.results) ? data.results : [];
-	if (!notes.length) return <EmptyNotes />;
-	const filmNotes = latestNotesByFilm(notes);
+	// The endpoint already returns one latest note per film with a note_count,
+	// newest film first — render directly, no client-side grouping.
+	const films = Array.isArray(data?.results) ? data.results : [];
+	if (!films.length) return <EmptyNotes />;
 
 	return (
 		<ul className="-mx-4 grid list-none grid-cols-1 justify-items-center gap-y-[48px] p-0 sm:mx-0 xl:grid-cols-[repeat(2,564px)] xl:justify-items-start xl:gap-x-[33px] xl:gap-y-[37px]">
-			{filmNotes.map(({ note, noteCount }) => (
-				<NoteEntry key={mediaKey(note)} note={note} noteCount={noteCount} />
+			{films.map((note) => (
+				<NoteEntry key={noteKey(note)} note={note} noteCount={note.note_count || 1} />
 			))}
 		</ul>
 	);

--- a/frontend/src/features/profile/components/sections/NotesSection.test.jsx
+++ b/frontend/src/features/profile/components/sections/NotesSection.test.jsx
@@ -1,0 +1,95 @@
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import profileQueryClient, { PROFILE_QUERY_KEYS } from '../../queryClient';
+import { NotesSection } from './NotesSection';
+
+function renderSection(author) {
+	return render(
+		<QueryClientProvider client={profileQueryClient}>
+			<NotesSection author={author} />
+		</QueryClientProvider>
+	);
+}
+
+describe('NotesSection', () => {
+	beforeEach(() => {
+		profileQueryClient.clear();
+	});
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('shows the empty state for non-owners without fetching', () => {
+		const fetchMock = vi.spyOn(globalThis, 'fetch');
+
+		renderSection({ username: 'jen', is_owner: false });
+
+		expect(screen.getByText(/no notes yet/i)).toBeInTheDocument();
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it('renders the owner notes with media context and timestamp deep-link', async () => {
+		vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+			ok: true,
+			json: async () => ({
+				results: [
+					{
+						uid: 'n1',
+						text: 'Latest note',
+						timestamp_seconds: 65,
+						add_date: '2026-07-11T05:12:00Z',
+						media: {
+							title: 'My Film',
+							friendly_token: 'abc',
+							url: '/view?m=abc',
+							thumbnail_url: '',
+							duration: 120,
+						},
+					},
+					{
+						uid: 'n2',
+						text: 'Older note',
+						timestamp_seconds: 30,
+						add_date: '2026-07-10T05:12:00Z',
+						media: {
+							title: 'My Film',
+							friendly_token: 'abc',
+							url: '/view?m=abc',
+							thumbnail_url: '',
+							duration: 120,
+						},
+					},
+				],
+				next: '',
+			}),
+		});
+
+		renderSection({ username: 'jen', is_owner: true });
+
+		await waitFor(() => expect(screen.getByText('Latest note')).toBeInTheDocument());
+		expect(screen.queryByText('Older note')).not.toBeInTheDocument();
+		expect(screen.getByText('Last Note')).toBeInTheDocument();
+		// The note timestamp (1:05) shows beside the card; the film duration
+		// (2:00) shows as a pill on the thumbnail.
+		expect(screen.getByText('1:05')).toBeInTheDocument();
+		expect(screen.getByText('2:00')).toBeInTheDocument();
+		const link = screen.getByRole('link', { name: /open my film at 1:05/i });
+		expect(link).toHaveAttribute('href', '/view?m=abc&t=65');
+		expect(screen.getByRole('link', { name: /view all 2 notes on this film/i })).toHaveAttribute(
+			'href',
+			'/view?m=abc'
+		);
+	});
+
+	it('shows the empty state when the owner has no notes', async () => {
+		vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+			ok: true,
+			json: async () => ({ results: [], next: '' }),
+		});
+
+		renderSection({ username: 'jen', is_owner: true });
+
+		await waitFor(() => expect(screen.getByText(/no notes yet/i)).toBeInTheDocument());
+	});
+});

--- a/frontend/src/features/profile/components/sections/NotesSection.test.jsx
+++ b/frontend/src/features/profile/components/sections/NotesSection.test.jsx
@@ -29,7 +29,9 @@ describe('NotesSection', () => {
 		expect(fetchMock).not.toHaveBeenCalled();
 	});
 
-	it('renders the owner notes with media context and timestamp deep-link', async () => {
+	it('renders one card per film from the server aggregate, with media context and count', async () => {
+		// The endpoint already returns one latest note per film plus note_count;
+		// the client renders it directly (no grouping).
 		vi.spyOn(globalThis, 'fetch').mockResolvedValue({
 			ok: true,
 			json: async () => ({
@@ -39,19 +41,7 @@ describe('NotesSection', () => {
 						text: 'Latest note',
 						timestamp_seconds: 65,
 						add_date: '2026-07-11T05:12:00Z',
-						media: {
-							title: 'My Film',
-							friendly_token: 'abc',
-							url: '/view?m=abc',
-							thumbnail_url: '',
-							duration: 120,
-						},
-					},
-					{
-						uid: 'n2',
-						text: 'Older note',
-						timestamp_seconds: 30,
-						add_date: '2026-07-10T05:12:00Z',
+						note_count: 2,
 						media: {
 							title: 'My Film',
 							friendly_token: 'abc',
@@ -68,7 +58,6 @@ describe('NotesSection', () => {
 		renderSection({ username: 'jen', is_owner: true });
 
 		await waitFor(() => expect(screen.getByText('Latest note')).toBeInTheDocument());
-		expect(screen.queryByText('Older note')).not.toBeInTheDocument();
 		expect(screen.getByText('Last Note')).toBeInTheDocument();
 		// The note timestamp (1:05) shows beside the card; the film duration
 		// (2:00) shows as a pill on the thumbnail.
@@ -76,10 +65,24 @@ describe('NotesSection', () => {
 		expect(screen.getByText('2:00')).toBeInTheDocument();
 		const link = screen.getByRole('link', { name: /open my film at 1:05/i });
 		expect(link).toHaveAttribute('href', '/view?m=abc&t=65');
+		// Count comes from the server-provided note_count, not the array length.
 		expect(screen.getByRole('link', { name: /view all 2 notes on this film/i })).toHaveAttribute(
 			'href',
 			'/view?m=abc'
 		);
+	});
+
+	it('fetches the notes endpoint exactly once (no client-side page walk)', async () => {
+		const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+			ok: true,
+			json: async () => ({ results: [], next: '' }),
+		});
+
+		renderSection({ username: 'jen', is_owner: true });
+
+		await waitFor(() => expect(screen.getByText(/no notes yet/i)).toBeInTheDocument());
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(fetchMock.mock.calls[0][0]).toBe('/api/v1/users/jen/private-journal');
 	});
 
 	it('shows the empty state when the owner has no notes', async () => {

--- a/frontend/src/features/profile/components/sections/PlaylistsSection.jsx
+++ b/frontend/src/features/profile/components/sections/PlaylistsSection.jsx
@@ -1,9 +1,64 @@
-import { Card, Text } from '../../../shared/components';
+import { formatCreatedDate } from '../../../playlist/utils/playlist';
+import { Icon, Text } from '../../../shared/components';
 import { useAuthorPlaylists } from '../../hooks/useAuthorPlaylists';
 
 function normalizeList(data) {
 	if (Array.isArray(data)) return data;
 	return Array.isArray(data?.results) ? data.results : [];
+}
+
+function PlaylistCard({ playlist }) {
+	const link = playlist.url || '#';
+	const title = playlist.title || 'Untitled playlist';
+	const count = playlist.media_count || 0;
+
+	return (
+		<li className="min-w-0">
+			<a
+				href={link}
+				title={title}
+				aria-label={`Play all in ${title}`}
+				className="group relative block aspect-video overflow-hidden rounded bg-bg-skeleton no-underline focus:outline-none focus-visible:ring-2 focus-visible:ring-ring-focus"
+			>
+				{playlist.thumbnail_url ? (
+					<img src={playlist.thumbnail_url} alt="" loading="lazy" className="h-full w-full object-cover" />
+				) : null}
+
+				{/* Right-side count panel (old-page style): count above the
+				    playlist-play icon, centered in a fixed 92px column. */}
+				<span className="absolute inset-y-0 right-0 flex w-[92px] flex-col items-center justify-center gap-0.5 bg-bg-overlay-dark/80 text-text-on-chrome">
+					<span className="leading-tight body-body-14-regular">{count}</span>
+					<Icon name="playlistPlay" size={29} decorative />
+				</span>
+
+				{/* Hover "PLAY ALL" overlay. */}
+				<span className="absolute inset-0 flex items-center justify-center gap-2 bg-bg-overlay-dark/80 text-text-on-chrome opacity-0 transition-opacity duration-300 group-hover:opacity-100 group-focus-visible:opacity-100">
+					<Icon name="play" size="sm" decorative />
+					<Text as="span" variant="body-14-medium" className="uppercase">
+						Play all
+					</Text>
+				</span>
+			</a>
+
+			<div className="mt-3 flex min-w-0 flex-col items-start">
+				<a
+					href={link}
+					className="line-clamp-2 text-text-primary no-underline hover:text-text-link-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-ring-focus body-body-16-medium"
+				>
+					{title}
+				</a>
+				<Text as="p" variant="body-12" className="mt-2 mb-0 text-text-muted">
+					{formatCreatedDate(playlist.add_date)}
+				</Text>
+				<a
+					href={link}
+					className="mt-1 text-text-link no-underline hover:text-text-link-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-ring-focus body-body-12-medium uppercase"
+				>
+					View full playlist
+				</a>
+			</div>
+		</li>
+	);
 }
 
 export function PlaylistsSection({ author }) {
@@ -17,31 +72,11 @@ export function PlaylistsSection({ author }) {
 	if (!playlists.length) return <Text className="text-text-muted">No playlists created yet.</Text>;
 
 	return (
-		<ul className="grid list-none gap-4 p-0">
+		// Match the legacy profile grid: cards cap at --default-item-width
+		// (372px) rather than stretching to fill the column, up to 4 per row.
+		<ul className="grid list-none grid-cols-[repeat(auto-fill,minmax(min(100%,280px),372px))] justify-start gap-x-[27px] gap-y-8 p-0">
 			{playlists.map((playlist) => (
-				<li key={playlist.url || playlist.title}>
-					<Card variant="outlined" className="flex flex-col gap-4 p-4 sm:flex-row">
-						<img
-							src={playlist.thumbnail_url}
-							alt=""
-							width="180"
-							height="135"
-							loading="lazy"
-							className="aspect-[4/3] w-full rounded object-cover sm:w-[180px]"
-						/>
-						<div className="min-w-0">
-							<a
-								href={playlist.url}
-								className="heading-h6-20-medium text-text-primary hover:text-text-link-hover"
-							>
-								{playlist.title}
-							</a>
-							<Text as="p" variant="body-14" className="mt-2 mb-0 text-text-muted">
-								{playlist.description || `${playlist.media_count || 0} films`}
-							</Text>
-						</div>
-					</Card>
-				</li>
+				<PlaylistCard key={playlist.url || playlist.title} playlist={playlist} />
 			))}
 		</ul>
 	);

--- a/frontend/src/features/profile/components/sections/PlaylistsSection.jsx
+++ b/frontend/src/features/profile/components/sections/PlaylistsSection.jsx
@@ -1,11 +1,7 @@
 import { formatCreatedDate } from '../../../playlist/utils/playlist';
 import { Icon, Text } from '../../../shared/components';
 import { useAuthorPlaylists } from '../../hooks/useAuthorPlaylists';
-
-function normalizeList(data) {
-	if (Array.isArray(data)) return data;
-	return Array.isArray(data?.results) ? data.results : [];
-}
+import { normalizeList } from '../../utils/list';
 
 function PlaylistCard({ playlist }) {
 	const link = playlist.url || '#';
@@ -75,8 +71,8 @@ export function PlaylistsSection({ author }) {
 		// Match the legacy profile grid: cards cap at --default-item-width
 		// (372px) rather than stretching to fill the column, up to 4 per row.
 		<ul className="grid list-none grid-cols-[repeat(auto-fill,minmax(min(100%,280px),372px))] justify-start gap-x-[27px] gap-y-8 p-0">
-			{playlists.map((playlist) => (
-				<PlaylistCard key={playlist.url || playlist.title} playlist={playlist} />
+			{playlists.map((playlist, index) => (
+				<PlaylistCard key={playlist.url || playlist.title || index} playlist={playlist} />
 			))}
 		</ul>
 	);

--- a/frontend/src/features/profile/hooks/useAuthorNotes.js
+++ b/frontend/src/features/profile/hooks/useAuthorNotes.js
@@ -1,15 +1,21 @@
 import { useQuery } from '@tanstack/react-query';
 import { PROFILE_QUERY_KEYS } from '../queryClient';
-import { fetchAllPages } from './useAuthorMedia';
 
-// Private journal notes are owner-only and paginated (DRF PageNumberPagination).
-// Only fetch when the profile belongs to the current user.
+// Private journal notes, owner-only. The endpoint aggregates server-side to one
+// row per film (latest note + note_count), paginated by film, so a single
+// request draws the tab — no client-side grouping or multi-page walk.
 export function useAuthorNotes(username, enabled) {
 	const url = username ? `/api/v1/users/${encodeURIComponent(username)}/private-journal` : '';
 
 	return useQuery({
 		queryKey: PROFILE_QUERY_KEYS.notes(username),
 		enabled: Boolean(url) && Boolean(enabled),
-		queryFn: ({ signal }) => fetchAllPages(url, signal),
+		queryFn: async ({ signal }) => {
+			const response = await fetch(url, { credentials: 'same-origin', signal });
+			if (!response.ok) {
+				throw new Error(`Failed to fetch ${url}: ${response.status}`);
+			}
+			return response.json();
+		},
 	});
 }

--- a/frontend/src/features/profile/hooks/useAuthorNotes.js
+++ b/frontend/src/features/profile/hooks/useAuthorNotes.js
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+import { PROFILE_QUERY_KEYS } from '../queryClient';
+import { fetchAllPages } from './useAuthorMedia';
+
+// Private journal notes are owner-only and paginated (DRF PageNumberPagination).
+// Only fetch when the profile belongs to the current user.
+export function useAuthorNotes(username, enabled) {
+	const url = username ? `/api/v1/users/${encodeURIComponent(username)}/private-journal` : '';
+
+	return useQuery({
+		queryKey: PROFILE_QUERY_KEYS.notes(username),
+		enabled: Boolean(url) && Boolean(enabled),
+		queryFn: ({ signal }) => fetchAllPages(url, signal),
+	});
+}

--- a/frontend/src/features/profile/queryClient.js
+++ b/frontend/src/features/profile/queryClient.js
@@ -17,6 +17,7 @@ export const PROFILE_QUERY_KEYS = {
 	playlists: (username) => ['profile', username, 'playlists'],
 	similar: (username, location) => ['profile', username, 'similar', location],
 	impact: (username) => ['profile', username, 'impact'],
+	notes: (username) => ['profile', username, 'notes'],
 	history: (username) => ['profile', username, 'history'],
 	liked: (username) => ['profile', username, 'liked'],
 };

--- a/frontend/src/features/profile/utils/list.js
+++ b/frontend/src/features/profile/utils/list.js
@@ -1,0 +1,4 @@
+export function normalizeList(data) {
+	if (Array.isArray(data)) return data;
+	return Array.isArray(data?.results) ? data.results : [];
+}

--- a/frontend/src/features/profile/utils/tabConfig.js
+++ b/frontend/src/features/profile/utils/tabConfig.js
@@ -60,6 +60,18 @@ export function getProfileTabs(author, runtimeConfig) {
 			visible: true,
 		},
 		{
+			id: 'contact',
+			label: 'Contact',
+			heading: `Contact ${name}`,
+			subtext: `Send a message directly to ${name}. You'll receive a copy in your own inbox so you can continue the conversation by email.`,
+			href: `${base}/contact`,
+			// author.can_contact is the viewer-aware flag from the backend
+			// (authenticated, non-owner, and the profile allows contact or the
+			// viewer is an editor/curator) — the same gate as the contact POST.
+			// The owner check is defensive; the backend never sets it for owners.
+			visible: !owner && Boolean(author.can_contact),
+		},
+		{
 			id: 'history',
 			label: 'Viewing History',
 			heading: 'Watching History',

--- a/frontend/src/features/profile/utils/tabConfig.test.js
+++ b/frontend/src/features/profile/utils/tabConfig.test.js
@@ -53,6 +53,28 @@ describe('getProfileTabs', () => {
 		expect(tabs.find((tab) => tab.id === 'media').label).toBe("Jen's Media");
 	});
 
+	it('shows the contact tab to visitors when contact is allowed', () => {
+		const tabs = getProfileTabs({ ...AUTHOR, is_owner: false, can_contact: true }, runtimeConfig());
+
+		expect(tabs.map((tab) => tab.id)).toEqual(['about', 'media', 'playlists', 'impact', 'contact']);
+		const contact = tabs.find((tab) => tab.id === 'contact');
+		expect(contact.heading).toBe('Contact Jen');
+		expect(contact.href).toBe('/user/jen/contact');
+	});
+
+	it('hides the contact tab when the backend disallows contact', () => {
+		const tabs = getProfileTabs({ ...AUTHOR, is_owner: false, can_contact: false }, runtimeConfig());
+
+		expect(tabs.map((tab) => tab.id)).not.toContain('contact');
+	});
+
+	it('never shows the contact tab to the profile owner', () => {
+		// The backend never sets can_contact for the owner, but guard anyway.
+		const tabs = getProfileTabs({ ...AUTHOR, is_owner: true, can_contact: true }, runtimeConfig());
+
+		expect(tabs.map((tab) => tab.id)).not.toContain('contact');
+	});
+
 	it('honors existing capability flags', () => {
 		const tabs = getProfileTabs(
 			{ ...AUTHOR, is_owner: true },

--- a/frontend/src/features/shared/icons/playlist-play.svg
+++ b/frontend/src/features/shared/icons/playlist-play.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M19 9H2v2h17V9zm0-4H2v2h17V5zM2 15h13v-2H2v2zm15-2v6l5-3-5-3z"/></svg>

--- a/frontend/src/features/video-viewer/components/community-impact/CommunityImpactSection.jsx
+++ b/frontend/src/features/video-viewer/components/community-impact/CommunityImpactSection.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useId, useMemo, useState } from 'react';
 import { Button, Text } from '../../../shared/components';
 import { AddImpactDialog } from './AddImpactDialog';
 import { ImpactCard } from './ImpactCard';
@@ -106,6 +106,8 @@ export function CommunityImpactSection({
 	title = "Film's Impact",
 }) {
 	const [dialogOpen, setDialogOpen] = useState(false);
+	const headingId = useId();
+	const showHeader = Boolean(title) || Boolean(description);
 	const cards = useMemo(
 		() =>
 			COMMUNITY_IMPACT_CATEGORIES.map(({ value }) => {
@@ -141,26 +143,38 @@ export function CommunityImpactSection({
 	}
 
 	return (
-		<section aria-labelledby="community-impact-heading" className="w-full text-text-primary">
-			<div className="flex flex-col gap-space-base lg:flex-row lg:items-center lg:justify-between">
-				<div className="max-w-[calc(var(--size-96)*6+var(--size-64))]">
-					<Text id="community-impact-heading" variant="h5-bold" as="h2" className="m-0 text-text-primary">
-						{title}
-					</Text>
-					<Text variant="body-14" color="meta" className="m-0 mt-space-xs">
-						{description}
-					</Text>
-				</div>
+		<section
+			aria-labelledby={title ? headingId : undefined}
+			aria-label={title ? undefined : 'Community impact'}
+			className="w-full text-text-primary"
+		>
+			{showHeader || canAdd ? (
+				<div className="flex flex-col gap-space-base lg:flex-row lg:items-center lg:justify-between">
+					{showHeader ? (
+						<div className="max-w-[calc(var(--size-96)*6+var(--size-64))]">
+							{title ? (
+								<Text id={headingId} variant="h5-bold" as="h2" className="m-0 text-text-primary">
+									{title}
+								</Text>
+							) : null}
+							{description ? (
+								<Text variant="body-14" color="meta" className="m-0 mt-space-xs">
+									{description}
+								</Text>
+							) : null}
+						</div>
+					) : null}
 
-				{canAdd ? (
-					<Button
-						className="w-full justify-center focus-visible:ring-2 focus-visible:ring-ring-focus sm:w-fit"
-						onClick={handleAddClick}
-					>
-						ADD IMPACT
-					</Button>
-				) : null}
-			</div>
+					{canAdd ? (
+						<Button
+							className="w-full justify-center focus-visible:ring-2 focus-visible:ring-ring-focus sm:w-fit"
+							onClick={handleAddClick}
+						>
+							ADD IMPACT
+						</Button>
+					) : null}
+				</div>
+			) : null}
 
 			{submitMessage ? (
 				<Text as="p" variant="body-14-bold" color="accent" className="m-0 mt-space-sm" aria-live="polite">
@@ -168,7 +182,7 @@ export function CommunityImpactSection({
 				</Text>
 			) : null}
 
-			<div className="mt-space-lg">
+			<div className={showHeader ? 'mt-space-lg' : ''}>
 				{populated ? (
 					<div className="grid grid-cols-1 gap-space-base lg:grid-cols-2">
 						{cards.map((card) => (

--- a/frontend/src/features/video-viewer/components/community-impact/CommunityImpactSection.jsx
+++ b/frontend/src/features/video-viewer/components/community-impact/CommunityImpactSection.jsx
@@ -107,7 +107,6 @@ export function CommunityImpactSection({
 }) {
 	const [dialogOpen, setDialogOpen] = useState(false);
 	const headingId = useId();
-	const showHeader = Boolean(title) || Boolean(description);
 	const cards = useMemo(
 		() =>
 			COMMUNITY_IMPACT_CATEGORIES.map(({ value }) => {
@@ -143,38 +142,26 @@ export function CommunityImpactSection({
 	}
 
 	return (
-		<section
-			aria-labelledby={title ? headingId : undefined}
-			aria-label={title ? undefined : 'Community impact'}
-			className="w-full text-text-primary"
-		>
-			{showHeader || canAdd ? (
-				<div className="flex flex-col gap-space-base lg:flex-row lg:items-center lg:justify-between">
-					{showHeader ? (
-						<div className="max-w-[calc(var(--size-96)*6+var(--size-64))]">
-							{title ? (
-								<Text id={headingId} variant="h5-bold" as="h2" className="m-0 text-text-primary">
-									{title}
-								</Text>
-							) : null}
-							{description ? (
-								<Text variant="body-14" color="meta" className="m-0 mt-space-xs">
-									{description}
-								</Text>
-							) : null}
-						</div>
-					) : null}
-
-					{canAdd ? (
-						<Button
-							className="w-full justify-center focus-visible:ring-2 focus-visible:ring-ring-focus sm:w-fit"
-							onClick={handleAddClick}
-						>
-							ADD IMPACT
-						</Button>
-					) : null}
+		<section aria-labelledby={headingId} className="w-full text-text-primary">
+			<div className="flex flex-col gap-space-base lg:flex-row lg:items-center lg:justify-between">
+				<div className="max-w-[calc(var(--size-96)*6+var(--size-64))]">
+					<Text id={headingId} variant="h5-bold" as="h2" className="m-0 text-text-primary">
+						{title}
+					</Text>
+					<Text variant="body-14" color="meta" className="m-0 mt-space-xs">
+						{description}
+					</Text>
 				</div>
-			) : null}
+
+				{canAdd ? (
+					<Button
+						className="w-full justify-center focus-visible:ring-2 focus-visible:ring-ring-focus sm:w-fit"
+						onClick={handleAddClick}
+					>
+						ADD IMPACT
+					</Button>
+				) : null}
+			</div>
 
 			{submitMessage ? (
 				<Text as="p" variant="body-14-bold" color="accent" className="m-0 mt-space-sm" aria-live="polite">
@@ -182,7 +169,7 @@ export function CommunityImpactSection({
 				</Text>
 			) : null}
 
-			<div className={showHeader ? 'mt-space-lg' : ''}>
+			<div className="mt-space-lg">
 				{populated ? (
 					<div className="grid grid-cols-1 gap-space-base lg:grid-cols-2">
 						{cards.map((card) => (

--- a/frontend/src/static/css/tailwind.css
+++ b/frontend/src/static/css/tailwind.css
@@ -1004,6 +1004,10 @@ body {
 	--bg-badge-danger: var(--cinemata-red-950);
 	--bg-badge-accent: var(--cinemata-sunset-horizon-800);
 	--bg-badge-muted: var(--cinemata-pacific-deep-700);
+	/* Film duration pill on the profile My Notes thumbnail — light pill in both
+	   themes per the notes-in-profile design spec. */
+	--bg-note-thumbnail-duration: var(--cinemata-strait-blue-50);
+	--text-note-thumbnail-duration: var(--cinemata-pacific-deep-900);
 	--bg-overlay-dark: var(--cinemata-pacific-deep-900);
 	--bg-chrome: var(--cinemata-pacific-deep-800);
 	--bg-chrome-hover: var(--cinemata-pacific-deep-700);
@@ -1085,6 +1089,7 @@ body {
 	--border-chrome: var(--cinemata-pacific-deep-700);
 	--border-input: var(--cinemata-coral-reef-400p);
 	--border-danger: var(--cinemata-red-500);
+	--border-note-divider: var(--cinemata-pacific-deep-600p);
 	--border-panel-divider: #dfeff4;
 	--border-disclosure-content: var(--cinemata-pacific-deep-300);
 	--border-disclosure-trigger: var(--cinemata-pacific-deep-300);
@@ -1112,6 +1117,9 @@ body.dark_theme {
 	--bg-primary: var(--cinemata-strait-blue-500);
 	--bg-primary-hover: var(--cinemata-strait-blue-700);
 	--bg-button-playlist-active: var(--cinemata-strait-blue-700);
+	/* Duration pill stays a light pill in dark theme too (notes-in-profile design). */
+	--bg-note-thumbnail-duration: var(--cinemata-strait-blue-50);
+	--text-note-thumbnail-duration: var(--cinemata-pacific-deep-900);
 	--bg-secondary: var(--cinemata-sunset-horizon-500);
 	--bg-secondary-hover: var(--cinemata-sunset-horizon-400p);
 	--bg-emblem-blue-deep: var(--cinemata-pacific-deep-950);
@@ -1163,6 +1171,7 @@ body.dark_theme {
 	--border-divider: var(--cinemata-pacific-deep-600p);
 	--border-strong: var(--cinemata-pacific-deep-400);
 	--border-input: var(--cinemata-sunset-horizon-400p);
+	--border-note-divider: var(--cinemata-pacific-deep-600p);
 	--border-panel-divider: var(--cinemata-pacific-deep-500);
 	--border-disclosure-content: var(--cinemata-pacific-deep-500);
 	--border-disclosure-trigger: transparent;
@@ -1187,6 +1196,7 @@ body.dark_theme {
 	--color-bg-badge-danger: var(--bg-badge-danger);
 	--color-bg-badge-accent: var(--bg-badge-accent);
 	--color-bg-badge-muted: var(--bg-badge-muted);
+	--color-bg-note-thumbnail-duration: var(--bg-note-thumbnail-duration);
 	--color-bg-overlay-dark: var(--bg-overlay-dark);
 	--color-bg-chrome: var(--bg-chrome);
 	--color-bg-chrome-hover: var(--bg-chrome-hover);
@@ -1239,6 +1249,7 @@ body.dark_theme {
 	--color-text-on-primary: var(--text-on-primary);
 	--color-text-on-chrome: var(--text-on-chrome);
 	--color-text-on-chrome-muted: var(--text-on-chrome-muted);
+	--color-text-note-thumbnail-duration: var(--text-note-thumbnail-duration);
 	--color-text-profile-section-icon: var(--text-profile-section-icon);
 	--color-text-link: var(--text-link);
 	--color-text-link-hover: var(--text-link-hover);
@@ -1269,6 +1280,7 @@ body.dark_theme {
 	--color-border-chrome: var(--border-chrome);
 	--color-border-input: var(--border-input);
 	--color-border-danger: var(--border-danger);
+	--color-border-note-divider: var(--border-note-divider);
 	--color-border-panel-divider: var(--border-panel-divider);
 	--color-border-disclosure-content: var(--border-disclosure-content);
 	--color-border-disclosure-trigger: var(--border-disclosure-trigger);

--- a/frontend/src/storybook/Colors.mdx
+++ b/frontend/src/storybook/Colors.mdx
@@ -38,6 +38,7 @@ This page is the working reference for the token catalogue. For the underlying d
 - **`text-text-link`** — inline links, "View all" affordances. Light: `sunset-horizon-700` / Dark: `sunset-horizon-200`
 - **`text-text-link-hover`** — hover state for `text-text-link`. Light: `sunset-horizon-800` / Dark: `sunset-horizon-100`
 - **`text-text-accent`** — theme-agnostic orange accent (helper text, brand emphasis). Constant `sunset-horizon-400p`.
+- **`text-text-note-thumbnail-duration`** — profile note thumbnail duration pill text. Constant `pacific-deep-900`.
 - **`text-text-dialog-accent`** — decorative hero glyph in a dialog header (e.g. Add Impact heart). Constant `strait-blue-400`.
 - **`text-text-danger`** — error labels. Constant `red-500`.
 - **`text-text-success`** — success messages. Light: `green-600` / Dark: `green-500`
@@ -96,6 +97,7 @@ This page is the working reference for the token catalogue. For the underlying d
 - **`bg-bg-control-checked`** — checked state of a checkbox/radio control. Light: `pacific-deep-100` / Dark: `sunset-horizon-400p`
 - **`bg-bg-chip-active`** — selected/active chip fill. Constant `sunset-horizon-400p`.
 - **`bg-bg-chip`** — inactive/subtle chip fill. Light: `strait-blue-100` / Dark: `pacific-deep-700`
+- **`bg-bg-note-thumbnail-duration`** — profile note thumbnail duration pill. Constant `strait-blue-50`.
 
 <Heading>Border tokens</Heading>
 
@@ -108,6 +110,7 @@ This page is the working reference for the token catalogue. For the underlying d
 - **`border-border-chrome`** — hairlines on always-dark chrome (search dropdown dividers, mobile overlay header border). Constant `pacific-deep-700`.
 - **`border-border-input`** — TextField focused/active border. Light: `coral-reef-400p` / Dark: `sunset-horizon-400p`
 - **`border-border-danger`** — error-state borders. Constant `red-500`.
+- **`border-border-note-divider`** — standalone divider in profile note entries. Constant `pacific-deep-600p`.
 - **`border-border-panel-divider`** — dividers and category borders inside a panel. Light: `#dfeff4` / Dark: `pacific-deep-500`
 - **`border-border-disclosure-content`** — disclosure/accordion content divider. Light: `pacific-deep-300` / Dark: `pacific-deep-500`
 - **`border-border-disclosure-trigger`** — closed disclosure/accordion trigger divider. Light: `pacific-deep-300` / Dark: `transparent`

--- a/tests/test_profile_revamp.py
+++ b/tests/test_profile_revamp.py
@@ -148,6 +148,29 @@ class ProfileRevampViewTests(TestCase):
 
         self.assertEqual(response.status_code, 204)
 
+    def test_contact_post_unknown_username_returns_404(self):
+        self.client.force_login(self.viewer)
+
+        response = self.client.post(
+            "/api/v1/users/does-not-exist/contact",
+            data={"subject": "Hi", "body": "Hello"},
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_contact_post_missing_subject_or_body_returns_400(self):
+        self.client.force_login(self.viewer)
+
+        for payload in ({"body": "Hello"}, {"subject": "Hi"}):
+            response = self.client.post(
+                f"/api/v1/users/{self.owner.username}/contact",
+                data=payload,
+                content_type="application/json",
+            )
+
+            self.assertEqual(response.status_code, 400, msg=payload)
+
     def test_user_detail_exposes_profile_header_fields(self):
         response = self.client.get(f"/api/v1/users/{self.owner.username}")
 

--- a/tests/test_profile_revamp.py
+++ b/tests/test_profile_revamp.py
@@ -2,7 +2,9 @@ from copy import deepcopy
 from datetime import date
 
 from django.conf import settings
+from django.db import connection
 from django.test import TestCase, override_settings
+from django.test.utils import CaptureQueriesContext
 
 from files.models import CommunityImpact, Media, PrivateJournalNote
 from files.tests.helpers import create_test_media
@@ -98,16 +100,15 @@ class ProfileRevampViewTests(TestCase):
             fetch_redirect_response=False,
         )
 
-    def test_anonymous_is_redirected_from_contact_tab(self):
-        # allow_contact defaults to True, but the tab still requires an
-        # authenticated viewer since the contact POST does.
-        response = self.client.get(f"/user/{self.owner.username}/contact")
+    def test_anonymous_contact_tab_redirects_to_login(self):
+        # An anonymous visitor following a shared /contact link is sent to
+        # login with a next back to the tab, like other gated pages.
+        contact_path = f"/user/{self.owner.username}/contact"
+        response = self.client.get(contact_path)
 
-        self.assertRedirects(
-            response,
-            self.owner.get_absolute_url(),
-            fetch_redirect_response=False,
-        )
+        self.assertEqual(response.status_code, 302)
+        self.assertIn(settings.LOGIN_URL, response.url)
+        self.assertIn(contact_path, response.url)
 
     def test_contact_flag_is_false_for_anonymous_viewer(self):
         response = self.client.get(self.owner.get_absolute_url())
@@ -148,6 +149,42 @@ class ProfileRevampViewTests(TestCase):
 
         self.assertEqual(response.status_code, 204)
 
+    def test_curator_cannot_contact_disallowed_profile(self):
+        # The send gate is editor-only (allow_contact or editor); a curator is a
+        # distinct role and does NOT override allow_contact=False. This keeps the
+        # pre-existing contact/email behaviour unchanged.
+        self.owner.allow_contact = False
+        self.owner.save(update_fields=["allow_contact"])
+        curator = User.objects.create_user(username="a-curator", password="testpass")
+        curator.is_curator = True
+        curator.save(update_fields=["is_curator"])
+        self.client.force_login(curator)
+
+        response = self.client.post(
+            f"/api/v1/users/{self.owner.username}/contact",
+            data={"subject": "Hi", "body": "Hello"},
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_editor_can_contact_disallowed_profile(self):
+        # Editors retain the override the original gate honoured.
+        self.owner.allow_contact = False
+        self.owner.save(update_fields=["allow_contact"])
+        editor = User.objects.create_user(username="an-editor", password="testpass")
+        editor.is_editor = True
+        editor.save(update_fields=["is_editor"])
+        self.client.force_login(editor)
+
+        response = self.client.post(
+            f"/api/v1/users/{self.owner.username}/contact",
+            data={"subject": "Hi", "body": "Hello"},
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 204)
+
     def test_contact_post_unknown_username_returns_404(self):
         self.client.force_login(self.viewer)
 
@@ -170,6 +207,36 @@ class ProfileRevampViewTests(TestCase):
             )
 
             self.assertEqual(response.status_code, 400, msg=payload)
+
+    def test_contact_post_rejects_subject_with_line_break(self):
+        # A newline in the subject would raise BadHeaderError (500) when built
+        # into the email header; it must be a clean 400 instead.
+        self.client.force_login(self.viewer)
+
+        response = self.client.post(
+            f"/api/v1/users/{self.owner.username}/contact",
+            data={"subject": "Hi\nBcc: evil@example.com", "body": "Hello"},
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+
+    def test_contact_post_rejects_overlong_fields(self):
+        self.client.force_login(self.viewer)
+
+        long_subject = self.client.post(
+            f"/api/v1/users/{self.owner.username}/contact",
+            data={"subject": "x" * 201, "body": "Hello"},
+            content_type="application/json",
+        )
+        self.assertEqual(long_subject.status_code, 400)
+
+        long_body = self.client.post(
+            f"/api/v1/users/{self.owner.username}/contact",
+            data={"subject": "Hi", "body": "x" * 5001},
+            content_type="application/json",
+        )
+        self.assertEqual(long_body.status_code, 400)
 
     def test_user_detail_exposes_profile_header_fields(self):
         response = self.client.get(f"/api/v1/users/{self.owner.username}")
@@ -220,7 +287,8 @@ class UserCommunityImpactApiTests(TestCase):
             [entry["title"] for entry in film["impact"][CommunityImpact.SCREENING]["entries"]],
             ["Approved screening"],
         )
-        self.assertEqual(film["impact"][CommunityImpact.FEATURED], {"entries": [], "totalCount": 0})
+        self.assertEqual(film["impact"][CommunityImpact.FEATURED], {"entries": []})
+        self.assertFalse(response.json()["has_more"])
 
     def test_endpoint_groups_entries_per_film(self):
         other_media = create_test_media(self.author)
@@ -254,7 +322,59 @@ class UserCommunityImpactApiTests(TestCase):
         response = self.client.get(f"/api/v1/users/{self.author.username}/community-impacts")
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), {"films": []})
+        self.assertEqual(response.json(), {"films": [], "has_more": False})
+
+    def test_endpoint_excludes_saves_and_curated_categories(self):
+        # saves is summary-only and curated is never shown, so neither should
+        # appear in the film's impact buckets (they must match the UI).
+        self._create_impact(status=CommunityImpact.APPROVED, title="A screening")
+        for category in (CommunityImpact.SAVES, CommunityImpact.CURATED):
+            CommunityImpact.objects.create(
+                media=self.media,
+                user=self.submitter,
+                category=category,
+                status=CommunityImpact.APPROVED,
+                title=f"{category} entry",
+                event_date=date(2026, 6, 30),
+            )
+
+        response = self.client.get(f"/api/v1/users/{self.author.username}/community-impacts")
+
+        self.assertEqual(response.status_code, 200)
+        buckets = response.json()["films"][0]["impact"]
+        self.assertNotIn(CommunityImpact.SAVES, buckets)
+        self.assertNotIn(CommunityImpact.CURATED, buckets)
+        self.assertIn(CommunityImpact.SCREENING, buckets)
+
+    def test_endpoint_query_count_is_flat_across_films(self):
+        # prefetch_related("media__category") keeps the query count from scaling
+        # with the number of films (MediaSerializer.categories_info walks m2m).
+        def make_film(title):
+            m = create_test_media(self.author)
+            Media.objects.filter(pk=m.pk).update(title=title)
+            CommunityImpact.objects.create(
+                media=m,
+                user=self.submitter,
+                category=CommunityImpact.SCREENING,
+                status=CommunityImpact.APPROVED,
+                title=f"screening for {title}",
+                event_date=date(2026, 6, 30),
+            )
+            return m
+
+        url = f"/api/v1/users/{self.author.username}/community-impacts"
+
+        make_film("Film A")
+        with CaptureQueriesContext(connection) as one_film:
+            self.client.get(url)
+
+        make_film("Film B")
+        make_film("Film C")
+        with CaptureQueriesContext(connection) as three_films:
+            self.client.get(url)
+
+        # Query count must not grow with the number of films.
+        self.assertEqual(len(three_films), len(one_film))
 
     def test_endpoint_does_not_expose_impacts_for_private_media(self):
         private_media = create_test_media(self.author, state="private")
@@ -270,7 +390,7 @@ class UserCommunityImpactApiTests(TestCase):
         response = self.client.get(f"/api/v1/users/{self.author.username}/community-impacts")
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), {"films": []})
+        self.assertEqual(response.json(), {"films": [], "has_more": False})
 
     def test_endpoint_returns_not_found_for_unknown_author(self):
         response = self.client.get("/api/v1/users/missing-user/community-impacts")
@@ -307,7 +427,7 @@ class UserPrivateJournalApiTests(TestCase):
 
         self.assertEqual(response.status_code, 403)
 
-    def test_owner_sees_own_notes_with_media_context(self):
+    def test_owner_sees_latest_note_per_film_with_media_context(self):
         self._create_note(text="A key moment", timestamp_seconds=42)
         self.client.force_login(self.owner)
 
@@ -319,9 +439,46 @@ class UserPrivateJournalApiTests(TestCase):
         note = results[0]
         self.assertEqual(note["text"], "A key moment")
         self.assertEqual(note["timestamp_seconds"], 42.0)
+        self.assertEqual(note["note_count"], 1)
         # Media context is embedded so the frontend can render + deep-link.
         self.assertEqual(note["media"]["friendly_token"], self.media.friendly_token)
         self.assertEqual(note["media"]["title"], self.media.title)
+
+    def test_notes_are_aggregated_to_one_row_per_film(self):
+        # Three notes on one film collapse to a single row: latest note + count.
+        self._create_note(text="First note")
+        self._create_note(text="Second note")
+        latest = self._create_note(text="Latest note")
+        self.client.force_login(self.owner)
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        results = response.json()["results"]
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["text"], "Latest note")
+        self.assertEqual(results[0]["uid"], str(latest.uid))
+        self.assertEqual(results[0]["note_count"], 3)
+
+    def test_films_are_ordered_by_most_recent_note(self):
+        other_media = create_test_media(self.owner)
+        Media.objects.filter(pk=other_media.pk).update(title="Second Film")
+        # Note on the first film, then a newer note on the second film.
+        self._create_note(text="Older film note")
+        PrivateJournalNote.objects.create(
+            media=other_media,
+            user=self.owner,
+            text="Newer film note",
+            timestamp_seconds=0,
+        )
+        self.client.force_login(self.owner)
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        tokens = [row["media"]["friendly_token"] for row in response.json()["results"]]
+        # Most recently noted film first.
+        self.assertEqual(tokens, [other_media.friendly_token, self.media.friendly_token])
 
     def test_owner_does_not_see_other_users_notes(self):
         # A note authored by someone else on the owner's media must not leak.

--- a/tests/test_profile_revamp.py
+++ b/tests/test_profile_revamp.py
@@ -4,7 +4,7 @@ from datetime import date
 from django.conf import settings
 from django.test import TestCase, override_settings
 
-from files.models import CommunityImpact
+from files.models import CommunityImpact, Media
 from files.tests.helpers import create_test_media
 from users.models import User
 
@@ -65,6 +65,89 @@ class ProfileRevampViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context["active_tab"], "impact")
 
+    def test_non_owner_can_open_contact_tab_when_contact_allowed(self):
+        self.client.force_login(self.viewer)
+
+        response = self.client.get(f"/user/{self.owner.username}/contact")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["active_tab"], "contact")
+        self.assertTrue(response.context["PROFILE_INITIAL_DATA"]["can_contact"])
+
+    def test_contact_tab_redirects_when_contact_disallowed(self):
+        self.owner.allow_contact = False
+        self.owner.save(update_fields=["allow_contact"])
+        self.client.force_login(self.viewer)
+
+        response = self.client.get(f"/user/{self.owner.username}/contact")
+
+        self.assertRedirects(
+            response,
+            self.owner.get_absolute_url(),
+            fetch_redirect_response=False,
+        )
+
+    def test_owner_is_redirected_from_own_contact_tab(self):
+        self.client.force_login(self.owner)
+
+        response = self.client.get(f"/user/{self.owner.username}/contact")
+
+        self.assertRedirects(
+            response,
+            self.owner.get_absolute_url(),
+            fetch_redirect_response=False,
+        )
+
+    def test_anonymous_is_redirected_from_contact_tab(self):
+        # allow_contact defaults to True, but the tab still requires an
+        # authenticated viewer since the contact POST does.
+        response = self.client.get(f"/user/{self.owner.username}/contact")
+
+        self.assertRedirects(
+            response,
+            self.owner.get_absolute_url(),
+            fetch_redirect_response=False,
+        )
+
+    def test_contact_flag_is_false_for_anonymous_viewer(self):
+        response = self.client.get(self.owner.get_absolute_url())
+
+        self.assertFalse(response.context["PROFILE_INITIAL_DATA"]["can_contact"])
+
+    def test_contact_post_requires_authentication(self):
+        response = self.client.post(
+            f"/api/v1/users/{self.owner.username}/contact",
+            data={"subject": "Hi", "body": "Hello"},
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 401)
+
+    def test_contact_post_forbidden_when_contact_disallowed(self):
+        self.owner.allow_contact = False
+        self.owner.save(update_fields=["allow_contact"])
+        self.client.force_login(self.viewer)
+
+        response = self.client.post(
+            f"/api/v1/users/{self.owner.username}/contact",
+            data={"subject": "Hi", "body": "Hello"},
+            content_type="application/json",
+        )
+
+        # Must NOT be a silent 204 success — the message was not sent.
+        self.assertEqual(response.status_code, 403)
+
+    def test_contact_post_succeeds_when_allowed(self):
+        self.client.force_login(self.viewer)
+
+        response = self.client.post(
+            f"/api/v1/users/{self.owner.username}/contact",
+            data={"subject": "Hi", "body": "Hello"},
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 204)
+
     def test_user_detail_exposes_profile_header_fields(self):
         response = self.client.get(f"/api/v1/users/{self.owner.username}")
 
@@ -98,24 +181,57 @@ class UserCommunityImpactApiTests(TestCase):
             event_date=date(2026, 6, 30),
         )
 
-    def test_endpoint_groups_only_approved_entries(self):
+    def test_endpoint_groups_only_approved_entries_under_their_film(self):
         self._create_impact(status=CommunityImpact.APPROVED, title="Approved screening")
         self._create_impact(status=CommunityImpact.WAITING_APPROVAL, title="Pending screening")
 
         response = self.client.get(f"/api/v1/users/{self.author.username}/community-impacts")
 
         self.assertEqual(response.status_code, 200)
+        films = response.json()["films"]
+        self.assertEqual(len(films), 1)
+        film = films[0]
+        # Each film group carries its media so entries can be attributed.
+        self.assertEqual(film["media"]["title"], self.media.title)
         self.assertEqual(
-            [entry["title"] for entry in response.json()[CommunityImpact.SCREENING]["entries"]],
+            [entry["title"] for entry in film["impact"][CommunityImpact.SCREENING]["entries"]],
             ["Approved screening"],
         )
-        self.assertEqual(response.json()[CommunityImpact.FEATURED], {"entries": [], "totalCount": 0})
+        self.assertEqual(film["impact"][CommunityImpact.FEATURED], {"entries": [], "totalCount": 0})
 
-    def test_endpoint_returns_empty_groups_for_author_without_entries(self):
+    def test_endpoint_groups_entries_per_film(self):
+        other_media = create_test_media(self.author)
+        Media.objects.filter(pk=other_media.pk).update(title="Second Film")
+        other_media.refresh_from_db()
+        self._create_impact(status=CommunityImpact.APPROVED, title="First film screening")
+        CommunityImpact.objects.create(
+            media=other_media,
+            user=self.submitter,
+            category=CommunityImpact.FEATURED,
+            status=CommunityImpact.APPROVED,
+            title="Second film feature",
+            event_date=date(2026, 6, 30),
+        )
+
         response = self.client.get(f"/api/v1/users/{self.author.username}/community-impacts")
 
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(all(category == {"entries": [], "totalCount": 0} for category in response.json().values()))
+        films = response.json()["films"]
+        self.assertEqual(len(films), 2)
+        entries_by_token = {
+            film["media"]["friendly_token"]: [
+                entry["title"] for bucket in film["impact"].values() for entry in bucket["entries"]
+            ]
+            for film in films
+        }
+        self.assertEqual(entries_by_token[self.media.friendly_token], ["First film screening"])
+        self.assertEqual(entries_by_token[other_media.friendly_token], ["Second film feature"])
+
+    def test_endpoint_returns_no_films_for_author_without_entries(self):
+        response = self.client.get(f"/api/v1/users/{self.author.username}/community-impacts")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"films": []})
 
     def test_endpoint_does_not_expose_impacts_for_private_media(self):
         private_media = create_test_media(self.author, state="private")
@@ -131,7 +247,7 @@ class UserCommunityImpactApiTests(TestCase):
         response = self.client.get(f"/api/v1/users/{self.author.username}/community-impacts")
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json()[CommunityImpact.SCREENING], {"entries": [], "totalCount": 0})
+        self.assertEqual(response.json(), {"films": []})
 
     def test_endpoint_returns_not_found_for_unknown_author(self):
         response = self.client.get("/api/v1/users/missing-user/community-impacts")

--- a/tests/test_profile_revamp.py
+++ b/tests/test_profile_revamp.py
@@ -4,7 +4,7 @@ from datetime import date
 from django.conf import settings
 from django.test import TestCase, override_settings
 
-from files.models import CommunityImpact, Media
+from files.models import CommunityImpact, Media, PrivateJournalNote
 from files.tests.helpers import create_test_media
 from users.models import User
 
@@ -253,3 +253,75 @@ class UserCommunityImpactApiTests(TestCase):
         response = self.client.get("/api/v1/users/missing-user/community-impacts")
 
         self.assertEqual(response.status_code, 404)
+
+
+class UserPrivateJournalApiTests(TestCase):
+    def setUp(self):
+        self.owner = User.objects.create_user(username="notes-owner", password="testpass", name="Notes Owner")
+        self.other = User.objects.create_user(username="notes-other", password="testpass")
+        self.media = create_test_media(self.owner)
+        self.url = f"/api/v1/users/{self.owner.username}/private-journal"
+
+    def _create_note(self, *, text, timestamp_seconds=0.0):
+        return PrivateJournalNote.objects.create(
+            media=self.media,
+            user=self.owner,
+            text=text,
+            timestamp_seconds=timestamp_seconds,
+        )
+
+    def test_anonymous_is_denied(self):
+        # DRF SessionAuthentication returns 403 (not 401) for unauthenticated
+        # requests since it sends no WWW-Authenticate challenge header.
+        response = self.client.get(self.url)
+
+        self.assertIn(response.status_code, (401, 403))
+
+    def test_other_user_is_forbidden(self):
+        self.client.force_login(self.other)
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_owner_sees_own_notes_with_media_context(self):
+        self._create_note(text="A key moment", timestamp_seconds=42)
+        self.client.force_login(self.owner)
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        results = response.json()["results"]
+        self.assertEqual(len(results), 1)
+        note = results[0]
+        self.assertEqual(note["text"], "A key moment")
+        self.assertEqual(note["timestamp_seconds"], 42.0)
+        # Media context is embedded so the frontend can render + deep-link.
+        self.assertEqual(note["media"]["friendly_token"], self.media.friendly_token)
+        self.assertEqual(note["media"]["title"], self.media.title)
+
+    def test_owner_does_not_see_other_users_notes(self):
+        # A note authored by someone else on the owner's media must not leak.
+        other_media = create_test_media(self.other)
+        PrivateJournalNote.objects.create(
+            media=other_media,
+            user=self.other,
+            text="Other user's private note",
+            timestamp_seconds=0,
+        )
+        self._create_note(text="Owner's note")
+        self.client.force_login(self.owner)
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        texts = [note["text"] for note in response.json()["results"]]
+        self.assertEqual(texts, ["Owner's note"])
+
+    def test_owner_with_no_notes_gets_empty_results(self):
+        self.client.force_login(self.owner)
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["results"], [])

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -10,17 +10,26 @@ VIDEO_COUNTRIES_DICT = dict(video_countries)
 
 
 class ProfilePrivateJournalNoteSerializer(PrivateJournalNoteSerializer):
-    """Notes aggregated on the profile carry their media context so each entry
-    can render a thumbnail card and deep-link back to the film at its timestamp.
+    """The latest note for a film on the profile "My Notes" tab. Carries media
+    context (so the card can render a thumbnail and deep-link back to the film
+    at its timestamp) and ``note_count`` — the total notes the user has on that
+    film, since the tab shows one card per film with a "View all N" link.
 
-    The per-media viewer serializer omits this because the viewer already knows
-    its own media.
+    The per-media viewer serializer omits both because the viewer already knows
+    its own media and lists notes individually.
     """
 
     media = serializers.SerializerMethodField()
+    note_count = serializers.SerializerMethodField()
 
     class Meta(PrivateJournalNoteSerializer.Meta):
-        fields = PrivateJournalNoteSerializer.Meta.fields + ("media",)
+        fields = PrivateJournalNoteSerializer.Meta.fields + ("media", "note_count")
+
+    def get_note_count(self, obj):
+        # Aggregated per-film count supplied by the view; falls back to 1 (this
+        # note) when the serializer is used outside the aggregated endpoint.
+        note_counts = self.context.get("note_counts") or {}
+        return note_counts.get(obj.media_id, 1)
 
     def get_media(self, obj):
         media = obj.media

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -1,11 +1,43 @@
 from rest_framework import serializers
 
 from files.lists import video_countries
+from files.serializers import PrivateJournalNoteSerializer
 
 from .models import User
 
 # Pre-build country dict once at module level to avoid rebuilding on every serialization
 VIDEO_COUNTRIES_DICT = dict(video_countries)
+
+
+class ProfilePrivateJournalNoteSerializer(PrivateJournalNoteSerializer):
+    """Notes aggregated on the profile carry their media context so each entry
+    can render a thumbnail card and deep-link back to the film at its timestamp.
+
+    The per-media viewer serializer omits this because the viewer already knows
+    its own media.
+    """
+
+    media = serializers.SerializerMethodField()
+
+    class Meta(PrivateJournalNoteSerializer.Meta):
+        fields = PrivateJournalNoteSerializer.Meta.fields + ("media",)
+
+    def get_media(self, obj):
+        media = obj.media
+        request = self.context.get("request")
+        thumbnail_url = media.thumbnail_url
+        url = media.get_absolute_url()
+        if request is not None:
+            if thumbnail_url:
+                thumbnail_url = request.build_absolute_uri(thumbnail_url)
+            url = request.build_absolute_uri(url)
+        return {
+            "title": media.title,
+            "friendly_token": media.friendly_token,
+            "url": url,
+            "thumbnail_url": thumbnail_url,
+            "duration": media.duration,
+        }
 
 
 class UserSerializer(serializers.ModelSerializer):

--- a/users/urls.py
+++ b/users/urls.py
@@ -82,6 +82,11 @@ urlpatterns = [
         name="api_user_community_impacts",
     ),
     re_path(
+        rf"^api/v1/users/(?P<username>{USERNAME_RE})/private-journal$",
+        views.UserPrivateJournalList.as_view(),
+        name="api_user_private_journal",
+    ),
+    re_path(
         rf"^api/v1/users/(?P<username>{USERNAME_RE})/contact",
         views.contact_user,
         name="api_contact_user",

--- a/users/urls.py
+++ b/users/urls.py
@@ -42,6 +42,11 @@ urlpatterns = [
         name="get_user_impact",
     ),
     re_path(
+        rf"^user/(?P<username>{USERNAME_RE})/contact$",
+        views.view_user_contact,
+        name="get_user_contact",
+    ),
+    re_path(
         rf"^user/(?P<username>{USERNAME_RE})/history$",
         views.view_user_history,
         name="get_user_history",

--- a/users/views.py
+++ b/users/views.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.mail import EmailMessage
@@ -30,6 +32,8 @@ from files.serializers import CommunityImpactSerializer, MediaSerializer
 from .forms import ChannelForm, UserForm
 from .models import Channel, User
 from .serializers import ProfilePrivateJournalNoteSerializer, UserDetailSerializer, UserSerializer
+
+logger = logging.getLogger(__name__)
 
 
 def get_user(username):
@@ -264,8 +268,17 @@ def contact_user(request, username):
     recipient = user
     sender_display_name = sender.name or sender.username
     recipient_display_name = recipient.name or recipient.username
-    form_subject = request.data.get("subject", "").strip()
-    form_body = request.data.get("body", "").strip()
+    form_subject = request.data.get("subject", "")
+    form_body = request.data.get("body", "")
+
+    if not isinstance(form_subject, str) or not isinstance(form_body, str):
+        return Response(
+            {"detail": "Subject and body are required"},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    form_subject = form_subject.strip()
+    form_body = form_body.strip()
 
     if not form_subject or not form_body:
         return Response(
@@ -287,7 +300,12 @@ def contact_user(request, username):
         to=[recipient.email],
         reply_to=[sender.email],
     )
-    recipient_email.send(fail_silently=True)
+    if not recipient_email.send(fail_silently=True):
+        logger.error(
+            "Failed to send contact email from user %s to user %s (recipient)",
+            sender.username,
+            recipient.username,
+        )
 
     # Copy to sender
     timestamp = timezone.now().strftime("%B %d, %Y at %I:%M %p")
@@ -305,7 +323,12 @@ def contact_user(request, username):
         from_email=settings.DEFAULT_FROM_EMAIL,
         to=[sender.email],
     )
-    sender_copy.send(fail_silently=True)
+    if not sender_copy.send(fail_silently=True):
+        logger.error(
+            "Failed to send contact email copy to sender %s (message to %s)",
+            sender.username,
+            recipient.username,
+        )
 
     return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/users/views.py
+++ b/users/views.py
@@ -2,8 +2,9 @@ import logging
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.views import redirect_to_login
 from django.core.mail import EmailMessage
-from django.db.models import Case, Q, Value, When
+from django.db.models import Case, Count, Max, Q, Value, When
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
 from django.utils import timezone
@@ -27,7 +28,7 @@ from cms.ui_variant import resolve_template
 from files.lists import video_countries
 from files.methods import is_curator, is_mediacms_editor, is_mediacms_manager
 from files.models import CommunityImpact, PrivateJournalNote
-from files.serializers import CommunityImpactSerializer, MediaSerializer
+from files.serializers import CommunityImpactSerializer
 
 from .forms import ChannelForm, UserForm
 from .models import Channel, User
@@ -48,14 +49,17 @@ def can_contact_user(viewer, target):
     """Whether ``viewer`` may send a contact message to ``target``.
 
     A single source of truth shared by the profile bootstrap (``can_contact``),
-    the Contact tab view, and the ``contact_user`` POST endpoint so the tab is
-    only shown when the send will actually succeed. The viewer must be
+    the Contact tab view, and the ``contact_user`` POST endpoint so the modern
+    tab is only shown when the send will actually succeed. The viewer must be
     authenticated and not the target; the target must allow contact, unless the
-    viewer is an editor/curator (override roles).
+    viewer is an editor (the override role the original ``contact_user`` gate
+    honoured). Curators are intentionally NOT included here — this PR does not
+    change the pre-existing contact/email behaviour, and the original send gate
+    was ``allow_contact or is_mediacms_editor`` only.
     """
     if not viewer.is_authenticated or viewer == target:
         return False
-    return bool(target.allow_contact or is_mediacms_editor(viewer) or is_curator(viewer))
+    return bool(target.allow_contact or is_mediacms_editor(viewer))
 
 
 def _profile_context(request, user, active_tab):
@@ -175,8 +179,12 @@ def view_user_contact(request, username):
     template = resolve_template(request, "profile")
     if request.ui_variant == "legacy":
         return HttpResponseRedirect(user.get_absolute_url())
-    # Contact is a public-facing tab, but only for authenticated non-owners on
-    # profiles that allow contact (mirrors the contact_user POST gate).
+    # Contact requires an authenticated non-owner on a profile that accepts
+    # contact (mirrors the contact_user POST gate). Send anonymous visitors who
+    # follow a shared /contact link to login with a next back to the tab, like
+    # the rest of the site's gated pages; everyone else bounces to the profile.
+    if not request.user.is_authenticated:
+        return redirect_to_login(request.get_full_path())
     if not can_contact_user(request.user, user):
         return HttpResponseRedirect(user.get_absolute_url())
     return render(request, template, _profile_context(request, user, "contact"))
@@ -247,6 +255,13 @@ def edit_channel(request, friendly_token):
     return render(request, "cms/channel_edit.html", {"form": form})
 
 
+# Contact message length caps (characters). Subject sits in an email header;
+# body is the message. Generous but bounded so the endpoint cannot be abused to
+# send huge emails.
+CONTACT_SUBJECT_MAX_LENGTH = 200
+CONTACT_BODY_MAX_LENGTH = 5000
+
+
 @csrf_exempt
 @api_view(["POST"])
 def contact_user(request, username):
@@ -283,6 +298,29 @@ def contact_user(request, username):
     if not form_subject or not form_body:
         return Response(
             {"detail": "Subject and body are required"},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    # The subject is interpolated into an email Subject header. A newline would
+    # make Django raise BadHeaderError from EmailMessage.message() — which is
+    # NOT swallowed by fail_silently (that only covers SMTP send errors) — so an
+    # unvalidated newline turns into a 500. Reject it here as a 400 instead.
+    if "\n" in form_subject or "\r" in form_subject:
+        return Response(
+            {"detail": "Subject may not contain line breaks"},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    # Bound both fields so the endpoint cannot be used to send arbitrarily large
+    # emails (otherwise limited only by DATA_UPLOAD_MAX_MEMORY_SIZE).
+    if len(form_subject) > CONTACT_SUBJECT_MAX_LENGTH:
+        return Response(
+            {"detail": f"Subject may not exceed {CONTACT_SUBJECT_MAX_LENGTH} characters"},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+    if len(form_body) > CONTACT_BODY_MAX_LENGTH:
+        return Response(
+            {"detail": f"Message may not exceed {CONTACT_BODY_MAX_LENGTH} characters"},
             status=status.HTTP_400_BAD_REQUEST,
         )
 
@@ -488,20 +526,57 @@ class UserDetail(APIView):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
+def _impact_film_media(media, request):
+    """Minimal media payload for an Impact-tab film-row header.
+
+    ImpactFilmRow (mirroring the Playlist FilmRow) only needs title, url,
+    thumbnail, uploader, country, views, synopsis and duration. Building this
+    dict directly — instead of the full MediaSerializer — avoids that
+    serializer's per-media work (e.g. encoding/preview lookups), so the endpoint
+    stays flat regardless of how many films are returned, and keeps the payload
+    scoped to what the UI renders.
+    """
+    thumbnail_url = media.thumbnail_url
+    return {
+        "friendly_token": media.friendly_token,
+        "title": media.title,
+        "url": request.build_absolute_uri(media.get_absolute_url()),
+        "thumbnail_url": request.build_absolute_uri(thumbnail_url) if thumbnail_url else None,
+        "author_name": media.author_name,
+        "author_profile": request.build_absolute_uri(media.author_profile()),
+        "duration": media.duration,
+        "views": media.views,
+        "summary": media.summary,
+        "media_country_info": media.media_country_info,
+    }
+
+
 class UserCommunityImpactList(APIView):
     permission_classes = (permissions.AllowAny,)
+    # Entries kept per category per film. The profile UI lists individual
+    # entries, so this caps a single film's list; it does not cap the number of
+    # films (see film_limit).
     category_limit = 50
+    # Films returned per request. Community impact is manually submitted and
+    # admin-approved per film, so a single author realistically has impact on a
+    # handful of films (single digits in practice). This cap is defensive
+    # insurance against a future data explosion, surfaced via `has_more` rather
+    # than full pagination, which the tiny realistic bound does not warrant.
+    film_limit = 50
 
     def get(self, request, username):
         user = get_user(username)
         if not user:
             return Response({"detail": "user does not exist"}, status=status.HTTP_404_NOT_FOUND)
 
-        # "curated" is never surfaced on the profile Impact tab, so exclude it
-        # here — otherwise a film whose only entries are curated would produce
-        # an empty film group in the UI.
+        # Only categories the profile Impact tab actually renders (see
+        # ImpactFilmGroup). "curated" is never shown, and "saves" is a
+        # summary-only category with no listable entries, so excluding both
+        # keeps the payload aligned with the UI and avoids empty film groups.
         display_categories = [
-            category for category, _ in CommunityImpact.CATEGORY_CHOICES if category != CommunityImpact.CURATED
+            category
+            for category, _ in CommunityImpact.CATEGORY_CHOICES
+            if category not in (CommunityImpact.CURATED, CommunityImpact.SAVES)
         ]
         entries = (
             CommunityImpact.objects.filter(
@@ -512,6 +587,9 @@ class UserCommunityImpactList(APIView):
                 status=CommunityImpact.APPROVED,
                 category__in=display_categories,
             )
+            # select_related covers everything _impact_film_media reads (media +
+            # its user); it builds a minimal dict, so there is no per-film m2m or
+            # encoding lookup to prefetch.
             .select_related("media", "media__user", "user")
             .order_by("-event_date", "-add_date")
         )
@@ -519,32 +597,42 @@ class UserCommunityImpactList(APIView):
         # Group entries under the film they belong to so the profile Impact tab
         # can attribute each entry to its media (issue #810). Films keep the
         # order in which their most recent impact entry appears (entries are
-        # already ordered by -event_date, -add_date above).
+        # already ordered by -event_date, -add_date above). Films beyond
+        # film_limit are dropped and flagged via has_more.
         films = {}
+        has_more = False
         for entry in entries:
             media = entry.media
             film = films.get(media.pk)
             if film is None:
+                if len(films) >= self.film_limit:
+                    has_more = True
+                    continue
                 film = {
-                    "media": MediaSerializer(media, context={"request": request}).data,
-                    "impact": {category: {"entries": [], "totalCount": 0} for category in display_categories},
+                    "media": _impact_film_media(media, request),
+                    "impact": {category: {"entries": []} for category in display_categories},
                 }
                 films[media.pk] = film
 
             bucket = film["impact"][entry.category]
-            bucket["totalCount"] += 1
             if len(bucket["entries"]) < self.category_limit:
                 bucket["entries"].append(CommunityImpactSerializer(entry, context={"request": request}).data)
 
-        return Response({"films": list(films.values())})
+        return Response({"films": list(films.values()), "has_more": has_more})
 
 
 class UserPrivateJournalList(APIView):
-    """Author-scoped private journal notes for the profile "My Notes" tab.
+    """Author-scoped private journal notes for the profile "My Notes" tab,
+    aggregated by film.
+
+    The tab renders one card per film (latest note + a total count), so this
+    endpoint groups server-side and paginates by *film* — mirroring the Impact
+    endpoint's per-film shape — instead of returning every note and collapsing
+    on the client. That keeps the note count authoritative and the request
+    count constant regardless of how many notes a user has.
 
     Private notes: a user may only list their own notes, so this requires
-    authentication and matching the requested username (403 otherwise) — unlike
-    the public Impact endpoint.
+    authentication and matching the requested username (403 otherwise).
     """
 
     permission_classes = (permissions.IsAuthenticated,)
@@ -556,8 +644,36 @@ class UserPrivateJournalList(APIView):
                 status=status.HTTP_403_FORBIDDEN,
             )
 
-        notes = PrivateJournalNote.objects.filter(user=request.user).select_related("media").order_by("-add_date")
+        # One row per film the user has notes on, ordered by the most recent
+        # note, with the per-film note count. Uses the (user, -add_date) index.
+        films = (
+            PrivateJournalNote.objects.filter(user=request.user)
+            .values("media")
+            .annotate(note_count=Count("id"), latest_note_date=Max("add_date"))
+            .order_by("-latest_note_date")
+        )
+
         paginator = api_settings.DEFAULT_PAGINATION_CLASS()
-        page = paginator.paginate_queryset(notes, request)
-        serializer = ProfilePrivateJournalNoteSerializer(page, many=True, context={"request": request})
+        page = paginator.paginate_queryset(films, request)
+
+        # Fetch the latest note per film in the page. self.request.user scopes
+        # this to the owner, and there is one film row per media, so this is a
+        # bounded number of point lookups (page size), not an N+1 over all notes.
+        counts = {row["media"]: row["note_count"] for row in page}
+        latest_notes = []
+        for media_pk in counts:
+            note = (
+                PrivateJournalNote.objects.filter(user=request.user, media=media_pk)
+                .select_related("media")
+                .order_by("-add_date")
+                .first()
+            )
+            if note is not None:
+                latest_notes.append(note)
+
+        serializer = ProfilePrivateJournalNoteSerializer(
+            latest_notes,
+            many=True,
+            context={"request": request, "note_counts": counts},
+        )
         return paginator.get_paginated_response(serializer.data)

--- a/users/views.py
+++ b/users/views.py
@@ -24,7 +24,7 @@ from cms.ui_variant import resolve_template
 from files.lists import video_countries
 from files.methods import is_curator, is_mediacms_editor, is_mediacms_manager
 from files.models import CommunityImpact
-from files.serializers import CommunityImpactSerializer
+from files.serializers import CommunityImpactSerializer, MediaSerializer
 
 from .forms import ChannelForm, UserForm
 from .models import Channel, User
@@ -39,15 +39,31 @@ def get_user(username):
         return None
 
 
+def can_contact_user(viewer, target):
+    """Whether ``viewer`` may send a contact message to ``target``.
+
+    A single source of truth shared by the profile bootstrap (``can_contact``),
+    the Contact tab view, and the ``contact_user`` POST endpoint so the tab is
+    only shown when the send will actually succeed. The viewer must be
+    authenticated and not the target; the target must allow contact, unless the
+    viewer is an editor/curator (override roles).
+    """
+    if not viewer.is_authenticated or viewer == target:
+        return False
+    return bool(target.allow_contact or is_mediacms_editor(viewer) or is_curator(viewer))
+
+
 def _profile_context(request, user, active_tab):
     can_edit = bool(user == request.user or is_mediacms_manager(request.user))
     can_delete = bool(user == request.user or is_mediacms_manager(request.user))
+    can_contact = can_contact_user(request.user, user)
     serialized_user = dict(UserDetailSerializer(user, context={"request": request}).data)
     serialized_user.update(
         {
             "is_owner": bool(request.user.is_authenticated and user == request.user),
             "can_edit": can_edit,
             "can_delete": can_delete,
+            "can_contact": can_contact,
             "playlist_count": user.playlists.count(),
             "active_tab": active_tab,
         }
@@ -57,6 +73,10 @@ def _profile_context(request, user, active_tab):
         "active_tab": active_tab,
         "CAN_EDIT": can_edit,
         "CAN_DELETE": can_delete,
+        # Legacy template config (templates/config/core/user.html) keys
+        # member.can.contactUser off this; keep its profile-level semantics
+        # (allow_contact / editor / curator) — the legacy frontend applies its
+        # own non-owner/anonymous checks.
         "SHOW_CONTACT_FORM": bool(user.allow_contact or is_mediacms_editor(request.user) or is_curator(request.user)),
         "PROFILE_INITIAL_DATA": serialized_user,
     }
@@ -143,6 +163,20 @@ def view_user_impact(request, username):
     return render(request, template, _profile_context(request, user, "impact"))
 
 
+def view_user_contact(request, username):
+    user, redirect_response = _get_profile_user_or_redirect(username)
+    if redirect_response:
+        return redirect_response
+    template = resolve_template(request, "profile")
+    if request.ui_variant == "legacy":
+        return HttpResponseRedirect(user.get_absolute_url())
+    # Contact is a public-facing tab, but only for authenticated non-owners on
+    # profiles that allow contact (mirrors the contact_user POST gate).
+    if not can_contact_user(request.user, user):
+        return HttpResponseRedirect(user.get_absolute_url())
+    return render(request, template, _profile_context(request, user, "contact"))
+
+
 @login_required
 def edit_user(request, username):
     user = get_user(username=username)
@@ -217,53 +251,60 @@ def contact_user(request, username):
             status=status.HTTP_401_UNAUTHORIZED,
         )
     user = User.objects.filter(username=username).first()
-    if user and (user.allow_contact or is_mediacms_editor(request.user)):
-        sender = request.user
-        recipient = user
-        sender_display_name = sender.name or sender.username
-        recipient_display_name = recipient.name or recipient.username
-        form_subject = request.data.get("subject", "").strip()
-        form_body = request.data.get("body", "").strip()
-
-        if not form_subject or not form_body:
-            return Response(
-                {"detail": "Subject and body are required"},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
-        # Email to recipient
-        recipient_email = EmailMessage(
-            subject=f"[{settings.PORTAL_NAME}] Message from {sender.username}: {form_subject}",
-            body=(
-                f"You have received a message from {sender_display_name} ({sender.email}) on {settings.PORTAL_NAME}.\n\n"
-                f"Subject: {form_subject}\n\n"
-                f"---\n{form_body}\n---\n\n"
-                f"Reply to this email to reach {sender_display_name} directly.\n\n"
-                f"--\nThis message was sent via {settings.PORTAL_NAME}\n"
-            ),
-            from_email=settings.DEFAULT_FROM_EMAIL,
-            to=[recipient.email],
-            reply_to=[sender.email],
+    if not user:
+        return Response({"detail": "user does not exist"}, status=status.HTTP_404_NOT_FOUND)
+    if not can_contact_user(request.user, user):
+        return Response(
+            {"detail": "You are not allowed to contact this user"},
+            status=status.HTTP_403_FORBIDDEN,
         )
-        recipient_email.send(fail_silently=True)
 
-        # Copy to sender
-        timestamp = timezone.now().strftime("%B %d, %Y at %I:%M %p")
-        sender_copy = EmailMessage(
-            subject=f"[{settings.PORTAL_NAME}] Copy of your message to {recipient_display_name}",
-            body=(
-                f"This is a copy of the message you sent on {settings.PORTAL_NAME}.\n\n"
-                f"To: {recipient_display_name}\n"
-                f"Date: {timestamp}\n"
-                f"Subject: {form_subject}\n\n"
-                f"---\n{form_body}\n---\n\n"
-                f"This is a confirmation copy for your records.\n\n"
-                f"--\nThis message was sent via {settings.PORTAL_NAME}\n"
-            ),
-            from_email=settings.DEFAULT_FROM_EMAIL,
-            to=[sender.email],
+    sender = request.user
+    recipient = user
+    sender_display_name = sender.name or sender.username
+    recipient_display_name = recipient.name or recipient.username
+    form_subject = request.data.get("subject", "").strip()
+    form_body = request.data.get("body", "").strip()
+
+    if not form_subject or not form_body:
+        return Response(
+            {"detail": "Subject and body are required"},
+            status=status.HTTP_400_BAD_REQUEST,
         )
-        sender_copy.send(fail_silently=True)
+
+    # Email to recipient
+    recipient_email = EmailMessage(
+        subject=f"[{settings.PORTAL_NAME}] Message from {sender.username}: {form_subject}",
+        body=(
+            f"You have received a message from {sender_display_name} ({sender.email}) on {settings.PORTAL_NAME}.\n\n"
+            f"Subject: {form_subject}\n\n"
+            f"---\n{form_body}\n---\n\n"
+            f"Reply to this email to reach {sender_display_name} directly.\n\n"
+            f"--\nThis message was sent via {settings.PORTAL_NAME}\n"
+        ),
+        from_email=settings.DEFAULT_FROM_EMAIL,
+        to=[recipient.email],
+        reply_to=[sender.email],
+    )
+    recipient_email.send(fail_silently=True)
+
+    # Copy to sender
+    timestamp = timezone.now().strftime("%B %d, %Y at %I:%M %p")
+    sender_copy = EmailMessage(
+        subject=f"[{settings.PORTAL_NAME}] Copy of your message to {recipient_display_name}",
+        body=(
+            f"This is a copy of the message you sent on {settings.PORTAL_NAME}.\n\n"
+            f"To: {recipient_display_name}\n"
+            f"Date: {timestamp}\n"
+            f"Subject: {form_subject}\n\n"
+            f"---\n{form_body}\n---\n\n"
+            f"This is a confirmation copy for your records.\n\n"
+            f"--\nThis message was sent via {settings.PORTAL_NAME}\n"
+        ),
+        from_email=settings.DEFAULT_FROM_EMAIL,
+        to=[sender.email],
+    )
+    sender_copy.send(fail_silently=True)
 
     return Response(status=status.HTTP_204_NO_CONTENT)
 
@@ -432,24 +473,43 @@ class UserCommunityImpactList(APIView):
         if not user:
             return Response({"detail": "user does not exist"}, status=status.HTTP_404_NOT_FOUND)
 
-        entries = CommunityImpact.objects.filter(
-            media__user=user,
-            media__state="public",
-            media__is_reviewed=True,
-            media__encoding_status="success",
-            status=CommunityImpact.APPROVED,
+        # "curated" is never surfaced on the profile Impact tab, so exclude it
+        # here — otherwise a film whose only entries are curated would produce
+        # an empty film group in the UI.
+        display_categories = [
+            category for category, _ in CommunityImpact.CATEGORY_CHOICES if category != CommunityImpact.CURATED
+        ]
+        entries = (
+            CommunityImpact.objects.filter(
+                media__user=user,
+                media__state="public",
+                media__is_reviewed=True,
+                media__encoding_status="success",
+                status=CommunityImpact.APPROVED,
+                category__in=display_categories,
+            )
+            .select_related("media", "media__user", "user")
+            .order_by("-event_date", "-add_date")
         )
-        grouped = {}
-        for category, _label in CommunityImpact.CATEGORY_CHOICES:
-            category_entries = entries.filter(category=category)
-            grouped[category] = {
-                "entries": CommunityImpactSerializer(
-                    category_entries.select_related("media", "user").order_by("-event_date", "-add_date")[
-                        : self.category_limit
-                    ],
-                    many=True,
-                    context={"request": request},
-                ).data,
-                "totalCount": category_entries.count(),
-            }
-        return Response(grouped)
+
+        # Group entries under the film they belong to so the profile Impact tab
+        # can attribute each entry to its media (issue #810). Films keep the
+        # order in which their most recent impact entry appears (entries are
+        # already ordered by -event_date, -add_date above).
+        films = {}
+        for entry in entries:
+            media = entry.media
+            film = films.get(media.pk)
+            if film is None:
+                film = {
+                    "media": MediaSerializer(media, context={"request": request}).data,
+                    "impact": {category: {"entries": [], "totalCount": 0} for category in display_categories},
+                }
+                films[media.pk] = film
+
+            bucket = film["impact"][entry.category]
+            bucket["totalCount"] += 1
+            if len(bucket["entries"]) < self.category_limit:
+                bucket["entries"].append(CommunityImpactSerializer(entry, context={"request": request}).data)
+
+        return Response({"films": list(films.values())})

--- a/users/views.py
+++ b/users/views.py
@@ -16,6 +16,7 @@ from rest_framework.parsers import (
     MultiPartParser,
 )
 from rest_framework.response import Response
+from rest_framework.settings import api_settings
 from rest_framework.views import APIView
 
 from cms.custom_pagination import SmallPreviewPagination
@@ -23,12 +24,12 @@ from cms.permissions import IsUserOrManager
 from cms.ui_variant import resolve_template
 from files.lists import video_countries
 from files.methods import is_curator, is_mediacms_editor, is_mediacms_manager
-from files.models import CommunityImpact
+from files.models import CommunityImpact, PrivateJournalNote
 from files.serializers import CommunityImpactSerializer, MediaSerializer
 
 from .forms import ChannelForm, UserForm
 from .models import Channel, User
-from .serializers import UserDetailSerializer, UserSerializer
+from .serializers import ProfilePrivateJournalNoteSerializer, UserDetailSerializer, UserSerializer
 
 
 def get_user(username):
@@ -513,3 +514,27 @@ class UserCommunityImpactList(APIView):
                 bucket["entries"].append(CommunityImpactSerializer(entry, context={"request": request}).data)
 
         return Response({"films": list(films.values())})
+
+
+class UserPrivateJournalList(APIView):
+    """Author-scoped private journal notes for the profile "My Notes" tab.
+
+    Private notes: a user may only list their own notes, so this requires
+    authentication and matching the requested username (403 otherwise) — unlike
+    the public Impact endpoint.
+    """
+
+    permission_classes = (permissions.IsAuthenticated,)
+
+    def get(self, request, username):
+        if request.user.username != username:
+            return Response(
+                {"detail": "You may only view your own notes"},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        notes = PrivateJournalNote.objects.filter(user=request.user).select_related("media").order_by("-add_date")
+        paginator = api_settings.DEFAULT_PAGINATION_CLASS()
+        page = paginator.paginate_queryset(notes, request)
+        serializer = ProfilePrivateJournalNoteSerializer(page, many=True, context={"request": request})
+        return paginator.get_paginated_response(serializer.data)


### PR DESCRIPTION
## Description

Follow-ups to the modern-track profile revamp (#784, closing #543). All changes land in the modern track (`frontend/src/features/profile/`, Tailwind + semantic tokens); the legacy profile page is untouched.

- **#807 — Dedicated Contact tab.** Adds a Contact tab as the last public-facing tab (About → Media → Playlists → Impact → **Contact**, before owner-only tabs). New `ContactSection` ports the Subject/Message form to modern components and POSTs to the existing `/api/v1/users/<username>/contact` endpoint. Adds the `/user/<username>/contact` route + `view_user_contact`, and exposes a viewer-aware `can_contact` flag in the profile bootstrap data.
  - The contact permission is now centralized in a single `can_contact_user(viewer, target)` helper shared by the profile bootstrap, the tab view, and the `contact_user` POST — so the tab is only shown when the send will actually succeed. The POST now returns **403** on a disallowed profile instead of a silent `204` "success", and anonymous viewers no longer see the tab.
- **#808 — Bionote paragraph breaks.** The About bionote now preserves user-entered paragraph breaks via `whitespace-pre-line` (DOMPurify sanitization retained).
- **#809 — Manage Uploads landing content.** Removes the redundant "Your upload workspace" header and helper text. Per maintainer decision, the tab intentionally continues to link to the existing `/manage/uploads` manager (legacy track) rather than embedding it.
- **#810 — Impact tab: de-dup header + attribute entries to their film.** Removes the duplicated Impact sub-header (only the tab-level heading remains). The author community-impacts endpoint now returns `{ films: [{ media, impact }] }` grouped by film, and each film renders a Playlist-style film row header (`ImpactFilmRow`: thumbnail, title, uploader, country, views, synopsis) above its impact cards. `curated` is excluded server-side so films with only curated entries don't produce empty groups.
- **#797 — My Notes tab wired to live data.** #795 (the per-media `PrivateJournalNote` model + API) is now merged to `main`, so the My Notes empty-state placeholder is replaced with real data:
  - **Backend:** new `GET /api/v1/users/<username>/private-journal` (`UserPrivateJournalList`) — `IsAuthenticated` + **owner-only** (403 for other users, since notes are private, unlike the public Impact endpoint), paginated, `select_related("media")`, newest-first. A new `ProfilePrivateJournalNoteSerializer` embeds media context (title, token, url, thumbnail, duration) so each note can render a thumbnail card and deep-link back to `/view?m=<token>&t=<seconds>`.
  - **Frontend:** `useAuthorNotes` hook (owner-gated), `NoteEntry` (thumbnail with a film-duration pill + note timestamp beside a vertical divider + note text, geometry read from the exported `notes-in-profile.svg`), and `NotesSection` groups notes by film (one card per film with a "View all N notes" link) with owner/empty/loading/error states.
  - New purpose-based semantic tokens (`bg-note-thumbnail-duration`, `text-note-thumbnail-duration`, `border-note-divider`); documented in `docs/modern-track-color-system.md` and `Colors.mdx`.
- **Playlists tab restyle.** Rebuilds the Playlists tab in the old-page grid style: 16:9 thumbnail with a fixed right-side count panel (count above a playlist-play icon), hover "Play all", title, "Created X ago", and a "View full playlist" link. Cards cap at the legacy `--default-item-width` (372px) rather than stretching to fill the column.

Shared `CommunityImpactSection` now renders its header only when a title/description is provided and uses a unique `useId` heading id, so multiple per-film instances can coexist without duplicate ids or dangling ARIA references.

## Related Issue

Fixes #807
Fixes #808
Fixes #809
Fixes #810
Fixes #797
Relates to #543, #544, #784, #795

> The My Notes tab implements #797 (the profile-page surface of the **My Notes / Private Media Journal** feature, #544), building on the per-media journal shipped in #795.

## Motivation and Context

These are gaps and follow-ups identified after the profile revamp (#784) shipped: a contact form that lost its home in the tabbed layout, bionote formatting loss, a redundant Manage Uploads landing screen, un-attributed Impact entries, a Playlists tab that had drifted from the established old-page style, and the My Notes tab (which shipped as an empty-state placeholder pending #795, now merged).

> **Contact/email behaviour is unchanged.** The contact send gate stays `allow_contact or editor` (curators are not included), exactly as before. What changed is only that a disallowed send now returns `403` instead of a silent `204` "success", the subject/body are validated (line breaks and length), and anonymous visitors are sent to login rather than silently bounced.

## How Has This Been Tested?

- **Backend:** `python manage.py test tests.test_profile_revamp --settings=cms.settings` — 23/23 passing. Coverage for contact tab/POST gating (anonymous, owner, disallowed → 403, allowed → 204), per-film impact grouping/filtering, and the private-journal endpoint (owner-only, other-user 403, anonymous denied, media context embedded, no cross-user leakage).
- **Frontend:** `vitest` — full suite 569/569 passing, including new `ContactSection`, `NotesSection`, `tabConfig`, bionote, and impact-grouping tests.
- **Linters:** `pre-commit` (ruff, ruff-format, django-upgrade, prettier) and `eslint` clean on all changed files.
- **Manual:** seeded local data (notes + impact across several films) and verified the My Notes, Impact, Playlists, and Contact tabs render as expected.

## Screenshots (if appropriate):
<img width="1223" height="530" alt="image" src="https://github.com/user-attachments/assets/bea105a0-1c86-4d33-8edb-d1846671e2f9" />
<img width="1528" height="690" alt="image" src="https://github.com/user-attachments/assets/de33bf29-7316-4960-b257-cf28b7362bf0" />
<img width="1517" height="779" alt="image" src="https://github.com/user-attachments/assets/982ecd51-5c9e-4745-96a3-928669e5fe46" />
<img width="1137" height="913" alt="image" src="https://github.com/user-attachments/assets/0a051155-9e19-4b46-922a-880b82d535a9" />
<img width="1475" height="669" alt="image" src="https://github.com/user-attachments/assets/f1776fc4-e7ab-4e59-86f6-df4cae8878e3" />

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):
- [x] I have not imported `flux` in a new component
- [x] If adding a new feature, I used Modern Track patterns
- [x] New features do not create new SCSS files (use Tailwind instead)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an authorized Contact tab and contact form for eligible profile visitors.
  * Added owner-only My Notes views with timestamps, film links, durations, and note counts.
  * Expanded community impact displays into grouped, per-film entries with helpful empty states.
  * Redesigned playlist cards with thumbnails, media counts, creation dates, and “Play all” actions.
* **Improvements**
  * Preserved biography line breaks and improved accessibility for impact headings.
  * Simplified the Manage Uploads presentation.
* **Bug Fixes**
  * Improved contact validation and access handling with clearer success and error feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->