### PR TITLE
fix(nav): rename sidebar item to "My Profile", remove duplicate "My media" (#836)

### DIFF
--- a/frontend/src/features/layout/Sidebar/navigation/SidebarNavigationMenu.jsx
+++ b/frontend/src/features/layout/Sidebar/navigation/SidebarNavigationMenu.jsx
@@ -98,7 +98,7 @@ export function SidebarNavigationMenu() {
 				items.push({
 					link: user.pages?.home || links.user.addMedia,
 					icon: 'myMedia',
-					text: 'My Media & Playlist',
+					text: 'My Profile',
 					className: 'nav-item-upload-media',
 					activePattern: 'userProfile',
 				});

--- a/frontend/src/static/js/contexts/HeaderContext.js
+++ b/frontend/src/static/js/contexts/HeaderContext.js
@@ -23,14 +23,6 @@ function popupTopNavItems() {
 					className: 'visible-only-in-small',
 				},
 			});
-
-			if (user.pages.home) {
-				items.push({
-					link: user.pages.home,
-					icon: 'video_library',
-					text: 'My media',
-				});
-			}
 		}
 
 		items.push({


### PR DESCRIPTION
## Description

Two label/menu changes, no routing changes, no new components:

1. **Sidebar** — `frontend/src/features/layout/Sidebar/navigation/SidebarNavigationMenu.jsx`: the `MainMenuSecondSection` item text changes from `'My Media & Playlist'` to `'My Profile'`. Everything else about the item is untouched: same `user.pages?.home` destination, same icon, same `nav-item-upload-media` className (the `_extra.css` sprite rules key off it), same `userProfile` active pattern.
2. **Avatar dropdown** — `frontend/src/static/js/contexts/HeaderContext.js`: the `popupTopNavItems()` block that pushed the "My media" item is removed. "Upload media" and "Sign out" remain.

### Note on the issue's file pointer

The issue's implementation section points the sidebar rename at the legacy `static/js/components/-NEW-/SidebarNavigationMenu.js`, but the label being renamed only exists in the modern-track sidebar (`features/layout/Sidebar/navigation/SidebarNavigationMenu.jsx`) — the one the revamped layout actually renders. The legacy sidebar file has different items ("Upload media" / "My media" / "My playlists") that belong to the non-rendered legacy variant, so it is left untouched.

### Note on the empty-section concern

The issue asks to confirm the dropdown doesn't leave a stray divider or empty section on desktop once "My media" is gone. The modern `TopbarUserMenu` flattens `popupNavItems.top/middle/bottom` into a single list with only one divider (before Sign out), and it does not apply the legacy `visible-only-in-small` class, so "Upload media" remains visible at all widths. No empty section is possible; no guard was needed.

## Related Issue

Fixes #836

## Motivation and Context

"My Media & Playlist" truncated to "My Media & Play…" at the current sidebar width and described two of the profile page's eight tabs — neither of which is the About tab it actually lands on. "My Profile" is accurate and fits. The dropdown's "My media" was the third route to the same destination inside a single menu (account card + sidebar item already cover it), so removing it reduces noise without removing any capability.

## How Has This Been Tested?

- Full frontend suite: **604/604 passed** (110 files) — no test referenced the old labels.
- `npm run lint:modern`: 0 problems. `npm run lint:legacy`: 367 pre-existing warnings, none on the touched files, no new ones.
- `npm run build`: production build succeeds; pre-commit hooks pass on both touched files.

**Browser verification (Playwright, revamped UI, logged in as a regular user)** — all passed:

| # | Scenario | Result |
|---|----------|--------|
| 1 | Sidebar label | Reads "My Profile", no truncation (`scrollWidth == clientWidth`), icon renders, links to `/user/<username>` |
| 2 | Active state | On the profile page the item carries `aria-current="page"` and the active highlight |
| 3 | Avatar dropdown | Account card ("View profile"), Upload media, Edit profile, Change password, Sign out — no "My media", no empty section or stray divider |
| 4 | Anonymous user | No "My Profile" item, no avatar menu, Sign in button unchanged |

(The "MediaCMS administration" entry is admin-only and its block is untouched by this diff, so it isn't shown in the screenshots.)

## Screenshots (if appropriate):

Sidebar with the renamed item active on the profile page:

![Sidebar showing "My Profile" with active highlight on the profile page](https://raw.githubusercontent.com/Bejjoeqq/cinematacms/qa-screenshots-836/ss-836-sidebar-active.png)

Avatar dropdown without "My media":

![Open avatar dropdown showing account card, Upload media, Edit profile, Change password, Sign out](https://raw.githubusercontent.com/Bejjoeqq/cinematacms/qa-screenshots-836/ss-836-dropdown.png)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):

- [x] I have not imported `flux` in a new component
- [x] If adding a new feature, I used Modern Track patterns
- [x] New features do not create new SCSS files (use Tailwind instead)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the sidebar label to clearly identify the “My Profile” section.
  * Removed the outdated “My media” item from the top navigation menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->