### PR TITLE
fix(notifications): preference labels wrap instead of sliding under the channel control

### DIFF
--- a/frontend/src/features/user-settings/components/NotificationPreferencesForm.jsx
+++ b/frontend/src/features/user-settings/components/NotificationPreferencesForm.jsx
@@ -181,7 +181,7 @@ export function NotificationPreferencesForm() {
 										key={item.label}
 										className="grid min-h-[24px] min-w-0 grid-cols-1 gap-2 pb-[1.3px] pt-[2.5px] sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center"
 									>
-										<span className="min-w-0 whitespace-nowrap text-[13px] font-normal leading-[20px] tracking-normal text-text-secondary">
+										<span className="min-w-0 text-[13px] font-normal leading-[20px] tracking-normal text-text-secondary">
 											{item.label}
 										</span>
 										{isActive ? (


### PR DESCRIPTION
## Description

On the Notifications page's **Preferences** tab, each preference row is a two-column grid from the `sm:` breakpoint up: label in a `minmax(0,1fr)` column, channel control (or "Coming soon" pill) in an `auto` column. The label span carried `whitespace-nowrap`, so at in-between viewport widths — wide enough for the two-column layout but too narrow for the longest labels (e.g. *"New films from filmmakers you follow"*, *"Film added to a curated collection"*) — the label could not wrap while its column shrank. The text overflowed its grid column and was painted over by the segmented control's solid background, making it look cut off / hidden behind the control.

Fix: drop `whitespace-nowrap` from the label so it wraps onto a second line inside its own column. One-line change; the row's `min-h`, `sm:items-center` and column definitions already handle a two-line label correctly, and below `sm` the stacked one-column layout is unaffected.

## Related Issue

Reported directly by review feedback (no tracking issue).

## Motivation and Context

Preference labels must stay readable at every viewport width; text sliding underneath an opaque control is a WCAG reflow/readability problem and looks broken on tablets and narrow desktop windows.

## How Has This Been Tested?

- `npm run test:run` — 559/559 passing (includes the existing `NotificationPreferencesForm` suite).
- `npm run lint:modern` — 0 problems; `npm run build` — production build succeeds; pre-commit hooks pass on the touched file.
- Not exercised in a real browser in this session — please verify visually at ~640–900px widths that long labels now wrap beside their control.

## Screenshots (if appropriate):
<img width="938" height="1286" alt="image" src="https://github.com/user-attachments/assets/13b39951-7a77-4eac-b50d-968f4a25bf4c" />

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):

- [x] I have not imported `flux` in a new component
- [x] If adding a new feature, I used Modern Track patterns
- [x] New features do not create new SCSS files (use Tailwind instead)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved notification preference label layout so longer text can fit and truncate more naturally on smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->