### PR TITLE
fix(profile): restore Private/Unlisted/Restricted icons on user media page

### DIFF
--- a/frontend/src/features/profile/components/MediaGrid.test.jsx
+++ b/frontend/src/features/profile/components/MediaGrid.test.jsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import { MediaGrid } from './MediaGrid';
+
+function mediaItem(overrides) {
+	return {
+		friendly_token: 'abc123',
+		title: 'A Film',
+		url: '/view?m=abc123',
+		thumbnail_url: '/media/thumb.jpg',
+		...overrides,
+	};
+}
+
+describe('MediaGrid visibility indicators', () => {
+	it.each([
+		['private', 'eyeSlash', 'Private'],
+		['unlisted', 'link', 'Unlisted'],
+		['restricted', 'lockKey', 'Restricted'],
+	])('marks a %s film with its visibility icon', (state, iconName, label) => {
+		render(<MediaGrid items={[mediaItem({ state })]} />);
+
+		const icon = screen.getByRole('article').querySelector(`svg[data-icon="${iconName}"]`);
+
+		expect(icon).not.toBeNull();
+		expect(icon).toHaveAttribute('aria-label', label);
+	});
+
+	it('leaves a public film unmarked', () => {
+		render(<MediaGrid items={[mediaItem({ state: 'public' })]} />);
+
+		expect(screen.getByRole('article').querySelector('[data-movie-item-icon-chip]')).toBeNull();
+	});
+});

--- a/frontend/src/features/profile/utils/media.js
+++ b/frontend/src/features/profile/utils/media.js
@@ -3,9 +3,22 @@ import { buildMetadata, getCategoryBadge } from '../../video-viewer/utils/mediaC
 
 export { normalizeMediaList };
 
+// Owners, managers and curators get their non-public media back from /api/v1/media,
+// so the card has to say which visibility state each film is in.
+const VISIBILITY_INDICATORS = {
+	private: { iconName: 'eyeSlash', iconLabel: 'Private' },
+	unlisted: { iconName: 'link', iconLabel: 'Unlisted' },
+	restricted: { iconName: 'lockKey', iconLabel: 'Restricted' },
+};
+
+export function getVisibilityIndicator(state) {
+	return VISIBILITY_INDICATORS[state] || {};
+}
+
 export function getMovieItemProps(item, { hideAuthor = false } = {}) {
 	return {
 		...getCategoryBadge(item),
+		...getVisibilityIndicator(item.state),
 		title: item.title,
 		imageSrc: item.thumbnail_url,
 		link: item.url,

--- a/frontend/src/features/shared/components/MovieItem/MovieItem.jsx
+++ b/frontend/src/features/shared/components/MovieItem/MovieItem.jsx
@@ -148,7 +148,13 @@ function MoviePoster({
 					className="absolute top-2 right-2 inline-flex rounded bg-bg-secondary/90 p-1 text-text-on-primary"
 					data-movie-item-icon-chip
 				>
-					<Icon name={iconName} size={14} decorative={iconLabel ? false : true} label={iconLabel} />
+					<Icon
+						name={iconName}
+						size={14}
+						decorative={iconLabel ? false : true}
+						label={iconLabel}
+						title={iconLabel}
+					/>
 				</span>
 			) : null}
 		</div>

--- a/frontend/src/features/shared/icons/link.svg
+++ b/frontend/src/features/shared/icons/link.svg
@@ -1,4 +1,4 @@
-<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="18" height="18" viewBox="-1.5 -1.5 21 21" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M6.75 11.25L11.25 6.75" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
 <path d="M8.625 4.125L9.75 3C10.7 2.05 12 1.5 13.5 1.5C15 1.5 16.3 2.05 17.25 3C18.2 3.95 18.75 5.25 18.75 6.75C18.75 8.25 18.2 9.55 17.25 10.5L16.125 11.625" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M9.375 13.875L8.25 15C7.3 15.95 6 16.5 4.5 16.5C3 16.5 1.7 15.95 0.75 15C-0.2 14.05 -0.75 12.75 -0.75 11.25C-0.75 9.75 -0.2 8.45 0.75 7.5L1.875 6.375" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>


### PR DESCRIPTION
## Problem

M3-018 (P0 regression). Visibility indicators disappeared from a user's media page, so owners cannot tell which of their films are private, unlisted or restricted.

## Cause

The profile rewrite (#784) replaced the `ListItem` grid — which rendered `MediaItemStateBadge` — with `MediaGrid` → `VerticalMovieItem`, but `getMovieItemProps` never mapped `item.state` onto the card. The backend was never involved: `/api/v1/media?author=` still returns non-public media and its `state` to owners, managers, curators and superusers (`files/views.py:1511`, `MediaSerializer`).

## Fix

- `features/profile/utils/media.js` — map `state` to the icon chip `VerticalMovieItem` already supports: `private` → `eyeSlash`, `unlisted` → `link`, `restricted` → `lockKey`. Public and unknown states render nothing.
- `MovieItem.jsx` — the chip icon also gets `title`, so it has a hover tooltip and not only an aria-label.
- `link.svg` — the asset drew outside its own viewBox (paths reach `x=-0.75` and `x=18.75` inside `0 0 18 18`), clipping the chain ends at any chip size. viewBox widened to fit the artwork; no other component renders this icon.

## Tests

- New `MediaGrid.test.jsx` asserts each state's icon and label through the grid, and that a public film renders no chip. Written failing first against the regression.
- `vitest run src/features/profile src/features/shared/components` — 44 files / 253 tests pass.

## Manual verification

Ran the app (Django + Vite dev) against a seeded owner account with one film per state, viewed as an authenticated admin on `/user/<username>/media`: restricted → `lockKey` "Restricted", unlisted → `link` "Unlisted", private → `eyeSlash` "Private", public → no chip. No console errors.

<img width="1453" height="840" alt="screenshot-1785908512552-1" src="https://github.com/user-attachments/assets/c621d719-a410-4f30-b2e0-961b1b543bdf" />

