### PR TITLE
fix(profile): verified seal icon in header and rounded outer tab corners

### DIFF
--- a/frontend/src/features/profile/components/ProfileHeader.jsx
+++ b/frontend/src/features/profile/components/ProfileHeader.jsx
@@ -51,7 +51,12 @@ export function ProfileHeader({ author }) {
 								{displayName}
 							</Text>
 							{author.email_is_verified ? (
-								<Icon name="check" size="sm" label="Email verified" className="text-text-success" />
+								<Icon
+									name="verifiedCheck"
+									size="md"
+									label="Email verified"
+									className="text-text-success"
+								/>
 							) : null}
 						</div>
 						<Text as="p" variant="body-16" className="mt-1 mb-0 text-text-accent">

--- a/frontend/src/features/profile/components/ProfileTabs.jsx
+++ b/frontend/src/features/profile/components/ProfileTabs.jsx
@@ -7,7 +7,7 @@ export function ProfileTabs({ activeTab, tabs }) {
 			tabMode="wrap"
 			aria-label="Profile sections"
 			className="w-full"
-			listClassName="rounded-none"
+			listClassName="rounded-none rounded-tl-ds-8 rounded-tr-ds-8"
 			triggerClassName="min-w-max no-underline text-text-tab-trigger"
 			triggerSelectedColor="bg-bg-tab-trigger-selected"
 		>


### PR DESCRIPTION
## Description
Two small visual fixes to the modern-track (revamped) profile page so it matches the Figma design:

1. **Profile header verified checkmark** — the header rendered a bare `check` tick, while the Similar Profiles card uses the `verifiedCheck` seal (badge with tick inside). Switched the header to the same `verifiedCheck` seal for consistency, and bumped its size from `sm` (18px) to `md` (24px) so it reads at the scale of the name text.
2. **Profile tabs corners** — the tab strip forced `rounded-none`, squaring off every corner. The design rounds only the outer top-left and top-right corners (8px). Changed to `rounded-none rounded-tl-ds-8 rounded-tr-ds-8`, matching the pattern already used by the video-viewer tabs.

## Related Issue
<!--- Please link to the issue here: -->
N/A

## Motivation and Context
The revamped profile page diverged from the design:
- The header check used a different glyph than the Similar Profiles card (`check` vs `verifiedCheck`) and looked undersized next to the name.
- The tabs lacked the rounded outer top corners shown in `jeremy-tasks/design/new-profile/profile-tabs.svg` (clip path = 8px radius on top corners only, square bottom).

Both are purely presentational and align the implementation with the exported Figma specs.

## How Has This Been Tested?
- Local frontend dev server (`make frontend-dev`), viewed a verified user's profile page.
- Verified the header now shows the green `verifiedCheck` seal at 24px (gated on `author.email_is_verified`, unchanged).
- Verified the tab strip renders rounded top-left/top-right corners on the outer tabs with the bottom edge square, matching the design SVG; checked first/last-tab clipping via the existing `overflow-hidden` on the tab list.
- `pre-commit` (prettier) passes on both changed files.

## Screenshots (if appropriate):
<img width="1543" height="484" alt="image" src="https://github.com/user-attachments/assets/6dccdc3f-6cba-4285-b527-9b6162ce8c00" />

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):
- [x] I have not imported `flux` in a new component
- [x] If adding a new feature, I used Modern Track patterns
- [x] New features do not create new SCSS files (use Tailwind instead)
