### PR TITLE
fix(hls): store hls_file as MEDIA_ROOT-relative path

### DIFF
--- a/files/helpers.py
+++ b/files/helpers.py
@@ -192,11 +192,18 @@ def url_from_path(filename):
     # TODO: find a way to preserver http - https ...
     # Accepts MEDIA_ROOT-relative names (the storage convention) and absolute
     # paths; absolute prefixes are stripped even when the stored value and the
-    # current MEDIA_ROOT disagree about a trailing slash (#789).
+    # current MEDIA_ROOT disagree about a trailing slash. Foreign-root
+    # absolutes fall back to the last "/hls/" marker, mirroring migration
+    # 0034's _to_relative, so a row that escaped the backfill can never leak
+    # the server filesystem path into a URL (#789).
     name = str(filename or "")
     media_root = settings.MEDIA_ROOT.rstrip("/")
     if name.startswith(media_root + "/"):
         name = name[len(media_root) + 1 :]
+    elif os.path.isabs(name):
+        idx = name.rfind("/hls/")
+        if idx != -1:
+            name = name[idx + 1 :]
     return f"{settings.MEDIA_URL}{name.lstrip('/')}"
 
 

--- a/files/helpers.py
+++ b/files/helpers.py
@@ -190,7 +190,37 @@ def rm_dir(directory):
 
 def url_from_path(filename):
     # TODO: find a way to preserver http - https ...
-    return f"{settings.MEDIA_URL}{filename.replace(settings.MEDIA_ROOT, '')}"
+    # Accepts MEDIA_ROOT-relative names (the storage convention) and absolute
+    # paths; absolute prefixes are stripped even when the stored value and the
+    # current MEDIA_ROOT disagree about a trailing slash (#789).
+    name = str(filename or "")
+    media_root = settings.MEDIA_ROOT.rstrip("/")
+    if name.startswith(media_root + "/"):
+        name = name[len(media_root) + 1 :]
+    return f"{settings.MEDIA_URL}{name.lstrip('/')}"
+
+
+def hls_path_to_relative(path):
+    """Return the MEDIA_ROOT-relative form of an HLS file path.
+
+    Legacy rows store absolute paths whose prefix may no longer match the
+    current MEDIA_ROOT, so this anchors on the "/hls/" directory marker
+    (HLS output always lives in MEDIA_ROOT/hls/) before falling back to a
+    plain prefix strip. Already-relative values pass through unchanged, so
+    the conversion is idempotent (#789).
+    """
+    if not path:
+        return path
+    if not os.path.isabs(path):
+        return path.lstrip("/")
+    marker = "/hls/"
+    idx = path.find(marker)
+    if idx != -1:
+        return path[idx + 1 :]
+    media_root = settings.MEDIA_ROOT.rstrip("/") + "/"
+    if path.startswith(media_root):
+        return path[len(media_root) :]
+    return path
 
 
 def build_versioned_url(base_url, version):

--- a/files/helpers.py
+++ b/files/helpers.py
@@ -200,29 +200,6 @@ def url_from_path(filename):
     return f"{settings.MEDIA_URL}{name.lstrip('/')}"
 
 
-def hls_path_to_relative(path):
-    """Return the MEDIA_ROOT-relative form of an HLS file path.
-
-    Legacy rows store absolute paths whose prefix may no longer match the
-    current MEDIA_ROOT, so this anchors on the "/hls/" directory marker
-    (HLS output always lives in MEDIA_ROOT/hls/) before falling back to a
-    plain prefix strip. Already-relative values pass through unchanged, so
-    the conversion is idempotent (#789).
-    """
-    if not path:
-        return path
-    if not os.path.isabs(path):
-        return path.lstrip("/")
-    marker = "/hls/"
-    idx = path.find(marker)
-    if idx != -1:
-        return path[idx + 1 :]
-    media_root = settings.MEDIA_ROOT.rstrip("/") + "/"
-    if path.startswith(media_root):
-        return path[len(media_root) :]
-    return path
-
-
 def build_versioned_url(base_url, version):
     """Build a versioned URL with proper query parameter handling"""
     if not base_url:

--- a/files/migrations/0033_relative_hls_file.py
+++ b/files/migrations/0033_relative_hls_file.py
@@ -1,0 +1,68 @@
+import os
+
+from django.conf import settings
+from django.db import migrations
+
+# Rewrites Media.hls_file from absolute filesystem paths to MEDIA_ROOT-relative
+# ones (#789). Logic is inlined (not imported from files.helpers) so the
+# migration stays stable if the helper evolves.
+#
+# Forward is idempotent: already-relative rows are skipped, and absolute rows
+# are anchored on the "/hls/" marker (HLS output always lives under
+# MEDIA_ROOT/hls/), so it also converts rows whose stored prefix no longer
+# matches the current MEDIA_ROOT — the exact failure the issue describes.
+# Rows in neither form are left untouched; the tolerant reader on the model
+# (Media.hls_file_path) still resolves them.
+
+BATCH_SIZE = 500
+
+
+def _to_relative(path):
+    if not path or not os.path.isabs(path):
+        return path
+    idx = path.find("/hls/")
+    if idx != -1:
+        return path[idx + 1 :]
+    media_root = settings.MEDIA_ROOT.rstrip("/") + "/"
+    if path.startswith(media_root):
+        return path[len(media_root) :]
+    return path
+
+
+def _to_absolute(path):
+    if not path or os.path.isabs(path):
+        return path
+    return os.path.join(settings.MEDIA_ROOT, path)
+
+
+def _rewrite(apps, transform):
+    Media = apps.get_model("files", "Media")
+    batch = []
+    for media in Media.objects.exclude(hls_file="").only("id", "hls_file").iterator():
+        new_value = transform(media.hls_file)
+        if new_value != media.hls_file:
+            media.hls_file = new_value
+            batch.append(media)
+        if len(batch) >= BATCH_SIZE:
+            Media.objects.bulk_update(batch, ["hls_file"])
+            batch = []
+    if batch:
+        Media.objects.bulk_update(batch, ["hls_file"])
+
+
+def forwards(apps, schema_editor):
+    _rewrite(apps, _to_relative)
+
+
+def backwards(apps, schema_editor):
+    _rewrite(apps, _to_absolute)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("files", "0032_privatejournalnote"),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards, backwards),
+    ]

--- a/files/migrations/0033_relative_hls_file.py
+++ b/files/migrations/0033_relative_hls_file.py
@@ -4,15 +4,17 @@ from django.conf import settings
 from django.db import migrations
 
 # Rewrites Media.hls_file from absolute filesystem paths to MEDIA_ROOT-relative
-# ones (#789). Logic is inlined (not imported from files.helpers) so the
-# migration stays stable if the helper evolves.
+# ones (#789). The migration owns this logic (nothing is imported from
+# files.helpers) so it stays stable if application code evolves.
 #
-# Forward is idempotent: already-relative rows are skipped, and absolute rows
-# are anchored on the "/hls/" marker (HLS output always lives under
-# MEDIA_ROOT/hls/), so it also converts rows whose stored prefix no longer
-# matches the current MEDIA_ROOT — the exact failure the issue describes.
-# Rows in neither form are left untouched; the tolerant reader on the model
-# (Media.hls_file_path) still resolves them.
+# Forward is idempotent: already-relative rows are skipped. Absolute rows are
+# stripped of the exact current MEDIA_ROOT prefix first; only rows whose
+# stored prefix no longer matches fall back to anchoring on the last "/hls/"
+# marker (HLS output always lives under MEDIA_ROOT/hls/, and the uid/version
+# segments are hex tokens, so the last occurrence is always the HLS root —
+# unlike earlier occurrences, which can belong to a foreign prefix such as
+# /mnt/hls/...). Rows in neither form are left untouched; the tolerant reader
+# on the model (Media.hls_file_path) still resolves them.
 
 BATCH_SIZE = 500
 
@@ -20,12 +22,12 @@ BATCH_SIZE = 500
 def _to_relative(path):
     if not path or not os.path.isabs(path):
         return path
-    idx = path.find("/hls/")
-    if idx != -1:
-        return path[idx + 1 :]
     media_root = settings.MEDIA_ROOT.rstrip("/") + "/"
     if path.startswith(media_root):
         return path[len(media_root) :]
+    idx = path.rfind("/hls/")
+    if idx != -1:
+        return path[idx + 1 :]
     return path
 
 

--- a/files/migrations/0034_relative_hls_file.py
+++ b/files/migrations/0034_relative_hls_file.py
@@ -62,7 +62,7 @@ def backwards(apps, schema_editor):
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("files", "0032_privatejournalnote"),
+        ("files", "0033_remove_playlist_curator_note"),
     ]
 
     operations = [

--- a/files/models.py
+++ b/files/models.py
@@ -1110,6 +1110,20 @@ class Media(models.Model):
             return helpers.build_versioned_url(base_url, self.media_version)
         return None
 
+    @property
+    def hls_file_path(self):
+        """Absolute filesystem path for hls_file.
+
+        hls_file stores a MEDIA_ROOT-relative path (#789). Legacy rows may
+        still hold an absolute path until the data migration has run, so both
+        forms resolve here; never read hls_file directly for filesystem access.
+        """
+        if not self.hls_file:
+            return ""
+        if os.path.isabs(self.hls_file):
+            return self.hls_file
+        return os.path.join(settings.MEDIA_ROOT, self.hls_file)
+
     @cached_property
     def hls_version(self):
         """Version token for HLS URLs, taken from the per-generation output directory.
@@ -1127,8 +1141,8 @@ class Media(models.Model):
     def hls_info(self):
         res = {}
         if self.hls_file:
-            if os.path.exists(self.hls_file):
-                hls_file = self.hls_file
+            hls_file = self.hls_file_path
+            if os.path.exists(hls_file):
                 p = os.path.dirname(hls_file)
                 m3u8_obj = m3u8.load(hls_file)
                 if os.path.exists(hls_file):
@@ -2307,7 +2321,7 @@ def media_file_delete(sender, instance, **kwargs):
     if instance.sprites:
         helpers.rm_file(instance.sprites.path)
     if instance.hls_file:
-        p = os.path.dirname(instance.hls_file)
+        p = os.path.dirname(instance.hls_file_path)
         helpers.rm_dir(p)
     instance.user.update_user_media()
 

--- a/files/storage_usage.py
+++ b/files/storage_usage.py
@@ -136,7 +136,7 @@ def calculate_media_storage_usage(media):
     for subtitle in media.subtitles.all():
         total += _safe_filefield_size(subtitle.subtitle_file, seen_paths)
 
-    total += _safe_local_directory_size(media.hls_file, seen_paths)
+    total += _safe_local_directory_size(media.hls_file_path, seen_paths)
 
     return total
 

--- a/files/tasks.py
+++ b/files/tasks.py
@@ -870,13 +870,14 @@ def create_hls(friendly_token):
 
         # New URLs every regeneration: hls_file always changes, so the
         # post_save signal on Media always fires the storage usage refresh.
-        media.hls_file = pp
+        # Stored MEDIA_ROOT-relative so the row survives a MEDIA_ROOT move (#789).
+        media.hls_file = os.path.relpath(pp, settings.MEDIA_ROOT)
         media.save(update_fields=["hls_file"])
 
         # Remove stale output: never delete the directory hls_file currently
         # references (guards against a concurrently-committed newer run),
         # but clear every other version directory plus legacy flat siblings.
-        current_dir = os.path.dirname(media.hls_file)
+        current_dir = os.path.dirname(pp)
         if os.path.isdir(uid_dir):
             for entry in os.listdir(uid_dir):
                 entry_path = os.path.join(uid_dir, entry)

--- a/files/tests/test_hls_encryption.py
+++ b/files/tests/test_hls_encryption.py
@@ -325,10 +325,11 @@ class CreateHlsVersionedDirectoryTests(TestCase):
             self.assertTrue(tasks.create_hls(self.media.friendly_token))
 
         self.media.refresh_from_db()
-        uid_dir = os.path.join(self.hls_dir, self.media.uid.hex)
-        self.assertTrue(self.media.hls_file.startswith(uid_dir + os.sep))
-        self.assertNotEqual(os.path.dirname(self.media.hls_file), uid_dir)
-        self.assertTrue(os.path.exists(self.media.hls_file))
+        uid_rel = os.path.join("hls", self.media.uid.hex)
+        self.assertFalse(os.path.isabs(self.media.hls_file))
+        self.assertTrue(self.media.hls_file.startswith(uid_rel + os.sep))
+        self.assertNotEqual(os.path.dirname(self.media.hls_file), uid_rel)
+        self.assertTrue(os.path.exists(self.media.hls_file_path))
 
     def test_regeneration_removes_previous_version_directory(self):
         from files import tasks
@@ -336,12 +337,12 @@ class CreateHlsVersionedDirectoryTests(TestCase):
         with patch("files.tasks.subprocess.run", side_effect=self._fake_run_writing_master):
             self.assertTrue(tasks.create_hls(self.media.friendly_token))
         self.media.refresh_from_db()
-        first_dir = os.path.dirname(self.media.hls_file)
+        first_dir = os.path.dirname(self.media.hls_file_path)
 
         with patch("files.tasks.subprocess.run", side_effect=self._fake_run_writing_master):
             self.assertTrue(tasks.create_hls(self.media.friendly_token))
         self.media.refresh_from_db()
-        second_dir = os.path.dirname(self.media.hls_file)
+        second_dir = os.path.dirname(self.media.hls_file_path)
 
         self.assertNotEqual(first_dir, second_dir)
         self.assertFalse(os.path.exists(first_dir))
@@ -365,7 +366,7 @@ class CreateHlsVersionedDirectoryTests(TestCase):
 
         self.assertFalse(os.path.exists(legacy_master))
         self.media.refresh_from_db()
-        self.assertTrue(os.path.exists(self.media.hls_file))
+        self.assertTrue(os.path.exists(self.media.hls_file_path))
 
     def test_mp4hls_failure_leaves_previous_hls_file_untouched(self):
         from files import tasks
@@ -380,7 +381,7 @@ class CreateHlsVersionedDirectoryTests(TestCase):
 
         self.media.refresh_from_db()
         self.assertEqual(self.media.hls_file, good_hls_file)
-        self.assertTrue(os.path.exists(good_hls_file))
+        self.assertTrue(os.path.exists(self.media.hls_file_path))
 
     def test_mp4hls_nonzero_with_master_discards_partial_output(self):
         from files import tasks
@@ -498,7 +499,7 @@ class CreateHlsVersionedDirectoryTests(TestCase):
             self.assertTrue(tasks.create_hls(self.media.friendly_token))
         self.media.refresh_from_db()
         hls_file_before = self.media.hls_file
-        dir_before = os.path.dirname(hls_file_before)
+        dir_before = os.path.dirname(self.media.hls_file_path)
 
         lock_key = f"create_hls_lock_{self.media.uid.hex}"
         pending_key = f"create_hls_pending_{self.media.uid.hex}"

--- a/files/tests/test_hls_relative_path.py
+++ b/files/tests/test_hls_relative_path.py
@@ -1,6 +1,6 @@
 """
 Tests for MEDIA_ROOT-relative hls_file storage (#789): the tolerant
-Media.hls_file_path reader, url_from_path prefix handling, the 0033
+Media.hls_file_path reader, url_from_path prefix handling, the 0034
 data-migration transforms (including the _rewrite pass that touches
 production rows), and hls_info URL generation from a relative row.
 """
@@ -19,7 +19,7 @@ from files.models import Media
 from files.tests.test_hls_encryption import create_test_media
 from users.models import User
 
-migration_0033 = importlib.import_module("files.migrations.0033_relative_hls_file")
+migration_0034 = importlib.import_module("files.migrations.0034_relative_hls_file")
 
 
 class UrlFromPathTests(TestCase):
@@ -51,7 +51,7 @@ class MigrationToRelativeTests(TestCase):
     @override_settings(MEDIA_ROOT="/srv/media_files/")
     def test_absolute_with_current_root(self):
         self.assertEqual(
-            migration_0033._to_relative("/srv/media_files/hls/uid/v1/master.m3u8"),
+            migration_0034._to_relative("/srv/media_files/hls/uid/v1/master.m3u8"),
             "hls/uid/v1/master.m3u8",
         )
 
@@ -59,7 +59,7 @@ class MigrationToRelativeTests(TestCase):
     def test_foreign_root_falls_back_to_hls_marker(self):
         # Row written on a host whose MEDIA_ROOT no longer matches.
         self.assertEqual(
-            migration_0033._to_relative("/old/container/media/hls/uid/v1/master.m3u8"),
+            migration_0034._to_relative("/old/container/media/hls/uid/v1/master.m3u8"),
             "hls/uid/v1/master.m3u8",
         )
 
@@ -68,7 +68,7 @@ class MigrationToRelativeTests(TestCase):
         # The foreign prefix itself contains an hls directory: only the LAST
         # /hls/ is the HLS root (uid/version segments are hex tokens).
         self.assertEqual(
-            migration_0033._to_relative("/mnt/hls/cinemata/media_files/hls/uid/v1/master.m3u8"),
+            migration_0034._to_relative("/mnt/hls/cinemata/media_files/hls/uid/v1/master.m3u8"),
             "hls/uid/v1/master.m3u8",
         )
 
@@ -77,33 +77,33 @@ class MigrationToRelativeTests(TestCase):
         # MEDIA_ROOT itself contains /hls/: the exact prefix strip must win
         # before any marker heuristic runs.
         self.assertEqual(
-            migration_0033._to_relative("/srv/hls/media_files/hls/uid/v1/master.m3u8"),
+            migration_0034._to_relative("/srv/hls/media_files/hls/uid/v1/master.m3u8"),
             "hls/uid/v1/master.m3u8",
         )
 
     def test_relative_value_is_idempotent(self):
-        self.assertEqual(migration_0033._to_relative("hls/uid/v1/master.m3u8"), "hls/uid/v1/master.m3u8")
+        self.assertEqual(migration_0034._to_relative("hls/uid/v1/master.m3u8"), "hls/uid/v1/master.m3u8")
 
     @override_settings(MEDIA_ROOT="/srv/media_files/")
     def test_unknown_absolute_left_untouched(self):
         self.assertEqual(
-            migration_0033._to_relative("/opt/data/uid/master.m3u8"),
+            migration_0034._to_relative("/opt/data/uid/master.m3u8"),
             "/opt/data/uid/master.m3u8",
         )
 
     def test_empty_value(self):
-        self.assertEqual(migration_0033._to_relative(""), "")
+        self.assertEqual(migration_0034._to_relative(""), "")
 
 
 class MigrationToAbsoluteTests(TestCase):
     @override_settings(MEDIA_ROOT="/srv/media_files/")
     def test_backward_transform_restores_absolute(self):
         self.assertEqual(
-            migration_0033._to_absolute("hls/uid/v1/master.m3u8"),
+            migration_0034._to_absolute("hls/uid/v1/master.m3u8"),
             "/srv/media_files/hls/uid/v1/master.m3u8",
         )
         self.assertEqual(
-            migration_0033._to_absolute("/already/absolute/master.m3u8"),
+            migration_0034._to_absolute("/already/absolute/master.m3u8"),
             "/already/absolute/master.m3u8",
         )
 
@@ -119,7 +119,7 @@ class MigrationRewriteTests(TestCase):
     def setUpClass(cls):
         super().setUpClass()
         loader = MigrationLoader(connection)
-        cls.migration_apps = loader.project_state(("files", "0033_relative_hls_file")).apps
+        cls.migration_apps = loader.project_state(("files", "0034_relative_hls_file")).apps
 
     def setUp(self):
         self.user = User.objects.create_user(username="owner", email="owner@example.com", password="pw")
@@ -139,9 +139,9 @@ class MigrationRewriteTests(TestCase):
         # BATCH_SIZE=1 forces the mid-loop flush path as well as the final one.
         with (
             override_settings(MEDIA_ROOT="/srv/media_files/"),
-            patch.object(migration_0033, "BATCH_SIZE", 1),
+            patch.object(migration_0034, "BATCH_SIZE", 1),
         ):
-            migration_0033._rewrite(self.migration_apps, migration_0033._to_relative)
+            migration_0034._rewrite(self.migration_apps, migration_0034._to_relative)
 
         for media in (current_root, foreign_root, already_relative, unknown_form, no_hls):
             media.refresh_from_db()
@@ -155,7 +155,7 @@ class MigrationRewriteTests(TestCase):
         media = self._media_with_hls_file("hls/aa/v1/master.m3u8")
 
         with override_settings(MEDIA_ROOT="/srv/media_files/"):
-            migration_0033._rewrite(self.migration_apps, migration_0033._to_absolute)
+            migration_0034._rewrite(self.migration_apps, migration_0034._to_absolute)
 
         media.refresh_from_db()
         self.assertEqual(media.hls_file, "/srv/media_files/hls/aa/v1/master.m3u8")

--- a/files/tests/test_hls_relative_path.py
+++ b/files/tests/test_hls_relative_path.py
@@ -1,0 +1,143 @@
+"""
+Tests for MEDIA_ROOT-relative hls_file storage (#789): the tolerant
+Media.hls_file_path reader, url_from_path prefix handling, the
+hls_path_to_relative conversion helper, the 0033 data-migration transforms,
+and hls_info URL generation from a relative row.
+"""
+
+import importlib
+import os
+import tempfile
+
+from django.test import TestCase, override_settings
+
+from files import helpers
+from files.tests.test_hls_encryption import create_test_media
+from users.models import User
+
+migration_0033 = importlib.import_module("files.migrations.0033_relative_hls_file")
+
+
+class UrlFromPathTests(TestCase):
+    @override_settings(MEDIA_ROOT="/srv/media_files/", MEDIA_URL="/media/")
+    def test_relative_name_passthrough(self):
+        self.assertEqual(helpers.url_from_path("hls/uid/v1/master.m3u8"), "/media/hls/uid/v1/master.m3u8")
+
+    @override_settings(MEDIA_ROOT="/srv/media_files/", MEDIA_URL="/media/")
+    def test_absolute_path_with_matching_root(self):
+        self.assertEqual(
+            helpers.url_from_path("/srv/media_files/hls/uid/v1/master.m3u8"),
+            "/media/hls/uid/v1/master.m3u8",
+        )
+
+    @override_settings(MEDIA_ROOT="/srv/media_files", MEDIA_URL="/media/")
+    def test_absolute_path_with_trailing_slash_mismatch(self):
+        # Stored value assumes a trailing slash the setting no longer has.
+        self.assertEqual(
+            helpers.url_from_path("/srv/media_files/hls/uid/v1/master.m3u8"),
+            "/media/hls/uid/v1/master.m3u8",
+        )
+
+    @override_settings(MEDIA_ROOT="/srv/media_files/", MEDIA_URL="/media/")
+    def test_empty_value(self):
+        self.assertEqual(helpers.url_from_path(""), "/media/")
+
+
+class HlsPathToRelativeTests(TestCase):
+    @override_settings(MEDIA_ROOT="/srv/media_files/")
+    def test_absolute_with_current_root(self):
+        self.assertEqual(
+            helpers.hls_path_to_relative("/srv/media_files/hls/uid/v1/master.m3u8"),
+            "hls/uid/v1/master.m3u8",
+        )
+
+    @override_settings(MEDIA_ROOT="/srv/media_files/")
+    def test_absolute_with_foreign_root_uses_hls_marker(self):
+        # Row written on a host whose MEDIA_ROOT no longer matches.
+        self.assertEqual(
+            helpers.hls_path_to_relative("/old/container/media/hls/uid/v1/master.m3u8"),
+            "hls/uid/v1/master.m3u8",
+        )
+
+    def test_relative_value_is_idempotent(self):
+        self.assertEqual(helpers.hls_path_to_relative("hls/uid/v1/master.m3u8"), "hls/uid/v1/master.m3u8")
+
+    def test_empty_value(self):
+        self.assertEqual(helpers.hls_path_to_relative(""), "")
+
+
+class MigrationTransformTests(TestCase):
+    @override_settings(MEDIA_ROOT="/srv/media_files/")
+    def test_forward_transform_matches_helper(self):
+        for value in (
+            "/srv/media_files/hls/uid/v1/master.m3u8",
+            "/old/root/hls/uid/v1/master.m3u8",
+            "hls/uid/v1/master.m3u8",
+            "",
+        ):
+            self.assertEqual(migration_0033._to_relative(value), helpers.hls_path_to_relative(value))
+
+    @override_settings(MEDIA_ROOT="/srv/media_files/")
+    def test_backward_transform_restores_absolute(self):
+        self.assertEqual(
+            migration_0033._to_absolute("hls/uid/v1/master.m3u8"),
+            "/srv/media_files/hls/uid/v1/master.m3u8",
+        )
+        self.assertEqual(
+            migration_0033._to_absolute("/already/absolute/master.m3u8"),
+            "/already/absolute/master.m3u8",
+        )
+
+
+class HlsFilePathPropertyTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="owner", email="owner@example.com", password="pw")
+        self.media = create_test_media(self.user)
+
+    @override_settings(MEDIA_ROOT="/srv/media_files/")
+    def test_relative_value_joins_media_root(self):
+        self.media.hls_file = "hls/uid/v1/master.m3u8"
+        self.assertEqual(self.media.hls_file_path, "/srv/media_files/hls/uid/v1/master.m3u8")
+
+    def test_legacy_absolute_value_passes_through(self):
+        self.media.hls_file = "/legacy/root/hls/uid/v1/master.m3u8"
+        self.assertEqual(self.media.hls_file_path, "/legacy/root/hls/uid/v1/master.m3u8")
+
+    def test_empty_value(self):
+        self.media.hls_file = ""
+        self.assertEqual(self.media.hls_file_path, "")
+
+
+class HlsInfoRelativeRowTests(TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+        self.override = override_settings(
+            MEDIA_ROOT=self.tmpdir.name + "/",
+            MEDIA_URL="/media/",
+            HLS_DIR=os.path.join(self.tmpdir.name, "hls/"),
+        )
+        self.override.enable()
+        self.addCleanup(self.override.disable)
+
+        self.user = User.objects.create_user(username="owner", email="owner@example.com", password="pw")
+        self.media = create_test_media(self.user)
+
+    def test_hls_info_builds_urls_from_relative_row(self):
+        version_dir = os.path.join(self.tmpdir.name, "hls", self.media.uid.hex, "v1abc")
+        os.makedirs(version_dir)
+        master = os.path.join(version_dir, "master.m3u8")
+        with open(master, "w") as f:
+            f.write("#EXTM3U\n")
+
+        self.media.hls_file = os.path.relpath(master, self.tmpdir.name + "/")
+
+        info = self.media.hls_info
+        self.assertEqual(
+            info["master_file"],
+            f"/media/hls/{self.media.uid.hex}/v1abc/master.m3u8?v=v1abc",
+        )
+
+    def test_hls_info_empty_when_file_missing(self):
+        self.media.hls_file = "hls/uid/gone/master.m3u8"
+        self.assertEqual(self.media.hls_info, {})

--- a/files/tests/test_hls_relative_path.py
+++ b/files/tests/test_hls_relative_path.py
@@ -43,6 +43,18 @@ class UrlFromPathTests(TestCase):
         )
 
     @override_settings(MEDIA_ROOT="/srv/media_files/", MEDIA_URL="/media/")
+    def test_absolute_path_with_foreign_root_uses_hls_marker(self):
+        # A row that escaped the backfill must not leak the server path.
+        self.assertEqual(
+            helpers.url_from_path("/old/container/media/hls/uid/v1/master.m3u8"),
+            "/media/hls/uid/v1/master.m3u8",
+        )
+        self.assertEqual(
+            helpers.url_from_path("/mnt/hls/cinemata/media_files/hls/uid/v1/master.m3u8"),
+            "/media/hls/uid/v1/master.m3u8",
+        )
+
+    @override_settings(MEDIA_ROOT="/srv/media_files/", MEDIA_URL="/media/")
     def test_empty_value(self):
         self.assertEqual(helpers.url_from_path(""), "/media/")
 

--- a/files/tests/test_hls_relative_path.py
+++ b/files/tests/test_hls_relative_path.py
@@ -1,17 +1,21 @@
 """
 Tests for MEDIA_ROOT-relative hls_file storage (#789): the tolerant
-Media.hls_file_path reader, url_from_path prefix handling, the
-hls_path_to_relative conversion helper, the 0033 data-migration transforms,
-and hls_info URL generation from a relative row.
+Media.hls_file_path reader, url_from_path prefix handling, the 0033
+data-migration transforms (including the _rewrite pass that touches
+production rows), and hls_info URL generation from a relative row.
 """
 
 import importlib
 import os
 import tempfile
+from unittest.mock import patch
 
+from django.db import connection
+from django.db.migrations.loader import MigrationLoader
 from django.test import TestCase, override_settings
 
 from files import helpers
+from files.models import Media
 from files.tests.test_hls_encryption import create_test_media
 from users.models import User
 
@@ -43,40 +47,55 @@ class UrlFromPathTests(TestCase):
         self.assertEqual(helpers.url_from_path(""), "/media/")
 
 
-class HlsPathToRelativeTests(TestCase):
+class MigrationToRelativeTests(TestCase):
     @override_settings(MEDIA_ROOT="/srv/media_files/")
     def test_absolute_with_current_root(self):
         self.assertEqual(
-            helpers.hls_path_to_relative("/srv/media_files/hls/uid/v1/master.m3u8"),
+            migration_0033._to_relative("/srv/media_files/hls/uid/v1/master.m3u8"),
             "hls/uid/v1/master.m3u8",
         )
 
     @override_settings(MEDIA_ROOT="/srv/media_files/")
-    def test_absolute_with_foreign_root_uses_hls_marker(self):
+    def test_foreign_root_falls_back_to_hls_marker(self):
         # Row written on a host whose MEDIA_ROOT no longer matches.
         self.assertEqual(
-            helpers.hls_path_to_relative("/old/container/media/hls/uid/v1/master.m3u8"),
+            migration_0033._to_relative("/old/container/media/hls/uid/v1/master.m3u8"),
+            "hls/uid/v1/master.m3u8",
+        )
+
+    @override_settings(MEDIA_ROOT="/srv/media_files/")
+    def test_foreign_root_containing_hls_uses_last_marker(self):
+        # The foreign prefix itself contains an hls directory: only the LAST
+        # /hls/ is the HLS root (uid/version segments are hex tokens).
+        self.assertEqual(
+            migration_0033._to_relative("/mnt/hls/cinemata/media_files/hls/uid/v1/master.m3u8"),
+            "hls/uid/v1/master.m3u8",
+        )
+
+    @override_settings(MEDIA_ROOT="/srv/hls/media_files/")
+    def test_exact_root_strip_takes_precedence_over_marker(self):
+        # MEDIA_ROOT itself contains /hls/: the exact prefix strip must win
+        # before any marker heuristic runs.
+        self.assertEqual(
+            migration_0033._to_relative("/srv/hls/media_files/hls/uid/v1/master.m3u8"),
             "hls/uid/v1/master.m3u8",
         )
 
     def test_relative_value_is_idempotent(self):
-        self.assertEqual(helpers.hls_path_to_relative("hls/uid/v1/master.m3u8"), "hls/uid/v1/master.m3u8")
+        self.assertEqual(migration_0033._to_relative("hls/uid/v1/master.m3u8"), "hls/uid/v1/master.m3u8")
+
+    @override_settings(MEDIA_ROOT="/srv/media_files/")
+    def test_unknown_absolute_left_untouched(self):
+        self.assertEqual(
+            migration_0033._to_relative("/opt/data/uid/master.m3u8"),
+            "/opt/data/uid/master.m3u8",
+        )
 
     def test_empty_value(self):
-        self.assertEqual(helpers.hls_path_to_relative(""), "")
+        self.assertEqual(migration_0033._to_relative(""), "")
 
 
-class MigrationTransformTests(TestCase):
-    @override_settings(MEDIA_ROOT="/srv/media_files/")
-    def test_forward_transform_matches_helper(self):
-        for value in (
-            "/srv/media_files/hls/uid/v1/master.m3u8",
-            "/old/root/hls/uid/v1/master.m3u8",
-            "hls/uid/v1/master.m3u8",
-            "",
-        ):
-            self.assertEqual(migration_0033._to_relative(value), helpers.hls_path_to_relative(value))
-
+class MigrationToAbsoluteTests(TestCase):
     @override_settings(MEDIA_ROOT="/srv/media_files/")
     def test_backward_transform_restores_absolute(self):
         self.assertEqual(
@@ -87,6 +106,59 @@ class MigrationTransformTests(TestCase):
             migration_0033._to_absolute("/already/absolute/master.m3u8"),
             "/already/absolute/master.m3u8",
         )
+
+
+class MigrationRewriteTests(TestCase):
+    """Exercises _rewrite, the pass that actually touches production rows.
+
+    Uses the historical apps registry (as RunPython provides), whose plain
+    model class is what _rewrite actually iterates during the migration.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        loader = MigrationLoader(connection)
+        cls.migration_apps = loader.project_state(("files", "0033_relative_hls_file")).apps
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="owner", email="owner@example.com", password="pw")
+
+    def _media_with_hls_file(self, value):
+        media = create_test_media(self.user)
+        Media.objects.filter(pk=media.pk).update(hls_file=value)
+        return media
+
+    def test_rewrite_converts_absolute_rows_and_skips_the_rest(self):
+        current_root = self._media_with_hls_file("/srv/media_files/hls/aa/v1/master.m3u8")
+        foreign_root = self._media_with_hls_file("/mnt/hls/old/media_files/hls/bb/v2/master.m3u8")
+        already_relative = self._media_with_hls_file("hls/cc/v3/master.m3u8")
+        unknown_form = self._media_with_hls_file("/opt/data/dd/master.m3u8")
+        no_hls = self._media_with_hls_file("")
+
+        # BATCH_SIZE=1 forces the mid-loop flush path as well as the final one.
+        with (
+            override_settings(MEDIA_ROOT="/srv/media_files/"),
+            patch.object(migration_0033, "BATCH_SIZE", 1),
+        ):
+            migration_0033._rewrite(self.migration_apps, migration_0033._to_relative)
+
+        for media in (current_root, foreign_root, already_relative, unknown_form, no_hls):
+            media.refresh_from_db()
+        self.assertEqual(current_root.hls_file, "hls/aa/v1/master.m3u8")
+        self.assertEqual(foreign_root.hls_file, "hls/bb/v2/master.m3u8")
+        self.assertEqual(already_relative.hls_file, "hls/cc/v3/master.m3u8")
+        self.assertEqual(unknown_form.hls_file, "/opt/data/dd/master.m3u8")
+        self.assertEqual(no_hls.hls_file, "")
+
+    def test_rewrite_backwards_restores_absolute_rows(self):
+        media = self._media_with_hls_file("hls/aa/v1/master.m3u8")
+
+        with override_settings(MEDIA_ROOT="/srv/media_files/"):
+            migration_0033._rewrite(self.migration_apps, migration_0033._to_absolute)
+
+        media.refresh_from_db()
+        self.assertEqual(media.hls_file, "/srv/media_files/hls/aa/v1/master.m3u8")
 
 
 class HlsFilePathPropertyTests(TestCase):

--- a/files/tests/test_storage_usage.py
+++ b/files/tests/test_storage_usage.py
@@ -190,6 +190,6 @@ class StorageUsageTests(TestCase):
 
         self.media.refresh_from_db()
         self.assertNotEqual(self.media.hls_file, old_hls_path)
-        self.assertTrue(os.path.exists(self.media.hls_file))
+        self.assertTrue(os.path.exists(self.media.hls_file_path))
         self.assertFalse(os.path.exists(old_hls_path))
         schedule_refresh.assert_called_once_with(self.media.id)


### PR DESCRIPTION
## Description

`Media.hls_file` was the last file reference stored as an **absolute** filesystem path; URL generation compensated at read time with `filename.replace(settings.MEDIA_ROOT, '')`, which only works while the stored prefix exactly matches the current `MEDIA_ROOT`. This PR converts the field to the `MEDIA_ROOT`-relative convention used by every other file field:

- **Write path** — `create_hls` now stores `os.path.relpath(pp, MEDIA_ROOT)` (`hls/<uid>/<version>/master.m3u8`); its stale-output cleanup derives the current directory from the local absolute path, unchanged in behavior.
- **Tolerant reader** — new `Media.hls_file_path` property resolves the stored value to an absolute path, accepting **both** the new relative form and legacy absolute rows. All filesystem consumers now go through it: `hls_info` (exists/m3u8 parse), the post-delete signal (`rm_dir`), and storage usage accounting. `hls_version` needs no change (pure string ops). `cleanup_hls_directory_for_media` already keys off `media.uid`, not `hls_file`.
- **URL hardening** — `url_from_path` now strips an absolute `MEDIA_ROOT` prefix even when the stored value and the setting disagree about a trailing slash, and passes relative names through as before (all other callers already send relative `.name` values — behavior is byte-identical for them).
- **Backfill** — data migration `0033_relative_hls_file` rewrites existing rows. It is idempotent and anchors on the `/hls/` directory marker (HLS output always lives under `MEDIA_ROOT/hls/`), so it also converts rows whose stored prefix no longer matches the current `MEDIA_ROOT` — the exact failure mode this issue describes. A reverse operation restores absolute paths for clean rollback.

**Deploy/rollout safety:** new code + old (absolute) rows work via the tolerant reader, so the standard deploy order (code out, then `migrate`) has no bad window. Old code + migrated rows is the only bad combination — relevant only for a rollback, which the reverse migration covers. No files move on disk, no re-encode, and generated URLs are byte-identical before/after, so no CDN invalidation is needed.

## Related Issue

Fixes #789

## Motivation and Context

If `MEDIA_ROOT` ever changes (server migration, container-vs-host path, trailing-slash drift), the `replace()` compensation fails: `hls_info` URLs embed the raw server path (breaking all HLS playback and leaking filesystem layout), and every existing row needs a data fix anyway. Relative storage removes the runtime dependency on the absolute prefix — the same portability rationale as the earlier relative-path work for uploaded files.

## How Has This Been Tested?

- New `files/tests/test_hls_relative_path.py` (13 tests): tolerant reader (relative / legacy-absolute / empty), `url_from_path` (relative passthrough, matching root, trailing-slash mismatch), `hls_path_to_relative` idempotency and foreign-prefix conversion via the `/hls/` marker, migration forward/backward transforms, and `hls_info` end-to-end from a relative row with a real `master.m3u8` on disk.
- Updated the six existing assertions in `test_hls_encryption.py` / `test_storage_usage.py` that pinned the old absolute storage format (they now resolve through `hls_file_path`).
- HLS-related suites: 61/61 passing. Full `files` app: 426 tests — the only 4 failures are **pre-existing** search/taxonomy environment failures, verified identical with this change stashed.
- **Manual test on a live dev DB (Postgres + Redis):** seeded a media row with a legacy absolute `hls_file` and a real `master.m3u8` on disk → `hls_info` produced the correct URL via the tolerant reader **before** migrating; ran `manage.py migrate` for real → row rewritten to `hls/<uid>/<version>/master.m3u8`, `hls_info` URL **byte-identical** to the pre-migration output; fetched `/api/v1/media/<token>` through the real API (as owner) and confirmed `hls_info.master_file` is correct. Seed data cleaned up afterwards.
- Not tested: a real `create_hls` encode run (needs Bento4/ffmpeg in the environment); the write path is covered by the existing mocked `CreateHlsVersionedDirectoryTests`.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):

- [x] I have not imported `flux` in a new component
- [x] If adding a new feature, I used Modern Track patterns
- [x] New features do not create new SCSS files (use Tailwind instead)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of media and HLS paths across relative and legacy absolute formats.
  * Made media URL generation more robust, including trailing-slash mismatches and foreign-root safety.
  * Updated HLS existence checks, deletion cleanup, and storage-usage calculations to consistently use resolved HLS filesystem paths.

* **Maintenance**
  * Migrated HLS file references to MEDIA_ROOT-relative values while preserving legacy compatibility.
  * Regeneration now records updated HLS output using relative paths.

* **Tests**
  * Added comprehensive coverage for path conversion, migration rewriting, URL building, and HLS info behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->