### PR TITLE
fix(profile): open Notes tab when opening a film from My Notes (#835)

### DIFF
--- a/frontend/src/features/profile/components/sections/NoteEntry.jsx
+++ b/frontend/src/features/profile/components/sections/NoteEntry.jsx
@@ -1,16 +1,25 @@
 import { formatDuration } from '../../../shared/utils/formatDuration';
 import { formatClock, formatTimestamp } from '../../../video-viewer/private-journal/utils/journalMedia';
 
-// Deep-link back into the film at the note's timestamp: /view?m=<token>&t=<seconds>.
+// Deep-link back into the film at the note's timestamp, opening the Notes tab:
+// /view?m=<token>&t=<seconds>&tab=notes. The `tab=notes` marker tells the media
+// page to select the "Your Notes" tab instead of the default Comments tab.
 function noteHref(media) {
 	const seconds = Math.max(0, Math.floor(Number(media?.timestamp_seconds) || 0));
-	const base = media?.url || (media?.friendly_token ? `/view?m=${encodeURIComponent(media.friendly_token)}` : '#');
+	const base = mediaBase(media);
 	if (base === '#') return base;
 	const separator = base.includes('?') ? '&' : '?';
-	return `${base}${separator}t=${seconds}`;
+	return `${base}${separator}t=${seconds}&tab=notes`;
 }
 
 function filmHref(media) {
+	const base = mediaBase(media);
+	if (base === '#') return base;
+	const separator = base.includes('?') ? '&' : '?';
+	return `${base}${separator}tab=notes`;
+}
+
+function mediaBase(media) {
 	return media?.url || (media?.friendly_token ? `/view?m=${encodeURIComponent(media.friendly_token)}` : '#');
 }
 

--- a/frontend/src/features/profile/components/sections/NotesSection.test.jsx
+++ b/frontend/src/features/profile/components/sections/NotesSection.test.jsx
@@ -63,12 +63,13 @@ describe('NotesSection', () => {
 		// (2:00) shows as a pill on the thumbnail.
 		expect(screen.getByText('1:05')).toBeInTheDocument();
 		expect(screen.getByText('2:00')).toBeInTheDocument();
+		// Links carry `tab=notes` so the media page opens the Your Notes tab (#835).
 		const link = screen.getByRole('link', { name: /open my film at 1:05/i });
-		expect(link).toHaveAttribute('href', '/view?m=abc&t=65');
+		expect(link).toHaveAttribute('href', '/view?m=abc&t=65&tab=notes');
 		// Count comes from the server-provided note_count, not the array length.
 		expect(screen.getByRole('link', { name: /view all 2 notes on this film/i })).toHaveAttribute(
 			'href',
-			'/view?m=abc'
+			'/view?m=abc&tab=notes'
 		);
 	});
 

--- a/frontend/src/features/video-viewer/components/page/VideoViewerPage.jsx
+++ b/frontend/src/features/video-viewer/components/page/VideoViewerPage.jsx
@@ -25,6 +25,18 @@ function isLoggedInUser() {
 	return window.MediaCMS?.user?.is?.anonymous === false;
 }
 
+// Deep-links from the profile's "My Notes" page carry `?tab=notes` so the media
+// page opens on the Your Notes tab rather than the default Comments tab. TabView
+// clamps to a valid tab, so this safely no-ops for anonymous users (no Notes tab).
+function requestedTab() {
+	if (typeof window === 'undefined') return undefined;
+	try {
+		return new URLSearchParams(window.location.search).get('tab') === 'notes' ? 'your-notes' : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
 export class VideoViewerPage extends Page {
 	constructor(props) {
 		super(props, 'media');
@@ -150,6 +162,7 @@ export class VideoViewerPage extends Page {
 			<div className="viewer-sidebar-comments mb-6 box-border w-full" key="viewer-comments">
 				<TabView
 					tabMode="wrap"
+					defaultSelectedTab={requestedTab()}
 					listClassName="rounded-none rounded-tl-ds-8 rounded-tr-ds-8"
 					triggerClassName="rounded-none py-3 px-size-22 text-text-tab-trigger aria-selected:text-text-primary"
 					triggerSelectedColor="bg-bg-surface"


### PR DESCRIPTION
## Description
On the profile **My Notes** page, the "View all N Notes on this Film" button (and the per-note timestamp links) navigated to the plain film page (`/view?m=<token>`), which always opens the **Comments** tab. Since the button is named "View Notes", it should land on the **Your Notes** tab.

This PR makes those deep-links carry a `tab=notes` marker, and has the media page select the "Your Notes" tab when that marker is present.

- `NoteEntry.jsx` — append `&tab=notes` to the film/note deep-links (shared `mediaBase()` helper handles the `?`/`&` separator, since some `media.url` values already contain `?m=`).
- `VideoViewerPage.jsx` — read `?tab=notes` from the URL and pass `defaultSelectedTab="your-notes"` to the existing `TabView`. `TabView` clamps to a valid tab, so this safely no-ops for anonymous users (who have no Notes tab).

## Related Issue
Fixes #835

## Motivation and Context
The button name promises Notes but delivered Comments, which is confusing. This aligns the navigation with the affordance's label.

## How Has This Been Tested?
- Updated `NotesSection.test.jsx` href assertions to expect the `tab=notes` marker.
- Ran `NotesSection` + `TabView` Vitest suites — 16 tests pass.
- `TabView`'s `defaultSelectedTab` (including clamping to a valid tab) is already covered by existing `TabView.test.jsx`.
- Pre-commit (prettier/whitespace) clean on all changed files.

Environment: modern track only (`media_revamp.html`), where the Notes tab lives.

## Screenshots (if appropriate):
N/A — behavioral change (tab selection on navigation).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):
- [x] I have not imported `flux` in a new component
- [x] If adding a new feature, I used Modern Track patterns
- [x] New features do not create new SCSS files (use Tailwind instead)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Media links that include notes now open directly to the “Your Notes” tab.
  * Note links preserve the relevant playback timestamp when opening a video.

* **Bug Fixes**
  * Updated note and film links to consistently include the correct query parameters.
  * Anonymous viewers and unsupported browsing environments continue to open safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->