### PR TITLE
fix(frontend): join media URLs with exactly one slash after the origin

### DIFF
--- a/frontend/src/static/js/components/-NEW-/VideoPlayer.js
+++ b/frontend/src/static/js/components/-NEW-/VideoPlayer.js
@@ -1,7 +1,7 @@
 import React, { useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import urlParse from 'url-parse';
 import videojs from '../../videojsGlobal.js';
+import { formatInnerLink } from '../../functions/formatInnerLink';
 
 import '@mediacms/media-player/dist/mediacms-media-player.css';
 import MediaPlayerClass from '@mediacms/media-player';
@@ -48,16 +48,6 @@ function getEstimatedBandwidth(deviceTier) {
 	};
 
 	return bandwidthMap[deviceTier] || bandwidthMap.mid;
-}
-
-export function formatInnerLink(url, baseUrl) {
-	let link = urlParse(url, {});
-
-	if ('' === link.origin || 'null' === link.origin || !link.origin) {
-		link = urlParse(baseUrl + '/' + url.replace(/^\//g, ''), {});
-	}
-
-	return link.toString();
 }
 
 // YouTube-style fullscreen orientation. Landscape videos

--- a/frontend/src/static/js/functions/formatInnerLink.js
+++ b/frontend/src/static/js/functions/formatInnerLink.js
@@ -1,11 +1,20 @@
 import urlParse from 'url-parse';
 
+// Join a base URL and a relative path with exactly one slash between them,
+// whether or not baseUrl ends with a slash or the path starts with one.
+// A trailing-slash site URL would otherwise yield "https://host//media/...",
+// which fragments CDN caches into separate // and / namespaces (#788).
+function joinWithBase(url, baseUrl) {
+	const safeUrl = url == null ? '' : url;
+	const safeBase = baseUrl == null ? '' : String(baseUrl).replace(/\/+$/, '');
+	return urlParse(safeBase + '/' + safeUrl.replace(/^\/+/, ''), {});
+}
+
 export function formatInnerLink(url, baseUrl) {
 	let link = urlParse(url, {});
 
 	if ('' === link.origin || 'null' === link.origin || !link.origin) {
-		const safeUrl = url == null ? '' : url;
-		link = urlParse(baseUrl + '/' + safeUrl.replace(/^\/+/, ''), {});
+		link = joinWithBase(url, baseUrl);
 	}
 
 	return link.toString();
@@ -15,8 +24,7 @@ export function formatMediaLink(url, baseUrl, token = null) {
 	let link = urlParse(url, {});
 
 	if ('' === link.origin || 'null' === link.origin || !link.origin) {
-		const safeUrl = url == null ? '' : url;
-		link = urlParse(baseUrl + '/' + safeUrl.replace(/^\/+/, ''), {});
+		link = joinWithBase(url, baseUrl);
 	}
 
 	// Add token parameter for restricted media

--- a/frontend/src/static/js/functions/formatInnerLink.js
+++ b/frontend/src/static/js/functions/formatInnerLink.js
@@ -2,8 +2,11 @@ import urlParse from 'url-parse';
 
 // Join a base URL and a relative path with exactly one slash between them,
 // whether or not baseUrl ends with a slash or the path starts with one.
-// A trailing-slash site URL would otherwise yield "https://host//media/...",
-// which fragments CDN caches into separate // and / namespaces (#788).
+// This is not an edge case: the site config template hardcodes a trailing
+// slash (templates/config/installation/site.html emits `url: '{{FRONTEND_HOST}}/'`),
+// so site.url ends in "/" on every deployment and the old join produced
+// "https://host//media/..." everywhere, fragmenting CDN caches into separate
+// // and / namespaces (#788).
 function joinWithBase(url, baseUrl) {
 	const safeUrl = url == null ? '' : url;
 	const safeBase = baseUrl == null ? '' : String(baseUrl).replace(/\/+$/, '');

--- a/frontend/src/static/js/functions/formatInnerLink.test.js
+++ b/frontend/src/static/js/functions/formatInnerLink.test.js
@@ -1,0 +1,48 @@
+import { formatInnerLink, formatMediaLink } from './formatInnerLink';
+
+describe('formatInnerLink', () => {
+	it('joins a trailing-slash base URL and a root-relative path with a single slash', () => {
+		expect(formatInnerLink('/media/hls/uid/media-1/stream.m3u8', 'https://host/')).toBe(
+			'https://host/media/hls/uid/media-1/stream.m3u8'
+		);
+	});
+
+	it('joins a base URL without a trailing slash unchanged', () => {
+		expect(formatInnerLink('/media/original/video.mp4', 'https://host')).toBe(
+			'https://host/media/original/video.mp4'
+		);
+	});
+
+	it('collapses multiple boundary slashes from both sides', () => {
+		expect(formatInnerLink('//media/file.mp4', 'https://host//')).toBe('https://host/media/file.mp4');
+	});
+
+	it('keeps absolute URLs untouched', () => {
+		expect(formatInnerLink('https://cdn.example.com/media/file.mp4', 'https://host/')).toBe(
+			'https://cdn.example.com/media/file.mp4'
+		);
+	});
+
+	it('handles a null or empty path without throwing', () => {
+		expect(formatInnerLink(null, 'https://host/')).toBe('https://host/');
+		expect(formatInnerLink('', 'https://host/')).toBe('https://host/');
+	});
+});
+
+describe('formatMediaLink', () => {
+	it('joins with a single slash when the base URL has a trailing slash', () => {
+		expect(formatMediaLink('/media/hls/uid/master.m3u8', 'https://host/')).toBe(
+			'https://host/media/hls/uid/master.m3u8'
+		);
+	});
+
+	it('appends the restricted-media token after a normalized join', () => {
+		expect(formatMediaLink('/media/hls/uid/master.m3u8', 'https://host/', 'tok123')).toBe(
+			'https://host/media/hls/uid/master.m3u8?token=tok123'
+		);
+	});
+
+	it('does not add a token parameter for blank tokens', () => {
+		expect(formatMediaLink('/media/file.mp4', 'https://host/', '  ')).toBe('https://host/media/file.mp4');
+	});
+});

--- a/frontend/src/static/js/functions/formatInnerLink.test.js
+++ b/frontend/src/static/js/functions/formatInnerLink.test.js
@@ -13,7 +13,10 @@ describe('formatInnerLink', () => {
 		);
 	});
 
-	it('collapses multiple boundary slashes from both sides', () => {
+	// Deliberate: a "//host/path" input is treated as a path to join, not as a
+	// protocol-relative URL. The API only ever emits root-relative paths, so a
+	// leading "//" here is a sloppy join artifact, not a scheme-less URL.
+	it('treats a double-slash-prefixed path as a path, collapsing boundary slashes', () => {
 		expect(formatInnerLink('//media/file.mp4', 'https://host//')).toBe('https://host/media/file.mp4');
 	});
 


### PR DESCRIPTION
## Description

`formatInnerLink()` and `formatMediaLink()` build relative-path URLs as `baseUrl + '/' + path` with leading slashes stripped from the path — but nothing strips a trailing slash from `baseUrl`. **This is not a configuration edge case:** `templates/config/installation/site.html` hardcodes `url: '{{FRONTEND_HOST}}/'`, so `site.url` ends in a slash on **every deployment**, and these helpers have been producing `https://host//media/hls/<uid>/media-1/stream.m3u8` everywhere, always. That is also what fed the CDN cache fragmentation described in #788.

This PR extracts the join into a small shared helper that trims boundary slashes on **both** sides (`/+$` off the base, `^/+` off the path) before parsing, so the result always has exactly one slash after the origin. Both exported functions use it; the absolute-URL passthrough and the restricted-media `?token=` handling are unchanged.

Per review, it also removes the **drifted duplicate** `formatInnerLink` in `frontend/src/static/js/components/-NEW-/VideoPlayer.js` (it stripped only a single leading slash, had no null guard, and its export had no importers) — VideoPlayer now imports the shared helper, so subtitle track URLs get the same normalization as video/HLS sources.

A deliberate behavior note: an input starting with `//` is treated as a **path to join**, not as a protocol-relative URL — the API only emits root-relative paths, so a leading `//` is a join artifact. The test suite documents this choice explicitly.

New unit tests cover trailing-slash/no-slash bases, multi-slash boundaries, absolute-URL passthrough, null/empty paths, and token appending after a normalized join. No caller changes needed — all call sites keep the same API.

**Possible follow-up (from review discussion):** dropping the hardcoded `/` from `site.html` would fix the raw `site.url + '/...'` joins that don't go through these helpers (`MediaPage/store.js:1021`, `PlaylistPage/store.js:140/148`) and make the scattered trailing-slash workarounds in `mediacms/config.js` removable. Nothing was found relying on the trailing slash, but that change is kept out of this PR so it stays a pure, revert-clean join hardening.

## Related Issue

Fixes #788

## Motivation and Context

Beyond serving malformed URLs to the player, the double slash fragments CDN caches: `//media/...` and `/media/...` are keyed as two separate namespaces that can hold different (and differently-aged) objects for the same file. This is how stale objects kept resurfacing during the HLS cache-busting investigation (#791/#792/#823) even after the backend fixes landed — those PRs fixed segment staleness but did not touch this client-side join.

## How Has This Been Tested?

- New `formatInnerLink.test.js` — 8 tests, all passing.
- Full frontend suite `npm run test:run` — 567/567 passing.
- `npm run lint:legacy` — no new warnings on the touched files; `npm run build` — production build succeeds; pre-commit hooks pass.
- Not exercised against a live deployment in this session.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):

- [x] I have not imported `flux` in a new component
- [x] If adding a new feature, I used Modern Track patterns
- [x] New features do not create new SCSS files (use Tailwind instead)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL normalization for internal and media links to avoid duplicate/missing slashes when combining base URLs and paths.
  * Preserved correct behavior for absolute URLs and empty/invalid origins/paths.
  * Ensured media links consistently append access tokens only when provided (including subtitle URL normalization consistency).

* **Tests**
  * Added Jest coverage for URL joining edge cases, absolute-link behavior, empty paths, and media token query-string handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->