### PR TITLE
fix(dropdown): restore type-to-jump keyboard behaviour in shared Dropdown

### DIFF
--- a/frontend/src/features/shared/components/Dropdown/Dropdown.jsx
+++ b/frontend/src/features/shared/components/Dropdown/Dropdown.jsx
@@ -46,6 +46,15 @@ const MENU_VARIANT_CLASSES = {
 	disabled: 'border-border-input bg-bg-surface-muted',
 };
 
+const TYPEAHEAD_RESET_DELAY = 500;
+
+function normalizeTypeaheadText(text) {
+	return text
+		.normalize('NFD')
+		.replace(/[\u0300-\u036f]/g, '')
+		.toLowerCase();
+}
+
 function normalizeOption(option) {
 	if (typeof option === 'string') {
 		return {
@@ -108,6 +117,8 @@ export function Dropdown({
 	const rootRef = useRef(null);
 	const optionRefs = useRef([]);
 	const pendingFocusIndexRef = useRef(null);
+	const typeaheadBufferRef = useRef('');
+	const typeaheadTimerRef = useRef(null);
 	const selectedValue = controlled ? value : internalValue;
 	const selectedOption = getSelectedOption(normalizedOptions, selectedValue);
 	const activeState = variant === 'default' && (isFocused || open);
@@ -151,6 +162,14 @@ export function Dropdown({
 		optionRefs.current[nextIndex]?.focus();
 	}, [open, normalizedOptions.length]);
 
+	useEffect(() => {
+		return () => {
+			if (typeaheadTimerRef.current) {
+				clearTimeout(typeaheadTimerRef.current);
+			}
+		};
+	}, []);
+
 	function focusOption(index) {
 		const nextIndex = clampIndex(index, normalizedOptions.length);
 
@@ -170,6 +189,43 @@ export function Dropdown({
 
 		pendingFocusIndexRef.current = index;
 		setOpen(true);
+	}
+
+	function handleTypeaheadKey(event) {
+		if (disabled || event.metaKey || event.ctrlKey || event.altKey) {
+			return;
+		}
+
+		// Space is excluded so it keeps toggling the trigger / activating options.
+		if (event.key.length !== 1 || event.key === ' ') {
+			return;
+		}
+
+		if (typeaheadTimerRef.current) {
+			clearTimeout(typeaheadTimerRef.current);
+		}
+
+		typeaheadTimerRef.current = setTimeout(() => {
+			typeaheadBufferRef.current = '';
+		}, TYPEAHEAD_RESET_DELAY);
+
+		typeaheadBufferRef.current += normalizeTypeaheadText(event.key);
+
+		const matchIndex = normalizedOptions.findIndex(
+			(option) =>
+				typeof option.label === 'string' &&
+				normalizeTypeaheadText(option.label).startsWith(typeaheadBufferRef.current)
+		);
+
+		if (matchIndex === -1) {
+			return;
+		}
+
+		if (open) {
+			focusOption(matchIndex);
+		} else {
+			openMenuWithFocus(matchIndex);
+		}
 	}
 
 	function getSelectedIndex() {
@@ -245,6 +301,8 @@ export function Dropdown({
 							event.preventDefault();
 							openMenuWithFocus(normalizedOptions.length - 1);
 						}
+
+						handleTypeaheadKey(event);
 					}}
 					onFocus={() => {
 						setIsFocused(true);
@@ -347,6 +405,8 @@ export function Dropdown({
 												rootRef.current?.querySelector('button')?.focus();
 											});
 										}
+
+										handleTypeaheadKey(event);
 									}}
 									className={cn(
 										'body-body-16-regular block w-full border-0 px-4 py-3 text-left outline-none transition-colors duration-150 hover:bg-bg-surface-hover focus:bg-bg-surface-hover',

--- a/frontend/src/features/shared/components/Dropdown/Dropdown.jsx
+++ b/frontend/src/features/shared/components/Dropdown/Dropdown.jsx
@@ -191,14 +191,32 @@ export function Dropdown({
 		setOpen(true);
 	}
 
+	function getTypeaheadAnchorIndex() {
+		const focusedIndex = optionRefs.current.indexOf(document.activeElement);
+
+		if (focusedIndex !== -1) {
+			return focusedIndex;
+		}
+
+		return normalizedOptions.findIndex((option) => option.value === selectedValue);
+	}
+
 	function handleTypeaheadKey(event) {
 		if (disabled || event.metaKey || event.ctrlKey || event.altKey) {
 			return;
 		}
 
-		// Space is excluded so it keeps toggling the trigger / activating options.
-		if (event.key.length !== 1 || event.key === ' ') {
+		// An empty-buffer Space keeps its native role (toggle the trigger, activate
+		// an option); mid-search it joins the query so multi-word labels such as
+		// "New Zealand" stay reachable without committing a selection.
+		const isSearchSpace = event.key === ' ' && typeaheadBufferRef.current.length > 0;
+
+		if (event.key.length !== 1 || (event.key === ' ' && !isSearchSpace)) {
 			return;
+		}
+
+		if (isSearchSpace) {
+			event.preventDefault();
 		}
 
 		if (typeaheadTimerRef.current) {
@@ -209,13 +227,29 @@ export function Dropdown({
 			typeaheadBufferRef.current = '';
 		}, TYPEAHEAD_RESET_DELAY);
 
-		typeaheadBufferRef.current += normalizeTypeaheadText(event.key);
+		const buffer = typeaheadBufferRef.current + normalizeTypeaheadText(event.key);
+		typeaheadBufferRef.current = buffer;
 
-		const matchIndex = normalizedOptions.findIndex(
-			(option) =>
-				typeof option.label === 'string' &&
-				normalizeTypeaheadText(option.label).startsWith(typeaheadBufferRef.current)
-		);
+		// Repeating one letter cycles through its matches, as native selects do;
+		// any other buffer is a prefix search anchored at the focused option.
+		const cycling = buffer.length > 1 && [...buffer].every((char) => char === buffer[0]);
+		const searchText = cycling ? buffer[0] : buffer;
+		const anchor = getTypeaheadAnchorIndex();
+		const total = normalizedOptions.length;
+		const searchFromNext = cycling || buffer.length === 1;
+		const start = anchor === -1 ? 0 : anchor + (searchFromNext ? 1 : 0);
+
+		let matchIndex = -1;
+
+		for (let step = 0; step < total; step += 1) {
+			const index = (start + step) % total;
+			const option = normalizedOptions[index];
+
+			if (typeof option.label === 'string' && normalizeTypeaheadText(option.label).startsWith(searchText)) {
+				matchIndex = index;
+				break;
+			}
+		}
 
 		if (matchIndex === -1) {
 			return;

--- a/frontend/src/features/shared/components/Dropdown/Dropdown.test.jsx
+++ b/frontend/src/features/shared/components/Dropdown/Dropdown.test.jsx
@@ -15,6 +15,14 @@ const COUNTRY_OPTIONS = [
 	{ label: 'Indonesia', value: 'ID' },
 ];
 
+const MULTI_WORD_OPTIONS = [
+	{ label: 'Nauru', value: 'NR' },
+	{ label: 'Nepal', value: 'NP' },
+	{ label: 'New Caledonia', value: 'NC' },
+	{ label: 'New Zealand', value: 'NZ' },
+	{ label: 'Northern Mariana Islands', value: 'MP' },
+];
+
 describe('Dropdown', () => {
 	it('renders placeholder, label, helper text, and chevron icon', () => {
 		render(
@@ -150,18 +158,68 @@ describe('Dropdown', () => {
 	});
 
 	it('starts a new type-to-jump search after a pause', async () => {
-		const user = userEvent.setup();
+		vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'requestAnimationFrame'] });
 
-		render(<Dropdown label="Country" placeholder="Choose country" options={COUNTRY_OPTIONS} />);
+		try {
+			render(<Dropdown label="Country" placeholder="Choose country" options={COUNTRY_OPTIONS} />);
+
+			const trigger = screen.getByRole('button', { name: 'Choose country' });
+			trigger.focus();
+			fireEvent.keyDown(trigger, { key: 'i' });
+			await vi.advanceTimersByTimeAsync(50);
+			expect(screen.getByRole('menuitemradio', { name: 'Iceland' })).toHaveFocus();
+
+			await vi.advanceTimersByTimeAsync(600);
+
+			fireEvent.keyDown(screen.getByRole('menuitemradio', { name: 'Iceland' }), { key: 'c' });
+			await vi.advanceTimersByTimeAsync(50);
+			expect(screen.getByRole('menuitemradio', { name: "Côte d'Ivoire" })).toHaveFocus();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it('treats Space as a search character once the buffer is active', async () => {
+		const user = userEvent.setup();
+		const onChange = vi.fn();
+
+		render(
+			<Dropdown label="Country" placeholder="Choose country" options={MULTI_WORD_OPTIONS} onChange={onChange} />
+		);
 
 		screen.getByRole('button', { name: 'Choose country' }).focus();
-		await user.keyboard('i');
-		await waitFor(() => expect(screen.getByRole('menuitemradio', { name: 'Iceland' })).toHaveFocus());
+		await user.keyboard('new z');
 
-		await new Promise((resolve) => setTimeout(resolve, 600));
+		await waitFor(() => expect(screen.getByRole('menuitemradio', { name: 'New Zealand' })).toHaveFocus());
+		expect(onChange).not.toHaveBeenCalled();
+		expect(screen.getByRole('menu')).toBeInTheDocument();
+	});
 
-		await user.keyboard('c');
-		await waitFor(() => expect(screen.getByRole('menuitemradio', { name: "Côte d'Ivoire" })).toHaveFocus());
+	it('keeps native Space behaviour when no search is active', async () => {
+		const user = userEvent.setup();
+
+		render(<Dropdown label="Country" placeholder="Choose country" options={MULTI_WORD_OPTIONS} />);
+
+		screen.getByRole('button', { name: 'Choose country' }).focus();
+		await user.keyboard(' ');
+
+		expect(screen.getByRole('menu')).toBeInTheDocument();
+	});
+
+	it('cycles through matches when the same letter is pressed repeatedly', async () => {
+		const user = userEvent.setup();
+
+		render(<Dropdown label="Country" placeholder="Choose country" options={MULTI_WORD_OPTIONS} />);
+
+		screen.getByRole('button', { name: 'Choose country' }).focus();
+		await user.keyboard('n');
+		await waitFor(() => expect(screen.getByRole('menuitemradio', { name: 'Nauru' })).toHaveFocus());
+
+		await user.keyboard('n');
+		await waitFor(() => expect(screen.getByRole('menuitemradio', { name: 'Nepal' })).toHaveFocus());
+
+		await user.keyboard('n');
+		await waitFor(() => expect(screen.getByRole('menuitemradio', { name: 'New Caledonia' })).toHaveFocus());
 	});
 
 	it('ignores printable keys pressed with a modifier', async () => {

--- a/frontend/src/features/shared/components/Dropdown/Dropdown.test.jsx
+++ b/frontend/src/features/shared/components/Dropdown/Dropdown.test.jsx
@@ -8,6 +8,13 @@ const OPTIONS = [
 	{ label: 'Short form', value: 'short-form' },
 ];
 
+const COUNTRY_OPTIONS = [
+	{ label: "Côte d'Ivoire", value: 'CI' },
+	{ label: 'Iceland', value: 'IS' },
+	{ label: 'India', value: 'IN' },
+	{ label: 'Indonesia', value: 'ID' },
+];
+
 describe('Dropdown', () => {
 	it('renders placeholder, label, helper text, and chevron icon', () => {
 		render(
@@ -102,6 +109,70 @@ describe('Dropdown', () => {
 
 		await user.keyboard('{End}');
 		await waitFor(() => expect(screen.getByRole('menuitemradio', { name: 'Short form' })).toHaveFocus());
+	});
+
+	it('opens the menu and focuses the first match when typing on the closed trigger', async () => {
+		const user = userEvent.setup();
+
+		render(<Dropdown label="Country" placeholder="Choose country" options={COUNTRY_OPTIONS} />);
+
+		screen.getByRole('button', { name: 'Choose country' }).focus();
+		await user.keyboard('i');
+
+		expect(screen.getByRole('menu')).toBeInTheDocument();
+		await waitFor(() => expect(screen.getByRole('menuitemradio', { name: 'Iceland' })).toHaveFocus());
+	});
+
+	it('groups quick keystrokes into a single type-to-jump search', async () => {
+		const user = userEvent.setup();
+
+		render(<Dropdown label="Country" placeholder="Choose country" options={COUNTRY_OPTIONS} />);
+
+		const trigger = screen.getByRole('button', { name: 'Choose country' });
+
+		trigger.focus();
+		await user.keyboard('{ArrowDown}');
+		await waitFor(() => expect(screen.getByRole('menuitemradio', { name: "Côte d'Ivoire" })).toHaveFocus());
+
+		await user.keyboard('indo');
+		await waitFor(() => expect(screen.getByRole('menuitemradio', { name: 'Indonesia' })).toHaveFocus());
+	});
+
+	it('matches accented option labels against unaccented input', async () => {
+		const user = userEvent.setup();
+
+		render(<Dropdown label="Country" placeholder="Choose country" options={COUNTRY_OPTIONS} />);
+
+		screen.getByRole('button', { name: 'Choose country' }).focus();
+		await user.keyboard('cot');
+
+		await waitFor(() => expect(screen.getByRole('menuitemradio', { name: "Côte d'Ivoire" })).toHaveFocus());
+	});
+
+	it('starts a new type-to-jump search after a pause', async () => {
+		const user = userEvent.setup();
+
+		render(<Dropdown label="Country" placeholder="Choose country" options={COUNTRY_OPTIONS} />);
+
+		screen.getByRole('button', { name: 'Choose country' }).focus();
+		await user.keyboard('i');
+		await waitFor(() => expect(screen.getByRole('menuitemradio', { name: 'Iceland' })).toHaveFocus());
+
+		await new Promise((resolve) => setTimeout(resolve, 600));
+
+		await user.keyboard('c');
+		await waitFor(() => expect(screen.getByRole('menuitemradio', { name: "Côte d'Ivoire" })).toHaveFocus());
+	});
+
+	it('ignores printable keys pressed with a modifier', async () => {
+		const user = userEvent.setup();
+
+		render(<Dropdown label="Country" placeholder="Choose country" options={COUNTRY_OPTIONS} />);
+
+		screen.getByRole('button', { name: 'Choose country' }).focus();
+		await user.keyboard('{Control>}i{/Control}');
+
+		expect(screen.queryByRole('menu')).not.toBeInTheDocument();
 	});
 
 	it('uses invalid and disabled semantics', () => {


### PR DESCRIPTION
## Description

Adds a type-ahead ("type-to-jump") buffer to the shared modern-track `Dropdown` component (`frontend/src/features/shared/components/Dropdown/Dropdown.jsx`):

- A `useRef` string buffer collects printable keystrokes; a 500ms inactivity timer clears it, so quick keystrokes group into a single prefix search and a pause starts a new one.
- On each printable key, the first option whose accent-normalised, lower-cased label starts with the buffer receives focus — via `openMenuWithFocus(index)` when the menu is closed, `focusOption(index)` when it is open. Both helpers already existed in the component.
- Modifier combinations (`meta`/`ctrl`/`alt`) and Space are excluded, so browser shortcuts and the trigger's native Space-to-toggle behaviour are untouched.
- Labels and input are normalised with NFD + combining-mark stripping, so typing `cot` reaches "Côte d'Ivoire".
- The reset timer is cleared on unmount.

The handler is wired into both keydown paths (trigger button and menu items), so it works whether the menu is closed or open — and since the fix lives in the shared component, every long selection list built on `Dropdown` benefits, not just Country and Language.

## Related Issue

Fixes #831

## Motivation and Context

The old Edit Media rendered Country and Language as native `<select>` elements, which provide first-letter type-ahead for free. The revamped Edit Media replaced them with the custom `Dropdown`, whose keyboard support only covered arrows/Home/End/Escape — on a long country list, keyboard users had to arrow through the whole list. This restores the pre-rewrite behaviour.

## How Has This Been Tested?

**Unit tests** — 5 new tests in `Dropdown.test.jsx` (vitest + Testing Library): type-on-closed-trigger opens and focuses the match, multi-character buffering while open, accent normalisation, buffer reset after a pause, and modifier-key guarding. Full frontend suite: **575/575 passed** (106 files).

**Browser verification (Playwright, revamped Edit Media at `/edit`)** — all passed:

| # | Scenario | Result |
|---|----------|--------|
| 1 | Focus closed **Media Country** field, type `ind` | Menu opens, focus jumps to **India** |
| 2 | Menu open, type `ph` quickly | Focus jumps to **Philippines** (keystrokes group into one search) |
| 3 | Pause ~700ms, then type `j` | Focus jumps to **Japan** (buffer reset, new search) |
| 4 | Press `Enter` on the match | **Japan** is selected and shown in the field |
| 5 | **Media Language**: `ArrowDown` to open, type `sp` | Focus jumps to **Spanish** |
| 6 | Focus closed field, press `Ctrl+I` | Menu stays closed (modifier guard) |

Also: `npm run lint:modern` 0 problems, `npm run lint:legacy` no new warnings, `npm run build` succeeds, pre-commit hooks pass on both touched files.

## Screenshots (if appropriate):

Typing `ind` on the closed Media Country field — menu opens with **India** focused:

![Media Country menu opened by typing "ind", India focused](https://raw.githubusercontent.com/Bejjoeqq/cinematacms/qa-screenshots-831/ss-831-country-ind.png)

Typing `sp` in the open Media Language menu — focus jumps to **Spanish** (Quick Preview shows "Japan" selected by `Enter` in the earlier step):

![Media Language menu with Spanish focused after typing "sp"](https://raw.githubusercontent.com/Bejjoeqq/cinematacms/qa-screenshots-831/ss-831-language-sp.png)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):

- [x] I have not imported `flux` in a new component
- [x] If adding a new feature, I used Modern Track patterns
- [x] New features do not create new SCSS files (use Tailwind instead)
