### PR TITLE
fix: harden observability metric handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,9 @@ automated installation, pass `--non-interactive` with `--domain`, `--proxy`,
 and `--observability`. The [deployment guide](deploy/README.md) lists the
 options and the upgrade command.
 
+The production installer supports Ubuntu 22.04 on `amd64` and `arm64`. Run
+`./install.sh --check-platform` on the target host before installation.
+
 The installer runs database migrations and seeds django-waffle feature flag
 switches automatically.
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,13 @@ chmod +x install.sh
 ./install.sh
 ```
 
-The installer runs database migrations and seeds django-waffle feature flag switches automatically.
+The installer prompts for the domain, proxy, and observability settings. For an
+automated installation, pass `--non-interactive` with `--domain`, `--proxy`,
+and `--observability`. The [deployment guide](deploy/README.md) lists the
+options and the upgrade command.
+
+The installer runs database migrations and seeds django-waffle feature flag
+switches automatically.
 
 **Local development (macOS, Linux, or Windows):** Follow the
 [developer onboarding guide](docs/setup/Developer-Onboarding.md). The

--- a/cms/settings.py
+++ b/cms/settings.py
@@ -160,7 +160,10 @@ OTEL_ENABLED = os.getenv("OTEL_ENABLED", "false").lower() in ("1", "true", "yes"
 OTEL_SERVICE_NAME = os.getenv("OTEL_SERVICE_NAME", "cinematacms")
 OTEL_EXPORTER_OTLP_ENDPOINT = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://127.0.0.1:4318/v1/traces")
 OTEL_EXPORTER_OTLP_HEADERS = os.getenv("OTEL_EXPORTER_OTLP_HEADERS", "")
-OTEL_TRACES_SAMPLER_ARG = float(os.getenv("OTEL_TRACES_SAMPLER_ARG", "1.0"))
+try:
+    OTEL_TRACES_SAMPLER_ARG = float(os.getenv("OTEL_TRACES_SAMPLER_ARG", "1.0"))
+except ValueError:
+    OTEL_TRACES_SAMPLER_ARG = 1.0
 OBSERVABILITY_CELERY_QUEUES = ["long_tasks", "short_tasks", "whisper_tasks"]
 OBSERVABILITY_SLOW_REQUEST_SECONDS = 2.0
 OBSERVABILITY_SLOW_QUERY_SECONDS = 1.0

--- a/cms/settings.py
+++ b/cms/settings.py
@@ -156,13 +156,11 @@ FILE_UPLOAD_HANDLERS = [
 
 LOGS_DIR = os.path.join(BASE_DIR, "logs")
 
-# Observability settings are intentionally defined here, not read from .env.
-# Production currently manages runtime configuration through settings.py.
-OTEL_ENABLED = False
-OTEL_SERVICE_NAME = "cinematacms"
-OTEL_EXPORTER_OTLP_ENDPOINT = "http://127.0.0.1:4318/v1/traces"
-OTEL_EXPORTER_OTLP_HEADERS = ""
-OTEL_TRACES_SAMPLER_ARG = 1.0
+OTEL_ENABLED = os.getenv("OTEL_ENABLED", "false").lower() in ("1", "true", "yes")
+OTEL_SERVICE_NAME = os.getenv("OTEL_SERVICE_NAME", "cinematacms")
+OTEL_EXPORTER_OTLP_ENDPOINT = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://127.0.0.1:4318/v1/traces")
+OTEL_EXPORTER_OTLP_HEADERS = os.getenv("OTEL_EXPORTER_OTLP_HEADERS", "")
+OTEL_TRACES_SAMPLER_ARG = float(os.getenv("OTEL_TRACES_SAMPLER_ARG", "1.0"))
 OBSERVABILITY_CELERY_QUEUES = ["long_tasks", "short_tasks", "whisper_tasks"]
 OBSERVABILITY_SLOW_REQUEST_SECONDS = 2.0
 OBSERVABILITY_SLOW_QUERY_SECONDS = 1.0

--- a/cms/tests/test_observability.py
+++ b/cms/tests/test_observability.py
@@ -127,6 +127,58 @@ class CacheMetricTests(SimpleTestCase):
         record.assert_called_once_with("query", "get", hit=True)
 
 
+class MetricFailureIsolationTests(SimpleTestCase):
+    def test_cache_fallback_survives_metric_failure(self):
+        from files import cache_utils
+
+        with (
+            patch.object(cache_utils.cache, "get", return_value=True),
+            patch("files.metrics.CACHE_OPERATIONS_TOTAL.labels", side_effect=RuntimeError("metrics unavailable")),
+        ):
+            self.assertTrue(cache_utils.get_cached_permission("permission-key"))
+
+    def test_media_observation_survives_profile_metric_failure(self):
+        from files.metrics import observe_media_pipeline
+
+        media = SimpleNamespace(media_type="video", duration=120, media_file=SimpleNamespace(size=123456))
+        profile = SimpleNamespace(resolution=720, codec="h264", extension="mp4")
+        with (
+            patch("files.metrics.MEDIA_ENCODING_PROFILE_TOTAL.labels", side_effect=RuntimeError("metrics unavailable")),
+            patch("files.metrics.MEDIA_DURATION_SECONDS") as duration,
+            patch("files.metrics.MEDIA_FILE_SIZE_BYTES") as file_size,
+        ):
+            duration.labels.return_value.observe = Mock()
+            file_size.labels.return_value.observe = Mock()
+
+            observe_media_pipeline(media, profile, "success")
+
+        duration.labels.return_value.observe.assert_called_once_with(120)
+        file_size.labels.return_value.observe.assert_called_once_with(123456)
+
+    def test_stale_encoding_recovery_survives_metric_failure(self):
+        from files.metrics import record_stale_encoding
+
+        encoding = SimpleNamespace(
+            profile=SimpleNamespace(resolution=720, codec="h264", extension="mp4"),
+        )
+        with patch("files.metrics.ENCODING_STALE_TOTAL.labels", side_effect=RuntimeError("metrics unavailable")):
+            record_stale_encoding(encoding)
+
+
+class RuntimeGaugeTests(SimpleTestCase):
+    def test_runtime_snapshot_gauges_use_mostrecent_multiprocess_mode(self):
+        from files import metrics
+
+        snapshot_gauges = {
+            "celery queue depth": metrics.CELERY_QUEUE_DEPTH,
+            "transcription requests": metrics.TRANSCRIPTION_REQUESTS,
+            "stalled encodings": metrics.ENCODING_STALLED,
+        }
+        for name, gauge in snapshot_gauges.items():
+            with self.subTest(metric=name):
+                self.assertEqual(gauge._multiprocess_mode, "mostrecent")
+
+
 class CeleryAndMediaMetricTests(SimpleTestCase):
     def test_celery_task_signal_helpers_record_lifecycle(self):
         from files import metrics

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,10 +1,95 @@
-# Deploy Resources
+# Deploy CinemataCMS
 
-## Certificate Files (.pem)
-The .pem files in this directory are **placeholder self-signed certificates** used only during initial installation. They:
-- Are NEVER used in production environments
-- Are automatically replaced by Let's Encrypt certificates during installation on real domains
-- Only facilitate bootstrapping the installation process
-- Contain no sensitive cryptographic material
+Use `install.sh` for a new Ubuntu 22.04 server. Use
+`deploy/apply-release-config.sh` after an application upgrade. Both commands use
+the same nginx, systemd, and observability files.
 
-These files allow the installer to set up a working HTTPS configuration before proper certificates are obtained. For security reasons, you should always obtain proper certificates for production deployments.
+## Install a new server
+
+Run the interactive installer:
+
+```bash
+sudo ./install.sh
+```
+
+The installer asks for the portal hostname, portal name, reverse proxy mode,
+and observability mode. Run the installer without prompts for an automated
+deployment:
+
+```bash
+sudo ./install.sh \
+  --non-interactive \
+  --domain video.example.org \
+  --portal-name "Example Video" \
+  --proxy cloudflare \
+  --observability local
+```
+
+Use `--proxy none` when nginx receives traffic directly. Use
+`--proxy cloudflare` only when Cloudflare proxies the domain.
+
+The `local` observability mode installs the Ubuntu Prometheus package and the
+pinned OpenTelemetry Collector Contrib package when they are missing.
+Prometheus listens on `127.0.0.1:9090` and scrapes the protected nginx
+`/metrics` endpoint. The collector listens for OTLP HTTP traces on
+`127.0.0.1:4318` and writes trace summaries to its systemd journal. Run these
+commands to inspect each service:
+
+```bash
+curl --fail http://127.0.0.1:9090/-/healthy
+sudo journalctl -u cinematacms-otelcol
+```
+
+Use `--observability none` when another deployment system manages Prometheus
+and trace collection.
+
+Run a dry run to validate installer options without changing the server:
+
+```bash
+./install.sh \
+  --non-interactive \
+  --domain video.example.org \
+  --proxy none \
+  --observability none \
+  --dry-run
+```
+
+## Apply release configuration
+
+The installer saves the selected domain, proxy, and observability modes in
+`/etc/cinematacms/deployment.env`. After you update the repository, apply its
+deployment files:
+
+```bash
+sudo ./deploy/apply-release-config.sh
+```
+
+The updater performs these actions:
+
+1. Backs up every file that it changes under `/var/backups/cinematacms/`.
+2. Installs the nginx metrics restriction and the selected proxy config.
+3. Installs the application and observability systemd units.
+4. Runs `nginx -t`.
+5. Restores the backup if nginx rejects the configuration.
+6. Restarts the affected services and reloads nginx.
+
+Pass new proxy or observability values to change the saved deployment settings:
+
+```bash
+sudo ./deploy/apply-release-config.sh \
+  --proxy cloudflare \
+  --observability local
+```
+
+The updater rejects domain changes because nginx and Certbot must change
+together. To change the domain, update the nginx certificate and site config as
+one maintenance operation.
+
+Use `--no-restart` to install and validate files without restarting services.
+
+## Placeholder certificates
+
+The `.pem` files in this directory are placeholder self-signed certificates
+for initial installation. The installer replaces them with Let's Encrypt
+certificates for a real domain. Do not use the placeholder certificates in
+production.

--- a/deploy/apply-release-config.sh
+++ b/deploy/apply-release-config.sh
@@ -1,0 +1,311 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEPLOY_ROOT="${CINEMATA_DEPLOY_ROOT:-/}"
+SKIP_ROOT_CHECK="${CINEMATA_SKIP_ROOT_CHECK:-0}"
+NO_RESTART=false
+OBSERVABILITY_INSTALLER="${CINEMATA_OBSERVABILITY_INSTALLER:-$SCRIPT_DIR/install-local-observability.sh}"
+CLI_DOMAIN=""
+CLI_PROXY=""
+CLI_OBSERVABILITY=""
+
+usage() {
+    cat <<'EOF'
+Usage: sudo ./deploy/apply-release-config.sh [options]
+
+Run without configuration options to reuse /etc/cinematacms/deployment.env.
+
+Options:
+  --domain HOST           Portal hostname without a scheme, path, or port.
+  --proxy MODE            Reverse proxy mode: none or cloudflare.
+  --observability MODE    Observability mode: none or local.
+  --no-restart            Install and validate files without restarting services.
+  -h, --help              Show this help text.
+EOF
+}
+
+fail() {
+    echo "Error: $*" >&2
+    exit 1
+}
+
+root_path() {
+    if [ "$DEPLOY_ROOT" = "/" ]; then
+        printf '%s\n' "$1"
+    else
+        printf '%s%s\n' "${DEPLOY_ROOT%/}" "$1"
+    fi
+}
+
+validate_domain() {
+    local domain="$1"
+    [[ "$domain" =~ ^([A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)*[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?$ ]]
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --domain)
+            [ "$#" -ge 2 ] || fail "--domain requires a value"
+            CLI_DOMAIN="$2"
+            shift 2
+            ;;
+        --proxy)
+            [ "$#" -ge 2 ] || fail "--proxy requires a value"
+            CLI_PROXY="$2"
+            shift 2
+            ;;
+        --observability)
+            [ "$#" -ge 2 ] || fail "--observability requires a value"
+            CLI_OBSERVABILITY="$2"
+            shift 2
+            ;;
+        --no-restart)
+            NO_RESTART=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            fail "unknown option: $1"
+            ;;
+    esac
+done
+
+if [ "$SKIP_ROOT_CHECK" != "1" ] && [ "$(id -u)" -ne 0 ]; then
+    fail "run this command as root"
+fi
+
+CONFIG_DIR="$(root_path /etc/cinematacms)"
+CONFIG_FILE="$CONFIG_DIR/deployment.env"
+DOMAIN=""
+PROXY_MODE=""
+OBSERVABILITY_MODE=""
+SAVED_DOMAIN=""
+
+if [ -f "$CONFIG_FILE" ]; then
+    while IFS='=' read -r key value; do
+        case "$key" in
+            CINEMATA_DOMAIN) DOMAIN="$value" ;;
+            CINEMATA_PROXY) PROXY_MODE="$value" ;;
+            CINEMATA_OBSERVABILITY) OBSERVABILITY_MODE="$value" ;;
+        esac
+    done < "$CONFIG_FILE"
+fi
+
+SAVED_DOMAIN="$DOMAIN"
+
+if [ -n "$SAVED_DOMAIN" ] && [ -n "$CLI_DOMAIN" ] && [ "$SAVED_DOMAIN" != "$CLI_DOMAIN" ]; then
+    fail "change the domain manually so that Certbot and nginx stay in sync"
+fi
+
+[ -z "$CLI_DOMAIN" ] || DOMAIN="$CLI_DOMAIN"
+[ -z "$CLI_PROXY" ] || PROXY_MODE="$CLI_PROXY"
+[ -z "$CLI_OBSERVABILITY" ] || OBSERVABILITY_MODE="$CLI_OBSERVABILITY"
+
+[ -n "$DOMAIN" ] || fail "--domain is required on the first run"
+[ -n "$PROXY_MODE" ] || fail "--proxy is required on the first run"
+[ -n "$OBSERVABILITY_MODE" ] || fail "--observability is required on the first run"
+validate_domain "$DOMAIN" || fail "--domain must contain a hostname without a scheme, path, or port"
+case "$PROXY_MODE" in
+    none|cloudflare) ;;
+    *) fail "--proxy must be none or cloudflare" ;;
+esac
+case "$OBSERVABILITY_MODE" in
+    none|local) ;;
+    *) fail "--observability must be none or local" ;;
+esac
+
+if [ "$OBSERVABILITY_MODE" = "local" ]; then
+    if [ "$NO_RESTART" = true ]; then
+        if ! command -v prometheus >/dev/null 2>&1 || ! command -v otelcol-contrib >/dev/null 2>&1; then
+            fail "--no-restart cannot install missing observability packages; run again without --no-restart"
+        fi
+        "$OBSERVABILITY_INSTALLER" --no-service-changes
+    else
+        "$OBSERVABILITY_INSTALLER"
+    fi
+    command -v prometheus >/dev/null 2>&1 || fail "the Prometheus installation did not provide its binary"
+    command -v otelcol-contrib >/dev/null 2>&1 || fail "the OpenTelemetry Collector installation did not provide its binary"
+fi
+
+BACKUP_DIR="$(root_path /var/backups/cinematacms)/$(date -u +%Y%m%dT%H%M%SZ)-$$"
+BACKUP_PATHS=()
+BACKUP_FILES=()
+BACKUP_EXISTED=()
+
+backup_file() {
+    local target="$1"
+    local existing
+    local backup
+    for existing in "${BACKUP_PATHS[@]:-}"; do
+        [ "$existing" != "$target" ] || return 0
+    done
+    mkdir -p "$BACKUP_DIR"
+    backup="$BACKUP_DIR/$(printf '%s' "$target" | tr '/' '_')"
+    BACKUP_PATHS+=("$target")
+    BACKUP_FILES+=("$backup")
+    if [ -e "$target" ] || [ -L "$target" ]; then
+        cp -p "$target" "$backup"
+        BACKUP_EXISTED+=("1")
+    else
+        BACKUP_EXISTED+=("0")
+    fi
+}
+
+rollback() {
+    local index
+    for ((index=${#BACKUP_PATHS[@]}-1; index>=0; index--)); do
+        if [ "${BACKUP_EXISTED[$index]}" = "1" ]; then
+            mkdir -p "$(dirname "${BACKUP_PATHS[$index]}")"
+            cp -p "${BACKUP_FILES[$index]}" "${BACKUP_PATHS[$index]}"
+        else
+            rm -f "${BACKUP_PATHS[$index]}"
+        fi
+    done
+}
+
+APPLY_VALIDATED=false
+on_error() {
+    local status="$?"
+    trap - ERR
+    if [ "$APPLY_VALIDATED" = false ]; then
+        rollback
+    fi
+    exit "$status"
+}
+trap on_error ERR
+
+install_managed_file() {
+    local source="$1"
+    local target="$2"
+    local mode="${3:-0644}"
+    backup_file "$target"
+    mkdir -p "$(dirname "$target")"
+    install -m "$mode" "$source" "$target"
+}
+
+write_config() {
+    local target="$1"
+    local mode="$2"
+    local content="$3"
+    local temporary
+    backup_file "$target"
+    mkdir -p "$(dirname "$target")"
+    temporary="$(mktemp "$(dirname "$target")/.cinematacms.XXXXXX")"
+    printf '%s' "$content" > "$temporary"
+    chmod "$mode" "$temporary"
+    mv "$temporary" "$target"
+}
+
+write_config "$CONFIG_FILE" 0600 "CINEMATA_DOMAIN=$DOMAIN
+CINEMATA_PROXY=$PROXY_MODE
+CINEMATA_OBSERVABILITY=$OBSERVABILITY_MODE
+"
+
+if [ "$OBSERVABILITY_MODE" = "local" ]; then
+    otel_enabled="true"
+else
+    otel_enabled="false"
+fi
+write_config "$CONFIG_DIR/observability.env" 0640 "OTEL_ENABLED=$otel_enabled
+OTEL_SERVICE_NAME=cinematacms
+OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318/v1/traces
+OTEL_EXPORTER_OTLP_HEADERS=
+OTEL_TRACES_SAMPLER_ARG=1.0
+"
+
+NGINX_SNIPPET="$(root_path /etc/nginx/snippets/cinematacms-metrics.conf)"
+NGINX_SITE="$(root_path /etc/nginx/sites-available/mediacms.io)"
+NGINX_ENABLED="$(root_path /etc/nginx/sites-enabled/mediacms.io)"
+NGINX_UWSGI_PARAMS="$(root_path /etc/nginx/sites-enabled/uwsgi_params)"
+NGINX_MAIN="$(root_path /etc/nginx/nginx.conf)"
+NGINX_CLOUDFLARE="$(root_path /etc/nginx/conf.d/cloudflare_real_ip.conf)"
+
+install_managed_file "$SCRIPT_DIR/nginx/cinematacms-metrics.conf" "$NGINX_SNIPPET"
+install_managed_file "$SCRIPT_DIR/uwsgi_params" "$NGINX_UWSGI_PARAMS"
+if [ ! -e "$NGINX_MAIN" ]; then
+    install_managed_file "$SCRIPT_DIR/nginx.conf" "$NGINX_MAIN"
+fi
+
+if [ "$PROXY_MODE" = "cloudflare" ]; then
+    install_managed_file "$SCRIPT_DIR/cloudflare_real_ip.conf" "$NGINX_CLOUDFLARE"
+elif [ -e "$NGINX_CLOUDFLARE" ]; then
+    backup_file "$NGINX_CLOUDFLARE"
+    rm -f "$NGINX_CLOUDFLARE"
+fi
+
+if [ ! -e "$NGINX_SITE" ]; then
+    rendered_site="$(mktemp)"
+    sed \
+        -e "s/server_name localhost;/server_name $DOMAIN;/g" \
+        -e "s#/live/localhost/#/live/$DOMAIN/#g" \
+        "$SCRIPT_DIR/mediacms.io" > "$rendered_site"
+    install_managed_file "$rendered_site" "$NGINX_SITE"
+    rm -f "$rendered_site"
+elif ! grep -qE 'location = /metrics|cinematacms-metrics\.conf' "$NGINX_SITE"; then
+    rendered_site="$(mktemp)"
+    awk '
+        /^[[:space:]]*location \/ \{/ {
+            print "    include /etc/nginx/snippets/cinematacms-metrics.conf;"
+            found = 1
+        }
+        { print }
+        END { if (!found) exit 42 }
+    ' "$NGINX_SITE" > "$rendered_site" || {
+        rm -f "$rendered_site"
+        rollback
+        fail "could not find a root location in $NGINX_SITE"
+    }
+    install_managed_file "$rendered_site" "$NGINX_SITE"
+    rm -f "$rendered_site"
+fi
+
+if [ ! -e "$NGINX_ENABLED" ] && [ ! -L "$NGINX_ENABLED" ]; then
+    backup_file "$NGINX_ENABLED"
+    mkdir -p "$(dirname "$NGINX_ENABLED")"
+    ln -s ../sites-available/mediacms.io "$NGINX_ENABLED"
+fi
+
+for unit in mediacms celery_long celery_short celery_whisper celery_beat; do
+    install_managed_file "$SCRIPT_DIR/$unit.service" "$(root_path /etc/systemd/system/$unit.service)"
+done
+
+PROMETHEUS_UNIT="$(root_path /etc/systemd/system/cinematacms-prometheus.service)"
+OTELCOL_UNIT="$(root_path /etc/systemd/system/cinematacms-otelcol.service)"
+install_managed_file "$SCRIPT_DIR/cinematacms-prometheus.service" "$PROMETHEUS_UNIT"
+install_managed_file "$SCRIPT_DIR/cinematacms-otelcol.service" "$OTELCOL_UNIT"
+if [ "$OBSERVABILITY_MODE" = "local" ]; then
+    install_managed_file "$SCRIPT_DIR/prometheus-cinematacms.yml" "$CONFIG_DIR/prometheus.yml"
+    install_managed_file "$SCRIPT_DIR/otelcol-contrib-cinematacms.yml" "$CONFIG_DIR/otelcol-contrib.yml"
+fi
+
+if ! nginx -t; then
+    rollback
+    echo "Error: nginx validation failed; restored the previous configuration" >&2
+    exit 1
+fi
+
+APPLY_VALIDATED=true
+trap - ERR
+
+systemctl daemon-reload
+if [ "$NO_RESTART" = false ]; then
+    systemctl enable --now mediacms celery_long celery_short celery_whisper celery_beat
+    if [ "$OBSERVABILITY_MODE" = "local" ]; then
+        systemctl enable --now cinematacms-prometheus cinematacms-otelcol
+    else
+        systemctl disable --now cinematacms-prometheus cinematacms-otelcol >/dev/null 2>&1 || true
+    fi
+    systemctl enable nginx
+    systemctl reload-or-restart nginx
+fi
+
+echo "Applied CinemataCMS release configuration."
+echo "  domain=$DOMAIN"
+echo "  proxy=$PROXY_MODE"
+echo "  observability=$OBSERVABILITY_MODE"
+echo "  backup=$BACKUP_DIR"

--- a/deploy/apply-release-config.sh
+++ b/deploy/apply-release-config.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -euo pipefail
+set -o errtrace
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DEPLOY_ROOT="${CINEMATA_DEPLOY_ROOT:-/}"

--- a/deploy/celery_beat.service
+++ b/deploy/celery_beat.service
@@ -6,6 +6,7 @@ After=network.target
 Type=simple
 User=www-data
 Group=www-data
+EnvironmentFile=-/etc/cinematacms/observability.env
 Restart=always
 RestartSec=10
 Environment=APP_DIR="/home/cinemata/cinematacms"

--- a/deploy/celery_long.service
+++ b/deploy/celery_long.service
@@ -6,6 +6,7 @@ After=network.target
 Type=simple
 User=www-data
 Group=www-data
+EnvironmentFile=-/etc/cinematacms/observability.env
 Restart=always
 RestartSec=10
 Environment=APP_DIR="/home/cinemata/cinematacms"

--- a/deploy/celery_short.service
+++ b/deploy/celery_short.service
@@ -6,6 +6,7 @@ After=network.target
 Type=simple
 User=www-data
 Group=www-data
+EnvironmentFile=-/etc/cinematacms/observability.env
 Restart=always
 RestartSec=10
 Environment=APP_DIR="/home/cinemata/cinematacms"

--- a/deploy/celery_whisper.service
+++ b/deploy/celery_whisper.service
@@ -6,6 +6,7 @@ After=network.target
 Type=simple
 User=www-data
 Group=www-data
+EnvironmentFile=-/etc/cinematacms/observability.env
 Restart=always
 RestartSec=10
 Environment=APP_DIR="/home/cinemata/cinematacms"

--- a/deploy/cinematacms-otelcol.service
+++ b/deploy/cinematacms-otelcol.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=CinemataCMS OpenTelemetry Collector
+After=network.target
+
+[Service]
+Type=simple
+User=otelcol-contrib
+Group=otelcol-contrib
+ExecStart=/usr/bin/otelcol-contrib --config=/etc/cinematacms/otelcol-contrib.yml
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/cinematacms-prometheus.service
+++ b/deploy/cinematacms-prometheus.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=CinemataCMS Prometheus
+After=network.target mediacms.service
+
+[Service]
+Type=simple
+User=prometheus
+Group=prometheus
+ExecStart=/usr/bin/prometheus --config.file=/etc/cinematacms/prometheus.yml --storage.tsdb.path=/var/lib/prometheus --web.listen-address=127.0.0.1:9090
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/install-local-observability.sh
+++ b/deploy/install-local-observability.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+set -euo pipefail
+
+VERSION="0.159.0"
+TEMPORARY_DIR=""
+CHANGE_SERVICE_STATE=true
+
+fail() {
+    echo "Error: $*" >&2
+    exit 1
+}
+
+cleanup() {
+    if [ -n "$TEMPORARY_DIR" ] && [ -d "$TEMPORARY_DIR" ]; then
+        rm -f "$TEMPORARY_DIR/otelcol-contrib.deb"
+        rmdir "$TEMPORARY_DIR"
+    fi
+}
+trap cleanup EXIT
+
+if [ "${1:-}" = "--no-service-changes" ]; then
+    CHANGE_SERVICE_STATE=false
+    shift
+fi
+[ "$#" -eq 0 ] || fail "unknown option: $1"
+
+[ "$(id -u)" -eq 0 ] || fail "run this command as root"
+
+if ! command -v prometheus >/dev/null 2>&1; then
+    apt-get update
+    apt-get install -y prometheus
+fi
+
+if ! command -v otelcol-contrib >/dev/null 2>&1; then
+    command -v curl >/dev/null 2>&1 || fail "curl is required to install the OpenTelemetry Collector"
+    architecture="$(dpkg --print-architecture)"
+    case "$architecture" in
+        amd64)
+            checksum="4ede8d750d6bf845e353be46cc550f590e6ccdaeeb60aae941cde6ad561877db"
+            ;;
+        arm64)
+            checksum="430469fbfb48f123d08dfc896973bdc205ba393901cc506e92c9c928698a6d5e"
+            ;;
+        *)
+            fail "local observability supports amd64 and arm64"
+            ;;
+    esac
+
+    TEMPORARY_DIR="$(mktemp -d)"
+    package="$TEMPORARY_DIR/otelcol-contrib.deb"
+    curl -fsSL \
+        "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v${VERSION}/otelcol-contrib_${VERSION}_linux_${architecture}.deb" \
+        -o "$package"
+    printf '%s  %s\n' "$checksum" "$package" | sha256sum --check --status || fail "the OpenTelemetry Collector checksum did not match"
+    apt-get install -y "$package"
+fi
+
+if ! id -u otelcol-contrib >/dev/null 2>&1; then
+    useradd --system --home-dir /nonexistent --shell /usr/sbin/nologin otelcol-contrib
+fi
+
+if [ "$CHANGE_SERVICE_STATE" = true ]; then
+    # The release configuration owns loopback-only services with project config
+    # files. Stop package defaults that may listen on broader addresses.
+    systemctl disable --now prometheus otelcol-contrib >/dev/null 2>&1 || true
+fi

--- a/deploy/install-local-observability.sh
+++ b/deploy/install-local-observability.sh
@@ -56,12 +56,32 @@ if ! command -v otelcol-contrib >/dev/null 2>&1; then
     apt-get install -y "$package"
 fi
 
-if ! id -u otelcol-contrib >/dev/null 2>&1; then
-    useradd --system --home-dir /nonexistent --shell /usr/sbin/nologin otelcol-contrib
+if ! getent group otelcol-contrib >/dev/null 2>&1; then
+    groupadd --system otelcol-contrib
 fi
+
+if ! id -u otelcol-contrib >/dev/null 2>&1; then
+    useradd --system --gid otelcol-contrib --home-dir /nonexistent --shell /usr/sbin/nologin otelcol-contrib
+fi
+
+stop_package_service() {
+    local service="$1"
+    local load_state
+
+    load_state="$(systemctl show "$service" --property=LoadState --value 2>/dev/null)" || \
+        fail "could not inspect package service $service"
+    [ "$load_state" != "not-found" ] || return 0
+
+    systemctl disable --now "$service" >/dev/null 2>&1 || \
+        fail "could not stop package service $service"
+    if systemctl is-active --quiet "$service"; then
+        fail "package service $service is still active"
+    fi
+}
 
 if [ "$CHANGE_SERVICE_STATE" = true ]; then
     # The release configuration owns loopback-only services with project config
     # files. Stop package defaults that may listen on broader addresses.
-    systemctl disable --now prometheus otelcol-contrib >/dev/null 2>&1 || true
+    stop_package_service prometheus
+    stop_package_service otelcol-contrib
 fi

--- a/deploy/mediacms.io
+++ b/deploy/mediacms.io
@@ -1,3 +1,4 @@
+# Managed by CinemataCMS deployment tooling.
 server {
     listen 80 ;
     server_name localhost;
@@ -53,17 +54,7 @@ server {
     # All media requests now go through Django for authentication
     # Django will use X-Accel-Redirect to serve files efficiently
 
-    # Scraped from the box itself. With cloudflare_real_ip.conf loaded,
-    # $remote_addr is the real client, so a request arriving through Cloudflare
-    # is denied here and never reaches the application.
-    location = /metrics {
-        allow 127.0.0.1;
-        allow ::1;
-        deny all;
-
-        include /etc/nginx/sites-enabled/uwsgi_params;
-        uwsgi_pass 127.0.0.1:9000;
-    }
+    include /etc/nginx/snippets/cinematacms-metrics.conf;
 
     location / {
 
@@ -127,17 +118,7 @@ server {
     # All media requests now go through Django for authentication
     # Django will use X-Accel-Redirect to serve files efficiently
 
-    # Scraped from the box itself. With cloudflare_real_ip.conf loaded,
-    # $remote_addr is the real client, so a request arriving through Cloudflare
-    # is denied here and never reaches the application.
-    location = /metrics {
-        allow 127.0.0.1;
-        allow ::1;
-        deny all;
-
-        include /etc/nginx/sites-enabled/uwsgi_params;
-        uwsgi_pass 127.0.0.1:9000;
-    }
+    include /etc/nginx/snippets/cinematacms-metrics.conf;
 
     location / {
 

--- a/deploy/mediacms.service
+++ b/deploy/mediacms.service
@@ -2,6 +2,7 @@
 Description=uwsgi cinemata
 
 [Service]
+EnvironmentFile=-/etc/cinematacms/observability.env
 Environment=PROMETHEUS_MULTIPROC_DIR="/tmp/prometheus_multiproc"
 ExecStartPre=/bin/bash -c "mkdir -p /tmp/prometheus_multiproc && chown www-data:www-data /tmp/prometheus_multiproc"
 ExecStart=/home/cinemata/bin/uwsgi --ini /home/cinemata/cinematacms/uwsgi.ini

--- a/deploy/nginx/cinematacms-metrics.conf
+++ b/deploy/nginx/cinematacms-metrics.conf
@@ -1,0 +1,10 @@
+# Prometheus runs on the CinemataCMS host. Keep this endpoint unavailable to
+# public clients, including clients that reach nginx through Cloudflare.
+location = /metrics {
+    allow 127.0.0.1;
+    allow ::1;
+    deny all;
+
+    include /etc/nginx/sites-enabled/uwsgi_params;
+    uwsgi_pass 127.0.0.1:9000;
+}

--- a/deploy/otelcol-contrib-cinematacms.yml
+++ b/deploy/otelcol-contrib-cinematacms.yml
@@ -1,0 +1,19 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 127.0.0.1:4318
+
+processors:
+  batch: {}
+
+exporters:
+  debug:
+    verbosity: basic
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]

--- a/deploy/prometheus-cinematacms.yml
+++ b/deploy/prometheus-cinematacms.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: cinematacms
+    static_configs:
+      - targets: ["127.0.0.1:80"]

--- a/docs/setup/Developer-Onboarding.md
+++ b/docs/setup/Developer-Onboarding.md
@@ -481,12 +481,12 @@ if command -v mp4hls &> /dev/null; then
 # MP4HLS command path
 MP4HLS_COMMAND = '$(which mp4hls)'
 " >> cms/local_settings.py
-    echo "✅ MP4HLS configured"
+    echo "MP4HLS configured"
 else
-    echo "⚠️  MP4HLS not found - HLS streaming will be disabled"
+    echo "MP4HLS not found. HLS streaming will be disabled."
     echo "   Install bento4 if you need HLS support:"
     echo "   - macOS: brew install bento4"
-    echo "   - Ubuntu: Download from https://github.com/axiomatic-systems/Bento4/releases"
+    echo "   - Ubuntu: follow the Bento4 source build instructions"
 fi
 ```
 
@@ -499,22 +499,15 @@ brew install bento4
 ```
 
 **Ubuntu/Linux:**
-```bash
-# Download latest release
-wget https://github.com/axiomatic-systems/Bento4/releases/download/v1-6-0-639/Bento4-SDK-1-6-0-639.x86_64-unknown-linux.zip
-unzip Bento4-SDK-*.zip
-sudo cp Bento4-SDK-*/bin/mp4hls /usr/local/bin/
-sudo chmod +x /usr/local/bin/mp4hls
-```
+
+Follow the
+[Bento4 CMake build instructions](https://github.com/axiomatic-systems/Bento4/blob/v1.6.0-641/README.md#on-linux-and-other-platforms-using-cmake).
+The production `install.sh` builds the pinned source revision for both `amd64`
+and `arm64`.
 
 **Windows (WSL2):**
-```bash
-# Same as Ubuntu/Linux
-wget https://github.com/axiomatic-systems/Bento4/releases/download/v1-6-0-639/Bento4-SDK-1-6-0-639.x86_64-unknown-linux.zip
-unzip Bento4-SDK-*.zip
-sudo cp Bento4-SDK-*/bin/mp4hls /usr/local/bin/
-sudo chmod +x /usr/local/bin/mp4hls
-```
+
+Follow the same Bento4 source build instructions as Ubuntu.
 
 </details>
 

--- a/docs/setup/ubuntu-22.04-setup.md
+++ b/docs/setup/ubuntu-22.04-setup.md
@@ -6,7 +6,7 @@ services.
 
 As root, clone the repository under `/home/cinemata`:
 
-```
+```bash
 # cd /home
 # mkdir cinemata && cd cinemata
 # git clone https://github.com/EngageMedia-video/cinematacms cinematacms && cd cinematacms

--- a/docs/setup/ubuntu-22.04-setup.md
+++ b/docs/setup/ubuntu-22.04-setup.md
@@ -2,7 +2,8 @@
 
 The instructions have been tested on Ubuntu 22.04. Ensure no other services are running in the system, specifically no nginx/Postgresql, as the installation script will install them and replace any configs.
 
-As root, clone the repository on /home/cinemata and run install.sh:
+As root, clone the repository under `/home/cinemata` and run the interactive
+installer:
 
 ```
 # cd /home
@@ -12,4 +13,19 @@ As root, clone the repository on /home/cinemata and run install.sh:
 # ./install.sh
 ```
 
-The installer runs database migrations and seeds django-waffle feature flag switches automatically. New switches are initialized from the default settings during installation.
+For an automated installation, pass every required value:
+
+```bash
+# ./install.sh \
+    --non-interactive \
+    --domain video.example.org \
+    --portal-name "Example Video" \
+    --proxy cloudflare \
+    --observability local
+```
+
+The installer runs database migrations and seeds django-waffle feature flag
+switches. It saves the deployment choices in
+`/etc/cinematacms/deployment.env`. Follow the
+[deployment guide](../../deploy/README.md) to apply release configuration after
+an upgrade.

--- a/docs/setup/ubuntu-22.04-setup.md
+++ b/docs/setup/ubuntu-22.04-setup.md
@@ -1,15 +1,28 @@
-# CinemataCMS Installation Instructions
+# Install CinemataCMS on Ubuntu 22.04
 
-The instructions have been tested on Ubuntu 22.04. Ensure no other services are running in the system, specifically no nginx/Postgresql, as the installation script will install them and replace any configs.
+Use Ubuntu 22.04 on an `amd64` or `arm64` host. The installer configures nginx,
+PostgreSQL, and Redis. Run it only on a new host that does not already use those
+services.
 
-As root, clone the repository under `/home/cinemata` and run the interactive
-installer:
+As root, clone the repository under `/home/cinemata`:
 
 ```
 # cd /home
 # mkdir cinemata && cd cinemata
 # git clone https://github.com/EngageMedia-video/cinematacms cinematacms && cd cinematacms
 # chmod +x install.sh install-nodejs.sh scripts/build_frontend.sh
+```
+
+Check the host before installing:
+
+```bash
+# ./install.sh --check-platform
+Supported platform: Ubuntu 22.04 (amd64)
+```
+
+Run the interactive installer:
+
+```bash
 # ./install.sh
 ```
 
@@ -29,3 +42,8 @@ switches. It saves the deployment choices in
 `/etc/cinematacms/deployment.env`. Follow the
 [deployment guide](../../deploy/README.md) to apply release configuration after
 an upgrade.
+
+The installer uses the Ubuntu FFmpeg package. It builds Bento4 from the pinned
+source revision for the host architecture and installs it at `/opt/bento4`.
+The installer exits with a non-zero status if a required download, build,
+service, migration, or configuration step fails.

--- a/files/metrics.py
+++ b/files/metrics.py
@@ -67,6 +67,7 @@ CELERY_QUEUE_DEPTH = Gauge(
     "cinemata_celery_queue_depth",
     "Redis broker queue length by queue name",
     ["queue"],
+    multiprocess_mode="mostrecent",
 )
 
 MEDIA_ENCODING_PROFILE_TOTAL = Counter(
@@ -90,6 +91,7 @@ TRANSCRIPTION_REQUESTS = Gauge(
     "cinemata_transcription_requests",
     "Current transcription request rows",
     ["translate_to_english"],
+    multiprocess_mode="mostrecent",
 )
 ENCODING_STALE_TOTAL = Counter(
     "cinemata_encoding_stale_total",
@@ -100,6 +102,7 @@ ENCODING_STALLED = Gauge(
     "cinemata_encoding_stalled",
     "Current running encoding rows older than RUNNING_STATE_STALE",
     ["resolution", "codec", "extension"],
+    multiprocess_mode="mostrecent",
 )
 CACHE_OPERATIONS_TOTAL = Counter(
     "cinemata_cache_operations_total",
@@ -109,6 +112,13 @@ CACHE_OPERATIONS_TOTAL = Counter(
 
 _task_start_times: dict[str, float] = {}
 _stalled_encoding_label_values: set[tuple[str, str, str]] = set()
+
+
+def _safe_metric(metric_name: str, emit) -> None:
+    try:
+        emit()
+    except Exception:
+        logger.debug("Could not record %s metric", metric_name, exc_info=True)
 
 
 def classify_endpoint_group(path: str) -> str:
@@ -189,7 +199,10 @@ def record_cache_operation(cache_name: str, operation: str, hit: bool | None = N
         result = "ok"
     else:
         result = "hit" if hit else "miss"
-    CACHE_OPERATIONS_TOTAL.labels(cache=cache_name, operation=operation, result=result).inc()
+    _safe_metric(
+        "cache operation",
+        lambda: CACHE_OPERATIONS_TOTAL.labels(cache=cache_name, operation=operation, result=result).inc(),
+    )
 
 
 def _profile_labels(profile) -> dict[str, str]:
@@ -201,20 +214,32 @@ def _profile_labels(profile) -> dict[str, str]:
 
 
 def observe_media_pipeline(media, profile, status: str) -> None:
-    MEDIA_ENCODING_PROFILE_TOTAL.labels(status=status, **_profile_labels(profile)).inc()
+    _safe_metric(
+        "media encoding profile",
+        lambda: MEDIA_ENCODING_PROFILE_TOTAL.labels(status=status, **_profile_labels(profile)).inc(),
+    )
     media_type = str(getattr(media, "media_type", None) or "unknown")
     duration = getattr(media, "duration", 0) or 0
     if duration > 0:
-        MEDIA_DURATION_SECONDS.labels(media_type=media_type).observe(duration)
+        _safe_metric(
+            "media duration",
+            lambda: MEDIA_DURATION_SECONDS.labels(media_type=media_type).observe(duration),
+        )
     try:
         if getattr(media, "media_file", None):
-            MEDIA_FILE_SIZE_BYTES.labels(media_type=media_type).observe(media.media_file.size)
+            _safe_metric(
+                "media file size",
+                lambda: MEDIA_FILE_SIZE_BYTES.labels(media_type=media_type).observe(media.media_file.size),
+            )
     except Exception:
-        logger.debug("Could not observe media file size", exc_info=True)
+        logger.debug("Could not read media file size", exc_info=True)
 
 
 def record_stale_encoding(encoding) -> None:
-    ENCODING_STALE_TOTAL.labels(**_profile_labels(encoding.profile)).inc()
+    _safe_metric(
+        "stale encoding",
+        lambda: ENCODING_STALE_TOTAL.labels(**_profile_labels(encoding.profile)).inc(),
+    )
 
 
 def refresh_runtime_metrics() -> None:

--- a/files/tasks.py
+++ b/files/tasks.py
@@ -293,6 +293,15 @@ def encode_media(
         Encoding.objects.filter(id=encoding_id).delete()
         return False
 
+    outcome_recorded = False
+
+    def record_encoding_outcome(success):
+        nonlocal outcome_recorded
+        if outcome_recorded:
+            return
+        outcome_recorded = True
+        observe_media_pipeline(media, profile, "success" if success else "fail")
+
     # break logic with chunk True/False
     if chunk:
         # TODO: in case a video is chunkized and this enters here many times
@@ -303,6 +312,7 @@ def encode_media(
             and not force
         ):
             Encoding.objects.filter(id=encoding_id).delete()
+            record_encoding_outcome(False)
             return False
         else:
             try:
@@ -325,6 +335,7 @@ def encode_media(
     else:
         if Encoding.objects.filter(media=media, profile=profile).count() > 1 and force is False:
             Encoding.objects.filter(id=encoding_id).delete()
+            record_encoding_outcome(False)
             return False
         else:
             try:
@@ -368,14 +379,17 @@ def encode_media(
                 encoding.status = "success"
                 encoding.media_file.save(content=myfile, name=tf)
                 rm_file(tf)
+                record_encoding_outcome(True)
                 return True
         else:
+            record_encoding_outcome(False)
             return False
     original_media_path = chunk_file_path if chunk else media.media_file.path
 
     if not media.duration:
         encoding.status = "fail"
         encoding.save(update_fields=["status"])
+        record_encoding_outcome(False)
         return False
 
     with tempfile.TemporaryDirectory(dir=settings.TEMP_DIRECTORY) as temp_dir:
@@ -393,6 +407,7 @@ def encode_media(
         if not ffmpeg_commands:
             encoding.status = "fail"
             encoding.save(update_fields=["status"])
+            record_encoding_outcome(False)
             return False
 
         encoding.temp_file = tf
@@ -408,17 +423,21 @@ def encode_media(
             ffmpeg_command = [str(s) for s in ffmpeg_command]
             encoding_backend = FFmpegBackend()
             try:
-                with start_span(
-                    "media.encode.ffmpeg.start",
-                    {
-                        "media.type": media.media_type,
-                        "encoding.profile_id": profile.id,
-                        "encoding.resolution": profile.resolution,
-                        "encoding.codec": profile.codec,
-                        "encoding.extension": profile.extension,
-                    },
-                ):
-                    encoding_command = encoding_backend.encode(ffmpeg_command)
+
+                def encoding_output(backend=encoding_backend, command=ffmpeg_command):
+                    with start_span(
+                        "media.encode.ffmpeg.start",
+                        {
+                            "media.type": media.media_type,
+                            "encoding.profile_id": profile.id,
+                            "encoding.resolution": profile.resolution,
+                            "encoding.codec": profile.codec,
+                            "encoding.extension": profile.extension,
+                        },
+                    ):
+                        yield from backend.encode(command)
+
+                encoding_command = encoding_output()
                 _duration, n_times = 0, 0
                 output = ""
                 start_time = time.time()
@@ -445,6 +464,7 @@ def encode_media(
                                     if n_times % 20 == 0:
                                         if not _check_media_exists_or_cleanup(media.pk, encoding.id, "progress_save"):
                                             encoding_backend.terminate_process()
+                                            record_encoding_outcome(False)
                                             return False
                                         encoding.progress = percent
                                         try:
@@ -460,6 +480,7 @@ def encode_media(
                             if n_times % 100 == 0:
                                 if not _check_media_exists_or_cleanup(media.pk, encoding.id, "heartbeat_save"):
                                     encoding_backend.terminate_process()
+                                    record_encoding_outcome(False)
                                     return False
                                 try:
                                     encoding.save(update_fields=["update_date"])
@@ -506,6 +527,8 @@ def encode_media(
                     if error_msg.lower() in output.lower():
                         raise_exception = False
                 if raise_exception:
+                    if self.request.retries >= 1:
+                        record_encoding_outcome(False)
                     raise self.retry(exc=e, countdown=5, max_retries=1)
 
         encoding.logs = output
@@ -513,6 +536,7 @@ def encode_media(
 
         # Check media still exists before final save
         if not _check_media_exists_or_cleanup(media.pk, encoding.id, "final_save"):
+            record_encoding_outcome(False)
             return False
 
         success = False
@@ -531,12 +555,12 @@ def encode_media(
 
         try:
             encoding.save(update_fields=["status", "logs", "progress", "total_run_time"])
-            observe_media_pipeline(media, profile, "success" if success else "fail")
         except (Encoding.DoesNotExist, django.db.DatabaseError) as e:
             logger.warning(
                 f"Failed to save final encoding state for encoding {encoding.id}: {e}. Media may have been deleted."
             )
 
+        record_encoding_outcome(success)
         return success
 
 

--- a/files/tasks.py
+++ b/files/tasks.py
@@ -496,11 +496,13 @@ def encode_media(
                         if n_times > iteration_limit:
                             logger.error(f"Encoding iteration limit ({iteration_limit}) exceeded")
                             encoding_backend.terminate_process()
+                            encoding_command.close()
                             break
 
                         if time.time() - last_progress_time > no_progress_timeout:
                             logger.error(f"No progress for {no_progress_timeout} seconds, likely stuck")
                             encoding_backend.terminate_process()
+                            encoding_command.close()
                             break
 
                     except StopIteration:

--- a/files/tests/test_encoding.py
+++ b/files/tests/test_encoding.py
@@ -1,5 +1,8 @@
 import unittest
-from unittest.mock import Mock, patch
+from contextlib import ExitStack, contextmanager
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import Mock, mock_open, patch
 
 from django.test import override_settings
 
@@ -177,3 +180,261 @@ class TestEncodingProgressTracking(unittest.TestCase):
                             # We can't easily test this without refactoring encode_media.
                             # The integration test will cover the behavior.
                             pass
+
+
+class TestFFmpegSpanLifetime(unittest.TestCase):
+    @override_settings(TEMP_DIRECTORY="/tmp")
+    def test_ffmpeg_generator_is_consumed_inside_span(self):
+        from files.tasks import encode_media
+
+        span_active = False
+        observed = []
+
+        @contextmanager
+        def fake_span(*_args, **_kwargs):
+            nonlocal span_active
+            span_active = True
+            try:
+                yield
+            finally:
+                span_active = False
+
+        def output_stream():
+            observed.append(span_active)
+            return
+            yield  # pragma: no cover
+
+        media = SimpleNamespace(
+            pk=1,
+            media_type="video",
+            duration=120,
+            media_info="{}",
+            media_file=SimpleNamespace(path="/tmp/source.mp4"),
+        )
+        profile = SimpleNamespace(id=2, extension="mp4", resolution=720, codec="h264")
+        encoding = SimpleNamespace(
+            id=3,
+            profile=profile,
+            status="pending",
+            temp_file="",
+            commands="",
+            logs="",
+            progress=0,
+            save=Mock(),
+        )
+        query = Mock()
+        query.count.return_value = 1
+        query.exclude.return_value.delete = Mock()
+        backend = SimpleNamespace(encode=Mock(return_value=output_stream()))
+
+        with (
+            patch("files.tasks.Media.objects.get", return_value=media),
+            patch("files.tasks.EncodeProfile.objects.get", return_value=profile),
+            patch("files.tasks.Encoding.objects.get", return_value=encoding),
+            patch("files.tasks.Encoding.objects.filter", return_value=query),
+            patch("files.tasks.create_temp_file", side_effect=["/tmp/output.mp4", "/tmp/pass"]),
+            patch("files.tasks.produce_ffmpeg_commands", return_value=[["ffmpeg", "-i", "source"]]),
+            patch("files.tasks.FFmpegBackend", return_value=backend),
+            patch("files.tasks.start_span", side_effect=fake_span),
+            patch("files.tasks._check_media_exists_or_cleanup", return_value=False),
+        ):
+            encode_media.run("token", profile.id, encoding.id, "url")
+
+        self.assertEqual(observed, [True])
+
+
+class TestEncodingOutcomeObservation(unittest.TestCase):
+    def _run_encode_media(
+        self,
+        *,
+        extension="mp4",
+        duration=120,
+        ffmpeg_commands=None,
+        output_exists=False,
+        output_type=None,
+        media_info=None,
+        backend_exception=None,
+        capture_exception=False,
+        task_retries=None,
+    ):
+        from files.tasks import encode_media
+
+        media = SimpleNamespace(
+            pk=1,
+            media_type="video",
+            duration=duration,
+            media_info=media_info or "{}",
+            media_file=SimpleNamespace(path="/tmp/source.mp4"),
+        )
+        profile = SimpleNamespace(id=2, extension=extension, resolution=720, codec="h264")
+        encoding = SimpleNamespace(
+            id=3,
+            profile=profile,
+            status="pending",
+            temp_file="",
+            commands="",
+            logs="",
+            progress=0,
+            add_date=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            update_date=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            media_file=Mock(),
+            save=Mock(),
+        )
+        query = Mock()
+        query.count.return_value = 1
+        query.exclude.return_value.delete = Mock()
+        observer = Mock()
+        backend = SimpleNamespace(
+            encode=(
+                Mock(side_effect=backend_exception) if backend_exception is not None else Mock(return_value=iter(()))
+            ),
+            terminate_process=Mock(),
+        )
+
+        @contextmanager
+        def temporary_directory():
+            yield "/tmp/encoding-test"
+
+        output_file = "/tmp/encoding-test/output.mp4"
+        pass_file = "/tmp/encoding-test/pass"
+        temporary_files = [output_file, pass_file]
+        if extension == "gif":
+            temporary_files = ["/tmp/encoding-test/output.gif"]
+            output_file = temporary_files[0]
+
+        def path_exists(path):
+            return path == output_file and output_exists
+
+        with ExitStack() as stack:
+            stack.enter_context(patch("files.tasks.Media.objects.get", return_value=media))
+            stack.enter_context(patch("files.tasks.EncodeProfile.objects.get", return_value=profile))
+            stack.enter_context(patch("files.tasks.Encoding.objects.get", return_value=encoding))
+            stack.enter_context(patch("files.tasks.Encoding.objects.filter", return_value=query))
+            stack.enter_context(patch("files.tasks.create_temp_file", side_effect=temporary_files))
+            stack.enter_context(
+                patch(
+                    "files.tasks.produce_ffmpeg_commands",
+                    return_value=ffmpeg_commands if ffmpeg_commands is not None else [["ffmpeg", "-i", "source"]],
+                )
+            )
+            stack.enter_context(patch("files.tasks.FFmpegBackend", return_value=backend))
+            stack.enter_context(patch("files.tasks._check_media_exists_or_cleanup", return_value=True))
+            stack.enter_context(patch("files.tasks.observe_media_pipeline", observer))
+            if task_retries is not None:
+                stack.enter_context(patch.object(encode_media.request, "retries", task_retries))
+            stack.enter_context(patch("files.tasks.os.path.exists", side_effect=path_exists))
+            if output_type is not None:
+                stack.enter_context(patch("files.tasks.get_file_type", return_value=output_type))
+            if extension != "gif":
+                stack.enter_context(patch("files.tasks.media_file_info", return_value=media_info or {}))
+            if output_exists:
+                stack.enter_context(patch("files.tasks.os.path.getsize", return_value=1))
+                stack.enter_context(patch("builtins.open", mock_open(read_data=b"encoded")))
+                stack.enter_context(patch("files.tasks.File"))
+            if extension == "gif":
+                stack.enter_context(patch("files.tasks.run_command", return_value={"out": ""}))
+                stack.enter_context(patch("files.tasks.rm_file"))
+
+            try:
+                result = encode_media.run("token", profile.id, encoding.id, "url")
+            except Exception as exception:
+                if not capture_exception:
+                    raise
+                result = exception
+
+        return result, media, profile, encoding, observer
+
+    def test_gif_success_records_one_success(self):
+        result, media, profile, encoding, observer = self._run_encode_media(
+            extension="gif",
+            output_exists=True,
+            output_type="image",
+        )
+
+        self.assertTrue(result)
+        self.assertEqual(encoding.status, "success")
+        observer.assert_called_once_with(media, profile, "success")
+
+    def test_missing_duration_records_one_failure(self):
+        result, media, profile, encoding, observer = self._run_encode_media(duration=0)
+
+        self.assertFalse(result)
+        self.assertEqual(encoding.status, "fail")
+        encoding.save.assert_any_call(update_fields=["status"])
+        observer.assert_called_once_with(media, profile, "fail")
+
+    def test_missing_ffmpeg_commands_records_one_failure(self):
+        result, media, profile, encoding, observer = self._run_encode_media(ffmpeg_commands=[])
+
+        self.assertFalse(result)
+        self.assertEqual(encoding.status, "fail")
+        encoding.save.assert_any_call(update_fields=["status"])
+        observer.assert_called_once_with(media, profile, "fail")
+
+    def test_normal_success_records_one_success(self):
+        result, media, profile, encoding, observer = self._run_encode_media(
+            output_exists=True,
+            media_info={"is_video": True},
+        )
+
+        self.assertTrue(result)
+        self.assertEqual(encoding.status, "success")
+        encoding.media_file.save.assert_called_once()
+        observer.assert_called_once_with(media, profile, "success")
+
+    def test_normal_failure_records_one_failure(self):
+        result, media, profile, encoding, observer = self._run_encode_media(
+            output_exists=True,
+            media_info={"is_video": False, "is_audio": False},
+        )
+
+        self.assertFalse(result)
+        self.assertEqual(encoding.status, "fail")
+        observer.assert_called_once_with(media, profile, "fail")
+
+    def test_gif_failure_records_one_failure(self):
+        result, media, profile, encoding, observer = self._run_encode_media(extension="gif")
+
+        self.assertFalse(result)
+        observer.assert_called_once_with(media, profile, "fail")
+
+    def test_retryable_ffmpeg_exception_does_not_record_terminal_outcome(self):
+        from files.tasks import encode_media
+
+        with patch.object(encode_media, "retry", side_effect=RuntimeError("retry")) as retry:
+            result, _media, _profile, _encoding, observer = self._run_encode_media(
+                backend_exception=RuntimeError("unknown ffmpeg failure"),
+                capture_exception=True,
+            )
+
+        self.assertIsInstance(result, RuntimeError)
+        retry.assert_called_once()
+        observer.assert_not_called()
+
+    def test_known_ffmpeg_error_defers_outcome_until_final_result(self):
+        from files.exceptions import VideoEncodingError
+
+        result, media, profile, encoding, observer = self._run_encode_media(
+            output_exists=True,
+            media_info={"is_video": True},
+            backend_exception=VideoEncodingError("Invalid data found when processing input"),
+        )
+
+        self.assertTrue(result)
+        self.assertEqual(encoding.status, "success")
+        observer.assert_called_once_with(media, profile, "success")
+
+    def test_exhausted_retryable_ffmpeg_error_records_terminal_failure(self):
+        from files.tasks import encode_media
+
+        error = RuntimeError("unknown ffmpeg failure")
+        with patch.object(encode_media, "retry", side_effect=error) as retry:
+            result, media, profile, _encoding, observer = self._run_encode_media(
+                backend_exception=error,
+                capture_exception=True,
+                task_retries=1,
+            )
+
+        self.assertIs(result, error)
+        retry.assert_called_once()
+        observer.assert_called_once_with(media, profile, "fail")

--- a/files/tests/test_encoding.py
+++ b/files/tests/test_encoding.py
@@ -183,12 +183,12 @@ class TestEncodingProgressTracking(unittest.TestCase):
 
 
 class TestFFmpegSpanLifetime(unittest.TestCase):
-    @override_settings(TEMP_DIRECTORY="/tmp")
-    def test_ffmpeg_generator_is_consumed_inside_span(self):
+    def _run_safety_break(self, time_patch):
         from files.tasks import encode_media
 
         span_active = False
-        observed = []
+        observed_span_states = []
+        output_count = 0
 
         @contextmanager
         def fake_span(*_args, **_kwargs):
@@ -200,9 +200,18 @@ class TestFFmpegSpanLifetime(unittest.TestCase):
                 span_active = False
 
         def output_stream():
-            observed.append(span_active)
-            return
-            yield  # pragma: no cover
+            nonlocal output_count
+            while True:
+                output_count += 1
+                if output_count == 1:
+                    observed_span_states.append(span_active)
+                yield "unparseable"
+
+        def check_media_exists(_media_id, _encoding_id, stage):
+            if stage == "final_save":
+                observed_span_states.append(span_active)
+                return False
+            return True
 
         media = SimpleNamespace(
             pk=1,
@@ -225,7 +234,10 @@ class TestFFmpegSpanLifetime(unittest.TestCase):
         query = Mock()
         query.count.return_value = 1
         query.exclude.return_value.delete = Mock()
-        backend = SimpleNamespace(encode=Mock(return_value=output_stream()))
+        backend = SimpleNamespace(
+            encode=Mock(return_value=output_stream()),
+            terminate_process=Mock(),
+        )
 
         with (
             patch("files.tasks.Media.objects.get", return_value=media),
@@ -236,11 +248,27 @@ class TestFFmpegSpanLifetime(unittest.TestCase):
             patch("files.tasks.produce_ffmpeg_commands", return_value=[["ffmpeg", "-i", "source"]]),
             patch("files.tasks.FFmpegBackend", return_value=backend),
             patch("files.tasks.start_span", side_effect=fake_span),
-            patch("files.tasks._check_media_exists_or_cleanup", return_value=False),
+            patch("files.tasks.calculate_seconds", return_value=None),
+            time_patch,
+            patch("files.tasks.logger.error"),
+            patch("files.tasks.logger.info"),
+            patch("files.tasks._check_media_exists_or_cleanup", side_effect=check_media_exists),
         ):
             encode_media.run("token", profile.id, encoding.id, "url")
 
-        self.assertEqual(observed, [True])
+        return observed_span_states
+
+    @override_settings(TEMP_DIRECTORY="/tmp")
+    def test_ffmpeg_generator_is_closed_before_timeout_break_final_save(self):
+        observed_span_states = self._run_safety_break(patch("files.tasks.time.time", side_effect=[0, 1, 1801]))
+
+        self.assertEqual(observed_span_states, [True, False])
+
+    @override_settings(TEMP_DIRECTORY="/tmp")
+    def test_ffmpeg_generator_is_closed_before_iteration_limit_final_save(self):
+        observed_span_states = self._run_safety_break(patch("files.tasks.time.time", return_value=0))
+
+        self.assertEqual(observed_span_states, [True, False])
 
 
 class TestEncodingOutcomeObservation(unittest.TestCase):

--- a/install.sh
+++ b/install.sh
@@ -168,7 +168,10 @@ install_project_npm() {
     package_manager=$(node -e 'console.log(require(process.argv[1]).packageManager)' "$package_file") || \
         fail "could not read packageManager from $package_file"
     case "$package_manager" in
-        npm@*) expected_version="${package_manager#npm@}" ;;
+        npm@*)
+            expected_version="${package_manager#npm@}"
+            expected_version="${expected_version%%+*}"
+            ;;
         *) fail "unsupported frontend package manager $package_manager" ;;
     esac
     npm install --global "$package_manager" || fail "could not install $package_manager"

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,135 @@
 #!/bin/bash
 # should be run as root and only on Ubuntu 22
-echo "Welcome to the Cinemata installation!";
 
-if [ `id -u` -ne 0 ]
+usage() {
+    cat <<'EOF'
+Usage: sudo ./install.sh [options]
+
+Options:
+  --non-interactive       Do not prompt for installation values.
+  --domain HOST           Portal hostname without a scheme, path, or port.
+  --portal-name NAME      Portal name. Defaults to CinemataCMS.
+  --proxy MODE            Reverse proxy mode: none or cloudflare.
+  --observability MODE    Observability mode: none or local.
+  --dry-run               Resolve and validate options without changing the system.
+  -h, --help              Show this help text.
+EOF
+}
+
+fail() {
+    echo "Error: $*" >&2
+    exit 1
+}
+
+validate_domain() {
+    local domain="$1"
+    [[ "$domain" =~ ^([A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)*[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?$ ]]
+}
+
+validate_portal_name() {
+    local portal_name="$1"
+    [[ "$portal_name" =~ ^[A-Za-z0-9._\ -]{1,100}$ ]]
+}
+
+NON_INTERACTIVE=false
+DRY_RUN=false
+FRONTEND_HOST=""
+PORTAL_NAME=""
+PROXY_MODE=""
+OBSERVABILITY_MODE=""
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --non-interactive)
+            NON_INTERACTIVE=true
+            shift
+            ;;
+        --domain)
+            [ "$#" -ge 2 ] || fail "--domain requires a value"
+            FRONTEND_HOST="$2"
+            shift 2
+            ;;
+        --portal-name)
+            [ "$#" -ge 2 ] || fail "--portal-name requires a value"
+            PORTAL_NAME="$2"
+            shift 2
+            ;;
+        --proxy)
+            [ "$#" -ge 2 ] || fail "--proxy requires a value"
+            PROXY_MODE="$2"
+            shift 2
+            ;;
+        --observability)
+            [ "$#" -ge 2 ] || fail "--observability requires a value"
+            OBSERVABILITY_MODE="$2"
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            fail "unknown option: $1"
+            ;;
+    esac
+done
+
+if [ "$NON_INTERACTIVE" = true ]; then
+    [ -n "$FRONTEND_HOST" ] || fail "--domain is required with --non-interactive"
+    [ -n "$PROXY_MODE" ] || fail "--proxy is required with --non-interactive"
+    [ -n "$OBSERVABILITY_MODE" ] || fail "--observability is required with --non-interactive"
+else
+    if [ -z "$FRONTEND_HOST" ]; then
+        read -r -p "Enter the portal hostname, or press Enter for localhost: " FRONTEND_HOST
+    fi
+    if [ -z "$PORTAL_NAME" ]; then
+        read -r -p "Enter the portal name, or press Enter for CinemataCMS: " PORTAL_NAME
+    fi
+    if [ -z "$PROXY_MODE" ]; then
+        read -r -p "Enter the reverse proxy mode [none/cloudflare], or press Enter for none: " PROXY_MODE
+    fi
+    if [ -z "$OBSERVABILITY_MODE" ]; then
+        read -r -p "Enter the observability mode [none/local], or press Enter for none: " OBSERVABILITY_MODE
+    fi
+fi
+
+[ -n "$FRONTEND_HOST" ] || FRONTEND_HOST="localhost"
+[ -n "$PORTAL_NAME" ] || PORTAL_NAME="CinemataCMS"
+[ -n "$PROXY_MODE" ] || PROXY_MODE="none"
+[ -n "$OBSERVABILITY_MODE" ] || OBSERVABILITY_MODE="none"
+
+FRONTEND_HOST="${FRONTEND_HOST#http://}"
+FRONTEND_HOST="${FRONTEND_HOST#https://}"
+FRONTEND_HOST="${FRONTEND_HOST%/}"
+validate_domain "$FRONTEND_HOST" || fail "--domain must contain a hostname without a scheme, path, or port"
+validate_portal_name "$PORTAL_NAME" || fail "--portal-name may contain letters, numbers, spaces, periods, underscores, and hyphens"
+case "$PROXY_MODE" in
+    none|cloudflare) ;;
+    *) fail "--proxy must be none or cloudflare" ;;
+esac
+case "$OBSERVABILITY_MODE" in
+    none|local) ;;
+    *) fail "--observability must be none or local" ;;
+esac
+
+echo "Resolved installation configuration:"
+echo "  domain=$FRONTEND_HOST"
+echo "  portal_name=$PORTAL_NAME"
+echo "  proxy=$PROXY_MODE"
+echo "  observability=$OBSERVABILITY_MODE"
+
+if [ "$DRY_RUN" = true ]; then
+    echo "No changes were made."
+    exit 0
+fi
+
+echo "Welcome to the Cinemata installation!"
+
+if [ "$(id -u)" -ne 0 ]
   then echo "Please run as root"
   exit
 fi
@@ -23,17 +150,19 @@ if [ "$SCRIPT_DIR" != "$EXPECTED_DIR" ]; then
 fi
 
 
-while true; do
-    read -p "
+if [ "$NON_INTERACTIVE" = false ]; then
+    while true; do
+        read -r -p "
 This script will attempt to perform a system update, install required dependencies, install and configure PostgreSQL, NGINX, Redis and a few other utilities.
 It is expected to run on a new system **with no running instances of any these services**. Make sure you check the script before you continue. Then enter yes or no
 " yn
-    case $yn in
-        [Yy]* ) echo "OK!"; break;;
-        [Nn]* ) echo "Have a great day"; exit;;
-        * ) echo "Please answer yes or no.";;
-    esac
-done
+        case $yn in
+            [Yy]* ) echo "OK!"; break;;
+            [Nn]* ) echo "Installation cancelled"; exit;;
+            * ) echo "Enter yes or no.";;
+        esac
+    done
+fi
 
 
 osVersion=$(lsb_release -d)
@@ -54,24 +183,6 @@ cp -v tmp/{ffmpeg,ffprobe,qt-faststart} /usr/local/bin
 rm -rf tmp ffmpeg-release-amd64-static.tar.xz
 echo "ffmpeg installed to /usr/local/bin"
 
-read -p "Enter portal URL, or press enter for localhost : " FRONTEND_HOST
-read -p "Enter portal name, or press enter for 'CinemataCMS : " PORTAL_NAME
-
-[ -z "$PORTAL_NAME" ] && PORTAL_NAME='CinemataCMS'
-[ -z "$FRONTEND_HOST" ] && FRONTEND_HOST='localhost'
-
-# Normalize and validate the entered host before using it in shell commands or
-# generated Python settings. Restricting it to DNS-style labels (including
-# localhost and IPv4-shaped values) prevents quotes and other metacharacters
-# from changing the generated local_settings.py code.
-FRONTEND_HOST="${FRONTEND_HOST#http://}"
-FRONTEND_HOST="${FRONTEND_HOST#https://}"
-FRONTEND_HOST="${FRONTEND_HOST%/}"
-if [[ ! "$FRONTEND_HOST" =~ ^([A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)*[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?$ ]]; then
-    echo "Error: portal URL must contain a valid hostname without a path or port"
-    exit 1
-fi
-
 echo 'Creating database to be used in CinemataCMS'
 
 su -c "psql -c \"CREATE DATABASE mediacms\"" postgres
@@ -91,10 +202,14 @@ fi
 if [ -f "$NODEJS_SCRIPT" ]; then
     if bash "$NODEJS_SCRIPT"; then
         export NVM_DIR="/root/.nvm"
+        # shellcheck source=/dev/null
         [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
         # Ensure Node is on PATH in this shell
         nvm use --silent default >/dev/null 2>&1 || nvm use --silent 22 >/dev/null 2>&1
-        node -v && npm -v || { echo "Error: node/npm not on PATH after install"; exit 1; }
+        if ! node -v || ! npm -v; then
+            echo "Error: node/npm not on PATH after install"
+            exit 1
+        fi
         hash -r
     else
         echo "Error: Node.js installation script failed"; exit 1
@@ -105,36 +220,34 @@ fi
 
 echo 'Creating python virtualenv on /home/cinemata'
 
-cd /home/cinemata
+cd /home/cinemata || exit 1
 virtualenv . --python=python3
-source  /home/cinemata/bin/activate
-cd cinematacms
+# shellcheck source=/dev/null
+source /home/cinemata/bin/activate
+cd cinematacms || exit 1
 pip install -r requirements.txt
 cd .. && git clone https://github.com/ggerganov/whisper.cpp.git
-cd whisper.cpp/
+cd whisper.cpp/ || exit 1
 bash ./models/download-ggml-model.sh base
 make
-cd ../cinematacms
+cd ../cinematacms || exit 1
 
-SECRET_KEY=`python -c 'from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())'`
+SECRET_KEY=$(python -c 'from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())')
 
-sed -i s/localhost/$FRONTEND_HOST/g deploy/mediacms.io
+FRONTEND_HOST_HTTP_PREFIX="http://$FRONTEND_HOST"
 
-FRONTEND_HOST_HTTP_PREFIX='http://'$FRONTEND_HOST
+{
+    echo 'FRONTEND_HOST='\'"$FRONTEND_HOST_HTTP_PREFIX"\'
+    echo 'PORTAL_NAME='\'"$PORTAL_NAME"\'
+    echo "SSL_FRONTEND_HOST = FRONTEND_HOST.replace('http', 'https')"
 
-echo 'FRONTEND_HOST='\'"$FRONTEND_HOST_HTTP_PREFIX"\' >> cms/local_settings.py
-echo 'PORTAL_NAME='\'"$PORTAL_NAME"\' >> cms/local_settings.py
-echo "SSL_FRONTEND_HOST = FRONTEND_HOST.replace('http', 'https')" >> cms/local_settings.py
-
-# Add the entered domain to ALLOWED_HOSTS. settings.py appends FRONTEND_HOST to
-# ALLOWED_HOSTS before local_settings.py is imported, so at that point it still
-# holds the default value, not the domain entered here. Because local_settings.py
-# is imported last, defining ALLOWED_HOSTS here is the effective override.
-echo "ALLOWED_HOSTS = ['127.0.0.1', 'localhost', '$FRONTEND_HOST']" >> cms/local_settings.py
-
-echo 'SECRET_KEY='\'"$SECRET_KEY"\' >> cms/local_settings.py
-echo "LOCAL_INSTALL = True" >> cms/local_settings.py
-echo "SITE_ID = 1" >> cms/local_settings.py
+    # Add the entered domain to ALLOWED_HOSTS. settings.py appends FRONTEND_HOST
+    # before local_settings.py is imported, so this is the effective override.
+    echo "ALLOWED_HOSTS = ['127.0.0.1', 'localhost', '$FRONTEND_HOST']"
+    echo 'SECRET_KEY='\'"$SECRET_KEY"\'
+    echo "LOCAL_INSTALL = True"
+    echo "SITE_ID = 1"
+} >> cms/local_settings.py
 
 mkdir -p logs
 mkdir -p pids
@@ -168,7 +281,7 @@ python manage.py populate_media_countries
 python manage.py populate_topics
 python manage.py populate_content_sensitivities
 
-ADMIN_PASS=`python -c "import secrets;chars = 'abcdefghijklmnopqrstuvwxyz0123456789';print(''.join(secrets.choice(chars) for i in range(10)))"`
+ADMIN_PASS=$(python -c "import secrets;chars = 'abcdefghijklmnopqrstuvwxyz0123456789';print(''.join(secrets.choice(chars) for i in range(10)))")
 echo "from users.models import User; User.objects.create_superuser('admin', 'admin@example.com', '$ADMIN_PASS')" | python manage.py shell
 
 # Configure Django Site with proper error handling
@@ -179,40 +292,31 @@ if ! python manage.py update_site_name --name "$PORTAL_NAME" --domain "$FRONTEND
 fi
 
 chown -R www-data. /home/cinemata/
-cp deploy/celery_long.service /etc/systemd/system/celery_long.service && systemctl enable celery_long && systemctl start celery_long
-cp deploy/celery_short.service /etc/systemd/system/celery_short.service && systemctl enable celery_short && systemctl start celery_short
-cp deploy/celery_beat.service /etc/systemd/system/celery_beat.service && systemctl enable celery_beat && systemctl start celery_beat
-cp deploy/mediacms.service /etc/systemd/system/mediacms.service && systemctl enable mediacms.service && systemctl start mediacms.service
-
-cp deploy/celery_whisper.service /etc/systemd/system/celery_whisper.service && systemctl enable celery_whisper.service && systemctl start celery_whisper.service
-
-
 mkdir -p /etc/letsencrypt/live/mediacms.io/
-mkdir -p /etc/letsencrypt/live/$FRONTEND_HOST
+mkdir -p "/etc/letsencrypt/live/$FRONTEND_HOST"
 mkdir -p /etc/nginx/sites-enabled
 mkdir -p /etc/nginx/sites-available
 mkdir -p /etc/nginx/dhparams/
 rm -rf /etc/nginx/conf.d/default.conf
 rm -rf /etc/nginx/sites-enabled/default
-cp deploy/mediacms.io_fullchain.pem /etc/letsencrypt/live/$FRONTEND_HOST/fullchain.pem
+cp deploy/mediacms.io_fullchain.pem "/etc/letsencrypt/live/$FRONTEND_HOST/fullchain.pem"
 # this is just a self signed key, will be replaced by certbot
-cp deploy/mediacms.io_privkey.pem /etc/letsencrypt/live/$FRONTEND_HOST/privkey.pem
+cp deploy/mediacms.io_privkey.pem "/etc/letsencrypt/live/$FRONTEND_HOST/privkey.pem"
 cp deploy/dhparams.pem /etc/nginx/dhparams/dhparams.pem
-cp deploy/mediacms.io /etc/nginx/sites-available/mediacms.io
-ln -s /etc/nginx/sites-available/mediacms.io /etc/nginx/sites-enabled/mediacms.io
-cp deploy/uwsgi_params /etc/nginx/sites-enabled/uwsgi_params
 mkdir -p /etc/nginx/conf.d
-cp deploy/cloudflare_real_ip.conf /etc/nginx/conf.d/cloudflare_real_ip.conf
-cp deploy/nginx.conf /etc/nginx/
-systemctl stop nginx
-systemctl start nginx
+
+chmod +x deploy/apply-release-config.sh
+deploy/apply-release-config.sh \
+    --domain "$FRONTEND_HOST" \
+    --proxy "$PROXY_MODE" \
+    --observability "$OBSERVABILITY_MODE"
 
 # attempt to get a valid certificate for specified domain
 
 if [ "$FRONTEND_HOST" != "localhost" ]; then
-    echo 'attempt to get a valid certificate for specified url $FRONTEND_HOST'
-    certbot --nginx -n --agree-tos --register-unsafely-without-email -d $FRONTEND_HOST
-    certbot --nginx -n --agree-tos --register-unsafely-without-email -d $FRONTEND_HOST
+    echo "Attempting to get a certificate for $FRONTEND_HOST"
+    certbot --nginx -n --agree-tos --register-unsafely-without-email -d "$FRONTEND_HOST"
+    certbot --nginx -n --agree-tos --register-unsafely-without-email -d "$FRONTEND_HOST"
     # unfortunately for some reason it needs to be run two times in order to create the entries
     # and directory structure!!!
     systemctl restart nginx
@@ -231,7 +335,7 @@ fi
 
 # Bento4 utility installation, for HLS
 
-cd /home/cinemata/cinematacms
+cd /home/cinemata/cinematacms || exit 1
 wget http://zebulon.bok.net/Bento4/binaries/Bento4-SDK-1-6-0-632.x86_64-unknown-linux.zip
 unzip Bento4-SDK-1-6-0-632.x86_64-unknown-linux.zip
 mkdir -p /home/cinemata/cinematacms/media_files/hls
@@ -239,7 +343,7 @@ mkdir -p /home/cinemata/cinematacms/media_files/hls
 # Create user logos directory and default avatar
 echo "Creating default user avatar..."
 mkdir -p /home/cinemata/cinematacms/media_files/userlogos
-wget -O /home/cinemata/cinematacms/media_files/userlogos/user.jpg https://www.gravatar.com/avatar/00000000000000000000000000000000?d=mp&f=y
+wget -O /home/cinemata/cinematacms/media_files/userlogos/user.jpg "https://www.gravatar.com/avatar/00000000000000000000000000000000?d=mp&f=y"
 
 # last, set default owner
 chown -R www-data. /home/cinemata/

--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,7 @@ Usage: sudo ./install.sh [options]
 
 Options:
   --non-interactive       Do not prompt for installation values.
+  --check-platform        Validate the host OS and architecture, then exit.
   --domain HOST           Portal hostname without a scheme, path, or port.
   --portal-name NAME      Portal name. Defaults to CinemataCMS.
   --proxy MODE            Reverse proxy mode: none or cloudflare.
@@ -21,6 +22,40 @@ fail() {
     exit 1
 }
 
+read_os_release_value() {
+    local key="$1"
+    local os_release_file="$2"
+    awk -F= -v key="$key" '
+        $1 == key {
+            value = substr($0, index($0, "=") + 1)
+            gsub(/^"|"$/, "", value)
+            print value
+            exit
+        }
+    ' "$os_release_file"
+}
+
+check_supported_platform() {
+    local os_release_file="${CINEMATA_OS_RELEASE_FILE:-/etc/os-release}"
+    local os_id
+    local os_version
+
+    [ -r "$os_release_file" ] || fail "cannot read OS information from $os_release_file"
+    os_id=$(read_os_release_value ID "$os_release_file")
+    os_version=$(read_os_release_value VERSION_ID "$os_release_file")
+    [ "$os_id" = "ubuntu" ] && [ "$os_version" = "22.04" ] || \
+        fail "Ubuntu 22.04 is required; found ${os_id:-unknown} ${os_version:-unknown}"
+    command -v dpkg >/dev/null 2>&1 || fail "dpkg is required to detect the system architecture"
+
+    SYSTEM_ARCHITECTURE=$(dpkg --print-architecture)
+    case "$SYSTEM_ARCHITECTURE" in
+        amd64|arm64) ;;
+        *) fail "supported architectures are amd64 and arm64; found $SYSTEM_ARCHITECTURE" ;;
+    esac
+
+    echo "Supported platform: Ubuntu 22.04 ($SYSTEM_ARCHITECTURE)"
+}
+
 validate_domain() {
     local domain="$1"
     [[ "$domain" =~ ^([A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)*[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?$ ]]
@@ -31,8 +66,143 @@ validate_portal_name() {
     [[ "$portal_name" =~ ^[A-Za-z0-9._\ -]{1,100}$ ]]
 }
 
+wait_for_service() {
+    local service_name="$1"
+    shift
+    local attempts="${CINEMATA_SERVICE_WAIT_ATTEMPTS:-30}"
+    local delay="${CINEMATA_SERVICE_WAIT_DELAY:-1}"
+    local attempt
+
+    for ((attempt = 1; attempt <= attempts; attempt++)); do
+        if "$@" >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep "$delay"
+    done
+
+    fail "$service_name did not become ready after $attempts attempts"
+}
+
+ensure_services_ready() {
+    systemctl enable --now postgresql redis-server || \
+        fail "could not start PostgreSQL and Redis"
+    wait_for_service "PostgreSQL" pg_isready -q
+    wait_for_service "Redis" redis-cli ping
+}
+
+bento4_target_for_arch() {
+    case "$1" in
+        amd64) echo "x86_64-unknown-linux" ;;
+        arm64) echo "arm64-unknown-linux" ;;
+        *) fail "cannot build Bento4 for unsupported architecture $1" ;;
+    esac
+}
+
+fail_bento4_install() {
+    local work_dir="$1"
+    local message="$2"
+    rm -rf "$work_dir"
+    fail "$message"
+}
+
+install_bento4() {
+    local architecture="$1"
+    local version="v1.6.0-641"
+    local expected_commit="dc264854d1f76c370b65b18d9f303a95f7f21ab1"
+    local install_dir="${CINEMATA_BENTO4_INSTALL_DIR:-/opt/bento4}"
+    local target
+    local work_dir
+    local source_dir
+    local build_dir
+    local sdk_dir
+    local actual_commit
+
+    target=$(bento4_target_for_arch "$architecture")
+    [ ! -e "$install_dir" ] || fail "$install_dir already exists; remove it before a fresh installation"
+    work_dir=$(mktemp -d)
+    source_dir="$work_dir/source"
+    build_dir="$source_dir/cmakebuild/$target"
+
+    echo "Building Bento4 $version for $architecture"
+    git clone --quiet --depth 1 --branch "$version" \
+        https://github.com/axiomatic-systems/Bento4.git "$source_dir" || \
+        fail_bento4_install "$work_dir" "could not download Bento4 $version"
+    actual_commit=$(git -C "$source_dir" rev-parse HEAD) || \
+        fail_bento4_install "$work_dir" "could not verify the Bento4 source revision"
+    [ "$actual_commit" = "$expected_commit" ] || \
+        fail_bento4_install "$work_dir" "Bento4 $version resolved to unexpected commit $actual_commit"
+    git -C "$source_dir" checkout --quiet -b cinematacms-build || \
+        fail_bento4_install "$work_dir" "could not prepare the Bento4 source tree"
+    cmake -S "$source_dir" -B "$build_dir" -DCMAKE_BUILD_TYPE=Release || \
+        fail_bento4_install "$work_dir" "could not configure the Bento4 build"
+    cmake --build "$build_dir" --parallel "$(nproc)" || \
+        fail_bento4_install "$work_dir" "could not build Bento4"
+    (
+        cd "$source_dir"
+        python3 Scripts/SdkPackager.py "$target" . cmake
+    ) || fail_bento4_install "$work_dir" "could not package Bento4"
+
+    sdk_dir=$(find "$source_dir/SDK" -mindepth 1 -maxdepth 1 -type d \
+        -name "Bento4-SDK-*.$target" -print -quit)
+    [ -n "$sdk_dir" ] || fail_bento4_install "$work_dir" "Bento4 SDK output was not created"
+    [ -x "$sdk_dir/bin/mp4hls" ] || \
+        fail_bento4_install "$work_dir" "Bento4 mp4hls was not packaged"
+    "$sdk_dir/bin/mp4hls" --help >/dev/null || \
+        fail_bento4_install "$work_dir" "Bento4 mp4hls failed its smoke test"
+    mkdir -p "$(dirname "$install_dir")"
+    mv "$sdk_dir" "$install_dir" || \
+        fail_bento4_install "$work_dir" "could not install Bento4 to $install_dir"
+    [ -x "$install_dir/bin/mp4hls" ] || \
+        fail_bento4_install "$work_dir" "Bento4 mp4hls was not installed"
+    rm -rf "$work_dir"
+    echo "Bento4 installed to $install_dir"
+}
+
+install_project_npm() {
+    local package_file="$1"
+    local package_manager
+    local expected_version
+    local installed_version
+
+    [ -f "$package_file" ] || fail "frontend package file not found at $package_file"
+    package_manager=$(node -e 'console.log(require(process.argv[1]).packageManager)' "$package_file") || \
+        fail "could not read packageManager from $package_file"
+    case "$package_manager" in
+        npm@*) expected_version="${package_manager#npm@}" ;;
+        *) fail "unsupported frontend package manager $package_manager" ;;
+    esac
+    npm install --global "$package_manager" || fail "could not install $package_manager"
+    installed_version=$(npm -v) || fail "could not read the installed npm version"
+    [ "$installed_version" = "$expected_version" ] || \
+        fail "expected npm $expected_version after installation; found $installed_version"
+}
+
+configure_package_manager() {
+    if [ "${NON_INTERACTIVE:-false}" = true ]; then
+        export DEBIAN_FRONTEND=noninteractive
+    fi
+}
+
+report_unexpected_failure() {
+    local status="$1"
+    local line="$2"
+    trap - ERR
+    echo "Error: installation failed during $CURRENT_STEP at line $line" >&2
+    exit "$status"
+}
+
+if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then
+    return 0
+fi
+
+set -Eeuo pipefail
+umask 022
+CURRENT_STEP="startup checks"
+trap 'report_unexpected_failure "$?" "$LINENO"' ERR
+
 NON_INTERACTIVE=false
 DRY_RUN=false
+CHECK_PLATFORM=false
 FRONTEND_HOST=""
 PORTAL_NAME=""
 PROXY_MODE=""
@@ -42,6 +212,10 @@ while [ "$#" -gt 0 ]; do
     case "$1" in
         --non-interactive)
             NON_INTERACTIVE=true
+            shift
+            ;;
+        --check-platform)
+            CHECK_PLATFORM=true
             shift
             ;;
         --domain)
@@ -77,6 +251,11 @@ while [ "$#" -gt 0 ]; do
             ;;
     esac
 done
+
+if [ "$CHECK_PLATFORM" = true ]; then
+    check_supported_platform
+    exit 0
+fi
 
 if [ "$NON_INTERACTIVE" = true ]; then
     [ -n "$FRONTEND_HOST" ] || fail "--domain is required with --non-interactive"
@@ -127,11 +306,11 @@ if [ "$DRY_RUN" = true ]; then
     exit 0
 fi
 
+configure_package_manager
 echo "Welcome to the Cinemata installation!"
 
-if [ "$(id -u)" -ne 0 ]
-  then echo "Please run as root"
-  exit
+if [ "$(id -u)" -ne 0 ]; then
+    fail "installer must run as root"
 fi
 
 # This installer hardcodes the repository location /home/cinemata/cinematacms
@@ -165,30 +344,30 @@ It is expected to run on a new system **with no running instances of any these s
 fi
 
 
-osVersion=$(lsb_release -d)
-if [[ $osVersion == *"Ubuntu 22"* ]]; then
-    echo 'Performing system update and dependency installation, this will take a few minutes'
-    apt-get update && apt-get -y upgrade && apt-get install python3-venv python3-dev python3-virtualenv python3-pip virtualenv redis-server postgresql nginx git gcc vim unzip ffmpeg imagemagick telnet htop certbot make build-essential libssl-dev zlib1g-dev  libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev  libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev python3-openssl python3-certbot cmake libpq-dev python3-certbot-nginx -y
-else
-    echo "This script is tested for Ubuntu 22 versions only"
-    exit
-fi
+CURRENT_STEP="platform validation"
+check_supported_platform
+CURRENT_STEP="system dependency installation"
+echo 'Performing system update and dependency installation, this will take a few minutes'
+apt-get update && apt-get -y upgrade && apt-get install python3-venv python3-dev python3-virtualenv python3-pip virtualenv redis-server postgresql nginx git gcc vim unzip ffmpeg imagemagick telnet htop certbot make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev python3-openssl python3-certbot cmake libpq-dev python3-certbot-nginx -y
 
-# install ffmpeg
-echo "Downloading and installing ffmpeg"
-wget -q https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz
-mkdir -p tmp
-tar -xf ffmpeg-release-amd64-static.tar.xz --strip-components 1 -C tmp
-cp -v tmp/{ffmpeg,ffprobe,qt-faststart} /usr/local/bin
-rm -rf tmp ffmpeg-release-amd64-static.tar.xz
-echo "ffmpeg installed to /usr/local/bin"
+CURRENT_STEP="PostgreSQL and Redis startup"
+ensure_services_ready
+
+CURRENT_STEP="media dependency installation"
+command -v ffmpeg >/dev/null 2>&1 || fail "Ubuntu ffmpeg package did not install ffmpeg"
+command -v ffprobe >/dev/null 2>&1 || fail "Ubuntu ffmpeg package did not install ffprobe"
+ffmpeg -version >/dev/null
+ffprobe -version >/dev/null
+install_bento4 "$SYSTEM_ARCHITECTURE"
 
 echo 'Creating database to be used in CinemataCMS'
 
+CURRENT_STEP="database initialization"
 su -c "psql -c \"CREATE DATABASE mediacms\"" postgres
 su -c "psql -c \"CREATE USER mediacms WITH ENCRYPTED PASSWORD 'mediacms'\"" postgres
 su -c "psql -c \"GRANT ALL PRIVILEGES ON DATABASE mediacms TO mediacms\"" postgres
 
+CURRENT_STEP="Node.js and npm installation"
 echo 'Installing Node.js v22 LTS...'
 # Resolve install-nodejs.sh relative to this script's own location, so the
 # installer works regardless of where the repository was cloned or the current
@@ -210,6 +389,7 @@ if [ -f "$NODEJS_SCRIPT" ]; then
             echo "Error: node/npm not on PATH after install"
             exit 1
         fi
+        install_project_npm "$SCRIPT_DIR/frontend/package.json"
         hash -r
     else
         echo "Error: Node.js installation script failed"; exit 1
@@ -218,6 +398,7 @@ else
     echo "Warning: Could not install Node.js - install script not found"; exit 1
 fi
 
+CURRENT_STEP="Python dependency installation"
 echo 'Creating python virtualenv on /home/cinemata'
 
 cd /home/cinemata || exit 1
@@ -226,6 +407,7 @@ virtualenv . --python=python3
 source /home/cinemata/bin/activate
 cd cinematacms || exit 1
 pip install -r requirements.txt
+CURRENT_STEP="Whisper dependency installation"
 cd .. && git clone https://github.com/ggerganov/whisper.cpp.git
 cd whisper.cpp/ || exit 1
 bash ./models/download-ggml-model.sh base
@@ -234,6 +416,7 @@ cd ../cinematacms || exit 1
 
 SECRET_KEY=$(python -c 'from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())')
 
+CURRENT_STEP="application settings"
 FRONTEND_HOST_HTTP_PREFIX="http://$FRONTEND_HOST"
 
 {
@@ -247,12 +430,14 @@ FRONTEND_HOST_HTTP_PREFIX="http://$FRONTEND_HOST"
     echo 'SECRET_KEY='\'"$SECRET_KEY"\'
     echo "LOCAL_INSTALL = True"
     echo "SITE_ID = 1"
+    echo "MP4HLS_COMMAND = '/opt/bento4/bin/mp4hls'"
 } >> cms/local_settings.py
 
 mkdir -p logs
 mkdir -p pids
 
 # Build frontend if Node.js is available
+CURRENT_STEP="frontend build"
 if command -v node &> /dev/null && command -v npm &> /dev/null; then
     echo "Building frontend assets..."
     if ! ./scripts/build_frontend.sh; then
@@ -265,6 +450,7 @@ else
 fi
 
 
+CURRENT_STEP="database migrations and fixtures"
 python manage.py migrate
 python manage.py backfill_media_storage_usage || echo "Warning: storage usage backfill encountered errors; continuing installation."
 echo "Seeding feature flag switches..."
@@ -282,9 +468,11 @@ python manage.py populate_topics
 python manage.py populate_content_sensitivities
 
 ADMIN_PASS=$(python -c "import secrets;chars = 'abcdefghijklmnopqrstuvwxyz0123456789';print(''.join(secrets.choice(chars) for i in range(10)))")
+CURRENT_STEP="administrator account creation"
 echo "from users.models import User; User.objects.create_superuser('admin', 'admin@example.com', '$ADMIN_PASS')" | python manage.py shell
 
 # Configure Django Site with proper error handling
+CURRENT_STEP="site configuration"
 echo "Configuring Django Site..."
 if ! python manage.py update_site_name --name "$PORTAL_NAME" --domain "$FRONTEND_HOST"; then
     echo "Error: Failed to configure Django Site. Aborting installation."
@@ -292,6 +480,7 @@ if ! python manage.py update_site_name --name "$PORTAL_NAME" --domain "$FRONTEND
 fi
 
 chown -R www-data. /home/cinemata/
+CURRENT_STEP="nginx and service configuration"
 mkdir -p /etc/letsencrypt/live/mediacms.io/
 mkdir -p "/etc/letsencrypt/live/$FRONTEND_HOST"
 mkdir -p /etc/nginx/sites-enabled
@@ -313,6 +502,7 @@ deploy/apply-release-config.sh \
 
 # attempt to get a valid certificate for specified domain
 
+CURRENT_STEP="TLS certificate configuration"
 if [ "$FRONTEND_HOST" != "localhost" ]; then
     echo "Attempting to get a certificate for $FRONTEND_HOST"
     certbot --nginx -n --agree-tos --register-unsafely-without-email -d "$FRONTEND_HOST"
@@ -333,14 +523,10 @@ else
     echo "will not generate new DH params for url 'localhost', using default DH params"
 fi
 
-# Bento4 utility installation, for HLS
-
-cd /home/cinemata/cinematacms || exit 1
-wget http://zebulon.bok.net/Bento4/binaries/Bento4-SDK-1-6-0-632.x86_64-unknown-linux.zip
-unzip Bento4-SDK-1-6-0-632.x86_64-unknown-linux.zip
 mkdir -p /home/cinemata/cinematacms/media_files/hls
 
 # Create user logos directory and default avatar
+CURRENT_STEP="media directory initialization"
 echo "Creating default user avatar..."
 mkdir -p /home/cinemata/cinematacms/media_files/userlogos
 wget -O /home/cinemata/cinematacms/media_files/userlogos/user.jpg "https://www.gravatar.com/avatar/00000000000000000000000000000000?d=mp&f=y"

--- a/tests/test_deploy_scripts.py
+++ b/tests/test_deploy_scripts.py
@@ -13,15 +13,310 @@ UPDATER = PROJECT_ROOT / "deploy" / "apply-release-config.sh"
 
 
 class InstallScriptTests(unittest.TestCase):
-    def run_installer(self, *args, input_text=""):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.test_root = Path(self.temp_dir.name)
+
+    def run_installer(self, *args, input_text="", env=None):
         return subprocess.run(
             ["bash", str(INSTALLER), *args],
             cwd=PROJECT_ROOT,
+            env=env,
             input=input_text,
             capture_output=True,
             text=True,
             check=False,
         )
+
+    def platform_env(self, version="22.04", architecture="amd64"):
+        os_release = self.test_root / "os-release"
+        os_release.write_text(f'ID=ubuntu\nVERSION_ID="{version}"\n')
+        fake_bin = self.test_root / "bin"
+        fake_bin.mkdir(exist_ok=True)
+        dpkg = fake_bin / "dpkg"
+        dpkg.write_text(f"#!/bin/sh\nprintf '%s\\n' '{architecture}'\n")
+        dpkg.chmod(dpkg.stat().st_mode | stat.S_IXUSR)
+        env = os.environ.copy()
+        env.update(
+            {
+                "CINEMATA_OS_RELEASE_FILE": str(os_release),
+                "PATH": f"{fake_bin}:{env['PATH']}",
+            }
+        )
+        return env
+
+    def run_installer_function(self, function_call, env=None):
+        return subprocess.run(
+            [
+                "bash",
+                "-c",
+                'source "$1"; eval "$2"',
+                "installer-test",
+                str(INSTALLER),
+                function_call,
+            ],
+            cwd=PROJECT_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def service_env(self, postgres_exit="0", redis_exit="0"):
+        fake_bin = self.test_root / "service-bin"
+        fake_bin.mkdir(exist_ok=True)
+        command_log = self.test_root / "service-commands.log"
+        commands = {
+            "systemctl": "exit 0",
+            "pg_isready": f'exit "{postgres_exit}"',
+            "redis-cli": f'exit "{redis_exit}"',
+        }
+        for name, result in commands.items():
+            command = fake_bin / name
+            command.write_text(f'#!/bin/sh\nprintf "%s\\n" "{name} $*" >> "$FAKE_COMMAND_LOG"\n{result}\n')
+            command.chmod(command.stat().st_mode | stat.S_IXUSR)
+        env = os.environ.copy()
+        env.update(
+            {
+                "CINEMATA_SERVICE_WAIT_ATTEMPTS": "1",
+                "CINEMATA_SERVICE_WAIT_DELAY": "0",
+                "FAKE_COMMAND_LOG": str(command_log),
+                "PATH": f"{fake_bin}:{env['PATH']}",
+            }
+        )
+        return env, command_log
+
+    def bento4_env(self, git_clone_exit="0", mp4hls_exit="0"):
+        fake_bin = self.test_root / "bento4-bin"
+        fake_bin.mkdir(exist_ok=True)
+        command_log = self.test_root / "bento4-commands.log"
+        install_dir = self.test_root / "opt" / "bento4"
+        git = fake_bin / "git"
+        git.write_text(
+            textwrap.dedent(
+                f"""\
+                #!/bin/sh
+                printf '%s\\n' "git $*" >> "$FAKE_COMMAND_LOG"
+                if [ "$1" = "clone" ]; then
+                    [ "{git_clone_exit}" = "0" ] || exit "{git_clone_exit}"
+                    for argument in "$@"; do destination="$argument"; done
+                    mkdir -p "$destination/Scripts"
+                    exit 0
+                fi
+                if [ "$1" = "-C" ]; then
+                    printf '%s\\n' dc264854d1f76c370b65b18d9f303a95f7f21ab1
+                    exit 0
+                fi
+                exit 1
+                """
+            )
+        )
+        cmake = fake_bin / "cmake"
+        cmake.write_text('#!/bin/sh\nprintf \'%s\\n\' "cmake $*" >> "$FAKE_COMMAND_LOG"\nexit 0\n')
+        python = fake_bin / "python3"
+        python.write_text(
+            textwrap.dedent(
+                f"""\
+                #!/bin/sh
+                printf '%s\n' "python3 $*" >> "$FAKE_COMMAND_LOG"
+                target="$2"
+                sdk="SDK/Bento4-SDK-1-6-0-641.$target"
+                mkdir -p "$sdk/bin"
+                printf '#!/bin/sh\nexit {mp4hls_exit}\n' > "$sdk/bin/mp4hls"
+                chmod +x "$sdk/bin/mp4hls"
+                """
+            )
+        )
+        nproc = fake_bin / "nproc"
+        nproc.write_text("#!/bin/sh\nprintf '2\\n'\n")
+        for command in (git, cmake, python, nproc):
+            command.chmod(command.stat().st_mode | stat.S_IXUSR)
+        env = os.environ.copy()
+        env.update(
+            {
+                "CINEMATA_BENTO4_INSTALL_DIR": str(install_dir),
+                "FAKE_COMMAND_LOG": str(command_log),
+                "PATH": f"{fake_bin}:{env['PATH']}",
+            }
+        )
+        return env, command_log, install_dir
+
+    def npm_env(self, installed_version="11.19.0"):
+        fake_bin = self.test_root / "npm-bin"
+        fake_bin.mkdir(exist_ok=True)
+        command_log = self.test_root / "npm-commands.log"
+        node = fake_bin / "node"
+        node.write_text("#!/bin/sh\nprintf 'npm@11.19.0\\n'\n")
+        npm = fake_bin / "npm"
+        npm.write_text(
+            textwrap.dedent(
+                f"""\
+                #!/bin/sh
+                printf '%s\\n' "npm $*" >> "$FAKE_COMMAND_LOG"
+                if [ "$1" = "-v" ]; then
+                    printf '%s\\n' "{installed_version}"
+                fi
+                """
+            )
+        )
+        for command in (node, npm):
+            command.chmod(command.stat().st_mode | stat.S_IXUSR)
+        env = os.environ.copy()
+        env.update(
+            {
+                "FAKE_COMMAND_LOG": str(command_log),
+                "PATH": f"{fake_bin}:{env['PATH']}",
+            }
+        )
+        return env, command_log
+
+    def test_service_readiness_starts_and_checks_postgres_and_redis(self):
+        env, command_log = self.service_env()
+
+        result = self.run_installer_function("ensure_services_ready", env=env)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            command_log.read_text().splitlines(),
+            [
+                "systemctl enable --now postgresql redis-server",
+                "pg_isready -q",
+                "redis-cli ping",
+            ],
+        )
+
+    def test_service_readiness_fails_when_postgres_does_not_start(self):
+        env, _ = self.service_env(postgres_exit="1")
+
+        result = self.run_installer_function("ensure_services_ready", env=env)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("PostgreSQL did not become ready", result.stderr)
+
+    def test_bento4_build_target_matches_supported_architecture(self):
+        expected_targets = {
+            "amd64": "x86_64-unknown-linux",
+            "arm64": "arm64-unknown-linux",
+        }
+
+        for architecture, expected_target in expected_targets.items():
+            with self.subTest(architecture=architecture):
+                result = self.run_installer_function(f"bento4_target_for_arch {architecture}")
+
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(result.stdout.strip(), expected_target)
+
+    def test_bento4_install_builds_arm64_and_smoke_tests_mp4hls(self):
+        env, command_log, install_dir = self.bento4_env()
+
+        result = self.run_installer_function("install_bento4 arm64", env=env)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue((install_dir / "bin" / "mp4hls").is_file())
+        commands = command_log.read_text()
+        self.assertIn("arm64-unknown-linux", commands)
+        self.assertIn("checkout --quiet -b cinematacms-build", commands)
+        self.assertIn("Bento4 installed", result.stdout)
+
+    def test_bento4_download_failure_stops_installation(self):
+        env, _, install_dir = self.bento4_env(git_clone_exit="23")
+
+        result = self.run_installer_function("install_bento4 amd64", env=env)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("could not download Bento4", result.stderr)
+        self.assertNotIn("Bento4 installed", result.stdout)
+        self.assertFalse(install_dir.exists())
+
+    def test_bento4_smoke_test_failure_leaves_no_partial_install(self):
+        env, _, install_dir = self.bento4_env(mp4hls_exit="7")
+
+        result = self.run_installer_function("install_bento4 arm64", env=env)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("failed its smoke test", result.stderr)
+        self.assertFalse(install_dir.exists())
+
+    def test_project_npm_version_comes_from_frontend_package(self):
+        env, command_log = self.npm_env()
+
+        result = self.run_installer_function(
+            f"install_project_npm {PROJECT_ROOT / 'frontend' / 'package.json'}",
+            env=env,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("npm install --global npm@11.19.0", command_log.read_text())
+
+    def test_project_npm_version_mismatch_fails_installation(self):
+        env, _ = self.npm_env(installed_version="10.9.8")
+
+        result = self.run_installer_function(
+            f"install_project_npm {PROJECT_ROOT / 'frontend' / 'package.json'}",
+            env=env,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("expected npm 11.19.0", result.stderr)
+
+    def test_non_interactive_install_disables_package_prompts(self):
+        result = self.run_installer_function(
+            "NON_INTERACTIVE=true; configure_package_manager; printf '%s' \"$DEBIAN_FRONTEND\""
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "noninteractive")
+
+    def test_platform_check_accepts_ubuntu_22_arm64(self):
+        result = self.run_installer(
+            "--check-platform",
+            env=self.platform_env(architecture="arm64"),
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Supported platform: Ubuntu 22.04 (arm64)", result.stdout)
+
+    def test_platform_check_rejects_other_ubuntu_release(self):
+        result = self.run_installer(
+            "--check-platform",
+            env=self.platform_env(version="24.04"),
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Ubuntu 22.04 is required", result.stderr)
+
+    def test_platform_check_rejects_unsupported_architecture(self):
+        result = self.run_installer(
+            "--check-platform",
+            env=self.platform_env(architecture="ppc64el"),
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("amd64 and arm64", result.stderr)
+
+    def test_full_install_rejects_non_root_with_failure_status(self):
+        fake_bin = self.test_root / "non-root-bin"
+        fake_bin.mkdir()
+        fake_id = fake_bin / "id"
+        fake_id.write_text("#!/bin/sh\nprintf '1000\\n'\n")
+        fake_id.chmod(fake_id.stat().st_mode | stat.S_IXUSR)
+        env = os.environ.copy()
+        env["PATH"] = f"{fake_bin}:{env['PATH']}"
+
+        result = self.run_installer(
+            "--non-interactive",
+            "--domain",
+            "localhost",
+            "--proxy",
+            "none",
+            "--observability",
+            "none",
+            env=env,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("must run as root", result.stderr)
 
     def test_non_interactive_dry_run_resolves_all_options(self):
         result = self.run_installer(
@@ -48,7 +343,7 @@ class InstallScriptTests(unittest.TestCase):
         env = os.environ.copy()
         env.update(
             {
-                "DJANGO_SETTINGS_MODULE": "cms.settings",
+                "DJANGO_SETTINGS_MODULE": "cms.ci_settings",
                 "OTEL_ENABLED": "true",
                 "OTEL_SERVICE_NAME": "cinematacms-deploy-test",
                 "OTEL_EXPORTER_OTLP_ENDPOINT": "http://127.0.0.1:14318/v1/traces",

--- a/tests/test_deploy_scripts.py
+++ b/tests/test_deploy_scripts.py
@@ -10,6 +10,7 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 INSTALLER = PROJECT_ROOT / "install.sh"
 UPDATER = PROJECT_ROOT / "deploy" / "apply-release-config.sh"
+LOCAL_OBSERVABILITY_INSTALLER = PROJECT_ROOT / "deploy" / "install-local-observability.sh"
 
 
 class InstallScriptTests(unittest.TestCase):
@@ -119,11 +120,11 @@ class InstallScriptTests(unittest.TestCase):
             textwrap.dedent(
                 f"""\
                 #!/bin/sh
-                printf '%s\n' "python3 $*" >> "$FAKE_COMMAND_LOG"
+                printf '%s\\n' "python3 $*" >> "$FAKE_COMMAND_LOG"
                 target="$2"
                 sdk="SDK/Bento4-SDK-1-6-0-641.$target"
                 mkdir -p "$sdk/bin"
-                printf '#!/bin/sh\nexit {mp4hls_exit}\n' > "$sdk/bin/mp4hls"
+                printf '#!/bin/sh\\nexit {mp4hls_exit}\\n' > "$sdk/bin/mp4hls"
                 chmod +x "$sdk/bin/mp4hls"
                 """
             )
@@ -142,12 +143,12 @@ class InstallScriptTests(unittest.TestCase):
         )
         return env, command_log, install_dir
 
-    def npm_env(self, installed_version="11.19.0"):
+    def npm_env(self, installed_version="11.19.0", package_manager="npm@11.19.0"):
         fake_bin = self.test_root / "npm-bin"
         fake_bin.mkdir(exist_ok=True)
         command_log = self.test_root / "npm-commands.log"
         node = fake_bin / "node"
-        node.write_text("#!/bin/sh\nprintf 'npm@11.19.0\\n'\n")
+        node.write_text(f"#!/bin/sh\nprintf '%s\\n' '{package_manager}'\n")
         npm = fake_bin / "npm"
         npm.write_text(
             textwrap.dedent(
@@ -260,6 +261,18 @@ class InstallScriptTests(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("expected npm 11.19.0", result.stderr)
 
+    def test_project_npm_ignores_corepack_integrity_suffix_for_version_check(self):
+        package_manager = "npm@11.19.0+sha512.deadbeef"
+        env, command_log = self.npm_env(package_manager=package_manager)
+
+        result = self.run_installer_function(
+            f"install_project_npm {PROJECT_ROOT / 'frontend' / 'package.json'}",
+            env=env,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(f"npm install --global {package_manager}", command_log.read_text())
+
     def test_non_interactive_install_disables_package_prompts(self):
         result = self.run_installer_function(
             "NON_INTERACTIVE=true; configure_package_manager; printf '%s' \"$DEBIAN_FRONTEND\""
@@ -339,6 +352,29 @@ class InstallScriptTests(unittest.TestCase):
         self.assertIn("observability=local", result.stdout)
         self.assertIn("No changes were made.", result.stdout)
 
+    def test_non_interactive_dry_run_rejects_portal_name_with_backslash(self):
+        result = self.run_installer(
+            "--non-interactive",
+            "--domain",
+            "video.example.org",
+            "--portal-name",
+            "Example\\",
+            "--proxy",
+            "none",
+            "--observability",
+            "none",
+            "--dry-run",
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("--portal-name may contain", result.stderr)
+
+    def test_bento4_fake_python_has_valid_shebang(self):
+        self.bento4_env()
+
+        python = self.test_root / "bento4-bin" / "python3"
+        self.assertTrue(python.read_bytes().startswith(b"#!/bin/sh\n"))
+
     def test_runtime_settings_read_observability_environment(self):
         env = os.environ.copy()
         env.update(
@@ -375,6 +411,30 @@ class InstallScriptTests(unittest.TestCase):
             ["True", "cinematacms-deploy-test", "http://127.0.0.1:14318/v1/traces", "0.25"],
         )
 
+    def test_runtime_settings_fall_back_for_invalid_sampler_value(self):
+        env = os.environ.copy()
+        env.update(
+            {
+                "DJANGO_SETTINGS_MODULE": "cms.ci_settings",
+                "OTEL_TRACES_SAMPLER_ARG": "0,25",
+            }
+        )
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "from django.conf import settings; print(settings.OTEL_TRACES_SAMPLER_ARG)",
+            ],
+            cwd=PROJECT_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "1.0")
+
     def test_non_interactive_mode_rejects_missing_required_option(self):
         result = self.run_installer(
             "--non-interactive",
@@ -401,6 +461,132 @@ class InstallScriptTests(unittest.TestCase):
         self.assertIn("observability=local", result.stdout)
 
 
+class LocalObservabilityInstallerTests(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.fake_bin = Path(self.temp_dir.name) / "bin"
+        self.command_log = Path(self.temp_dir.name) / "commands.log"
+        self.fake_bin.mkdir()
+        self._write_fake_command("prometheus", "exit 0")
+        self._write_fake_command("otelcol-contrib", "exit 0")
+        self._write_fake_command(
+            "id",
+            """
+            if [ "$#" -eq 1 ] && [ "$1" = "-u" ]; then
+                printf '0\\n'
+                exit 0
+            fi
+            if [ "${FAKE_USER_EXISTS:-0}" = "1" ]; then
+                printf '999\\n'
+                exit 0
+            fi
+            exit 1
+            """,
+        )
+        self._write_fake_command(
+            "getent",
+            """
+            [ "${FAKE_GROUP_EXISTS:-0}" = "1" ]
+            """,
+        )
+        self._write_fake_command("groupadd", "exit 0")
+        self._write_fake_command("useradd", "exit 0")
+        self._write_fake_command(
+            "systemctl",
+            """
+            case "$1" in
+                show)
+                    if [ "${FAKE_MISSING_UNITS:-0}" = "1" ]; then
+                        printf 'not-found\\n'
+                    else
+                        printf 'loaded\\n'
+                    fi
+                    ;;
+                disable)
+                    [ "${FAKE_DISABLE_FAIL_SERVICE:-}" != "$3" ]
+                    ;;
+                is-active)
+                    [ "${FAKE_ACTIVE_SERVICE:-}" = "$3" ]
+                    ;;
+            esac
+            """,
+        )
+
+    def _write_fake_command(self, name, body):
+        command = self.fake_bin / name
+        command.write_text(
+            "#!/bin/sh\nprintf '%s\\n' \"" + name + ' $*" >> "$FAKE_COMMAND_LOG"\n' + textwrap.dedent(body).lstrip()
+        )
+        command.chmod(command.stat().st_mode | stat.S_IXUSR)
+
+    def run_installer(self, *args, env_updates=None):
+        env = os.environ.copy()
+        env.update(
+            {
+                "FAKE_COMMAND_LOG": str(self.command_log),
+                "PATH": f"{self.fake_bin}:{env['PATH']}",
+            }
+        )
+        if env_updates:
+            env.update(env_updates)
+        return subprocess.run(
+            ["bash", str(LOCAL_OBSERVABILITY_INSTALLER), *args],
+            cwd=PROJECT_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_missing_group_is_created_before_the_service_user(self):
+        result = self.run_installer("--no-service-changes")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        commands = self.command_log.read_text().splitlines()
+        groupadd = commands.index("groupadd --system otelcol-contrib")
+        useradd = commands.index(
+            "useradd --system --gid otelcol-contrib --home-dir /nonexistent --shell /usr/sbin/nologin otelcol-contrib"
+        )
+        self.assertLess(groupadd, useradd)
+
+    def test_existing_service_shutdown_failure_aborts_installation(self):
+        result = self.run_installer(
+            env_updates={
+                "FAKE_USER_EXISTS": "1",
+                "FAKE_GROUP_EXISTS": "1",
+                "FAKE_DISABLE_FAIL_SERVICE": "prometheus",
+            }
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("could not stop package service prometheus", result.stderr)
+
+    def test_service_that_remains_active_aborts_installation(self):
+        result = self.run_installer(
+            env_updates={
+                "FAKE_USER_EXISTS": "1",
+                "FAKE_GROUP_EXISTS": "1",
+                "FAKE_ACTIVE_SERVICE": "prometheus",
+            }
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("package service prometheus is still active", result.stderr)
+
+    def test_missing_package_services_are_ignored(self):
+        result = self.run_installer(
+            env_updates={
+                "FAKE_USER_EXISTS": "1",
+                "FAKE_GROUP_EXISTS": "1",
+                "FAKE_MISSING_UNITS": "1",
+            }
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn("systemctl disable", self.command_log.read_text())
+
+
 class ApplyReleaseConfigTests(unittest.TestCase):
     def setUp(self):
         self.temp_dir = tempfile.TemporaryDirectory()
@@ -421,7 +607,7 @@ class ApplyReleaseConfigTests(unittest.TestCase):
                 #!/bin/sh
                 echo "install-observability" >> "$FAKE_COMMAND_LOG"
                 for command in prometheus otelcol-contrib; do
-                    printf '#!/bin/sh\nexit 0\n' > "$FAKE_BIN/$command"
+                    printf '#!/bin/sh\\nexit 0\\n' > "$FAKE_BIN/$command"
                     chmod +x "$FAKE_BIN/$command"
                 done
                 """
@@ -463,6 +649,9 @@ class ApplyReleaseConfigTests(unittest.TestCase):
             text=True,
             check=False,
         )
+
+    def test_fake_observability_installer_has_valid_shebang(self):
+        self.assertTrue(self.observability_installer.read_bytes().startswith(b"#!/bin/sh\n"))
 
     def test_first_apply_persists_config_and_installs_managed_files(self):
         result = self.run_updater(
@@ -537,6 +726,27 @@ class ApplyReleaseConfigTests(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("nginx validation failed", result.stderr)
         self.assertEqual(site_path.read_text(), original)
+
+    def test_managed_file_write_failure_restores_previous_config(self):
+        config_path = self.deploy_root / "etc/cinematacms/deployment.env"
+        config_path.parent.mkdir(parents=True)
+        original = (
+            "CINEMATA_DOMAIN=video.example.org\n"
+            "CINEMATA_PROXY=none\n"
+            "CINEMATA_OBSERVABILITY=none\n"
+            "# preserve this line\n"
+        )
+        config_path.write_text(original)
+        self._write_fake_command("install", "exit 17")
+
+        result = self.run_updater(
+            "--proxy",
+            "cloudflare",
+            "--no-restart",
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(config_path.read_text(), original)
 
     def test_local_mode_installs_missing_observability_binaries(self):
         (self.fake_bin / "prometheus").unlink()

--- a/tests/test_deploy_scripts.py
+++ b/tests/test_deploy_scripts.py
@@ -1,0 +1,285 @@
+import os
+import stat
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+INSTALLER = PROJECT_ROOT / "install.sh"
+UPDATER = PROJECT_ROOT / "deploy" / "apply-release-config.sh"
+
+
+class InstallScriptTests(unittest.TestCase):
+    def run_installer(self, *args, input_text=""):
+        return subprocess.run(
+            ["bash", str(INSTALLER), *args],
+            cwd=PROJECT_ROOT,
+            input=input_text,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_non_interactive_dry_run_resolves_all_options(self):
+        result = self.run_installer(
+            "--non-interactive",
+            "--domain",
+            "video.example.org",
+            "--portal-name",
+            "Example Video",
+            "--proxy",
+            "cloudflare",
+            "--observability",
+            "local",
+            "--dry-run",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("domain=video.example.org", result.stdout)
+        self.assertIn("portal_name=Example Video", result.stdout)
+        self.assertIn("proxy=cloudflare", result.stdout)
+        self.assertIn("observability=local", result.stdout)
+        self.assertIn("No changes were made.", result.stdout)
+
+    def test_runtime_settings_read_observability_environment(self):
+        env = os.environ.copy()
+        env.update(
+            {
+                "DJANGO_SETTINGS_MODULE": "cms.settings",
+                "OTEL_ENABLED": "true",
+                "OTEL_SERVICE_NAME": "cinematacms-deploy-test",
+                "OTEL_EXPORTER_OTLP_ENDPOINT": "http://127.0.0.1:14318/v1/traces",
+                "OTEL_TRACES_SAMPLER_ARG": "0.25",
+            }
+        )
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "from django.conf import settings; "
+                    "print(settings.OTEL_ENABLED); "
+                    "print(settings.OTEL_SERVICE_NAME); "
+                    "print(settings.OTEL_EXPORTER_OTLP_ENDPOINT); "
+                    "print(settings.OTEL_TRACES_SAMPLER_ARG)"
+                ),
+            ],
+            cwd=PROJECT_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            result.stdout.splitlines(),
+            ["True", "cinematacms-deploy-test", "http://127.0.0.1:14318/v1/traces", "0.25"],
+        )
+
+    def test_non_interactive_mode_rejects_missing_required_option(self):
+        result = self.run_installer(
+            "--non-interactive",
+            "--domain",
+            "video.example.org",
+            "--proxy",
+            "none",
+            "--dry-run",
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("--observability is required with --non-interactive", result.stderr)
+
+    def test_interactive_dry_run_prompts_for_missing_options(self):
+        result = self.run_installer(
+            "--dry-run",
+            input_text="video.example.org\nExample Video\ncloudflare\nlocal\n",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("domain=video.example.org", result.stdout)
+        self.assertIn("portal_name=Example Video", result.stdout)
+        self.assertIn("proxy=cloudflare", result.stdout)
+        self.assertIn("observability=local", result.stdout)
+
+
+class ApplyReleaseConfigTests(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.deploy_root = Path(self.temp_dir.name) / "root"
+        self.fake_bin = Path(self.temp_dir.name) / "bin"
+        self.command_log = Path(self.temp_dir.name) / "commands.log"
+        self.observability_installer = Path(self.temp_dir.name) / "install-observability"
+        self.fake_bin.mkdir()
+        self.deploy_root.mkdir()
+        self._write_fake_command("systemctl")
+        self._write_fake_command("nginx", 'exit "${FAKE_NGINX_EXIT:-0}"')
+        self._write_fake_command("prometheus")
+        self._write_fake_command("otelcol-contrib")
+        self.observability_installer.write_text(
+            textwrap.dedent(
+                """\
+                #!/bin/sh
+                echo "install-observability" >> "$FAKE_COMMAND_LOG"
+                for command in prometheus otelcol-contrib; do
+                    printf '#!/bin/sh\nexit 0\n' > "$FAKE_BIN/$command"
+                    chmod +x "$FAKE_BIN/$command"
+                done
+                """
+            )
+        )
+        self.observability_installer.chmod(self.observability_installer.stat().st_mode | stat.S_IXUSR)
+
+    def _write_fake_command(self, name, extra=""):
+        path = self.fake_bin / name
+        path.write_text(
+            textwrap.dedent(
+                f"""\
+                #!/bin/sh
+                echo "{name} $*" >> "$FAKE_COMMAND_LOG"
+                {extra}
+                """
+            )
+        )
+        path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+    def run_updater(self, *args, nginx_exit="0"):
+        env = os.environ.copy()
+        env.update(
+            {
+                "CINEMATA_DEPLOY_ROOT": str(self.deploy_root),
+                "CINEMATA_SKIP_ROOT_CHECK": "1",
+                "FAKE_COMMAND_LOG": str(self.command_log),
+                "FAKE_NGINX_EXIT": nginx_exit,
+                "FAKE_BIN": str(self.fake_bin),
+                "PATH": f"{self.fake_bin}:{env['PATH']}",
+                "CINEMATA_OBSERVABILITY_INSTALLER": str(self.observability_installer),
+            }
+        )
+        return subprocess.run(
+            ["bash", str(UPDATER), *args],
+            cwd=PROJECT_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_first_apply_persists_config_and_installs_managed_files(self):
+        result = self.run_updater(
+            "--domain",
+            "video.example.org",
+            "--proxy",
+            "cloudflare",
+            "--observability",
+            "local",
+            "--no-restart",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        config = (self.deploy_root / "etc/cinematacms/deployment.env").read_text()
+        self.assertIn("CINEMATA_DOMAIN=video.example.org", config)
+        self.assertIn("CINEMATA_PROXY=cloudflare", config)
+        self.assertIn("CINEMATA_OBSERVABILITY=local", config)
+        self.assertTrue((self.deploy_root / "etc/nginx/snippets/cinematacms-metrics.conf").is_file())
+        self.assertTrue((self.deploy_root / "etc/nginx/conf.d/cloudflare_real_ip.conf").is_file())
+        self.assertTrue((self.deploy_root / "etc/cinematacms/prometheus.yml").is_file())
+        self.assertTrue((self.deploy_root / "etc/cinematacms/otelcol-contrib.yml").is_file())
+        observability_env = (self.deploy_root / "etc/cinematacms/observability.env").read_text()
+        self.assertIn("OTEL_ENABLED=true", observability_env)
+        for unit in ("mediacms", "celery_long", "celery_short", "celery_whisper", "celery_beat"):
+            unit_text = (self.deploy_root / f"etc/systemd/system/{unit}.service").read_text()
+            self.assertIn("EnvironmentFile=-/etc/cinematacms/observability.env", unit_text)
+        site = (self.deploy_root / "etc/nginx/sites-available/mediacms.io").read_text()
+        self.assertIn("server_name video.example.org;", site)
+        self.assertEqual(site.count("cinematacms-metrics.conf"), 2)
+        self.assertIn("nginx -t", self.command_log.read_text())
+        self.assertNotIn("systemctl enable --now", self.command_log.read_text())
+
+    def test_second_apply_reuses_saved_config_without_duplicate_nginx_include(self):
+        first = self.run_updater(
+            "--domain",
+            "video.example.org",
+            "--proxy",
+            "none",
+            "--observability",
+            "none",
+            "--no-restart",
+        )
+        self.assertEqual(first.returncode, 0, first.stderr)
+        site_path = self.deploy_root / "etc/nginx/sites-available/mediacms.io"
+        site_path.write_text(site_path.read_text() + "# retained Certbot configuration\n")
+
+        second = self.run_updater("--no-restart")
+
+        self.assertEqual(second.returncode, 0, second.stderr)
+        site = site_path.read_text()
+        self.assertEqual(site.count("cinematacms-metrics.conf"), 2)
+        self.assertIn("# retained Certbot configuration", site)
+        self.assertFalse((self.deploy_root / "etc/nginx/conf.d/cloudflare_real_ip.conf").exists())
+
+    def test_failed_nginx_validation_restores_existing_site(self):
+        site_path = self.deploy_root / "etc/nginx/sites-available/mediacms.io"
+        site_path.parent.mkdir(parents=True)
+        original = "server {\n    location / { return 200; }\n}\n"
+        site_path.write_text(original)
+
+        result = self.run_updater(
+            "--domain",
+            "video.example.org",
+            "--proxy",
+            "cloudflare",
+            "--observability",
+            "none",
+            "--no-restart",
+            nginx_exit="1",
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("nginx validation failed", result.stderr)
+        self.assertEqual(site_path.read_text(), original)
+
+    def test_local_mode_installs_missing_observability_binaries(self):
+        (self.fake_bin / "prometheus").unlink()
+        (self.fake_bin / "otelcol-contrib").unlink()
+
+        result = self.run_updater(
+            "--domain",
+            "video.example.org",
+            "--proxy",
+            "none",
+            "--observability",
+            "local",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("install-observability", self.command_log.read_text())
+
+    def test_saved_domain_cannot_change_through_release_updater(self):
+        first = self.run_updater(
+            "--domain",
+            "video.example.org",
+            "--proxy",
+            "none",
+            "--observability",
+            "none",
+            "--no-restart",
+        )
+        self.assertEqual(first.returncode, 0, first.stderr)
+
+        second = self.run_updater(
+            "--domain",
+            "other.example.org",
+            "--no-restart",
+        )
+
+        self.assertNotEqual(second.returncode, 0)
+        self.assertIn("Certbot and nginx", second.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

This pull request hardens the observability behavior added in #811 and makes the matching runtime configuration deployable on new and existing CinemataCMS servers.

### Application behavior

- Treat Prometheus emission as best-effort so metric failures do not change cache, stale-encoding recovery, or media-processing outcomes.
- Use `multiprocess_mode="mostrecent"` for queue-depth, transcription-request, and stalled-encoding snapshot gauges.
- Keep the `media.encode.ffmpeg.start` span active while the FFmpeg generator runs.
- Record each terminal encoding result once across GIF, early-failure, normal-completion, and exhausted-retry paths. A scheduled retry is not a terminal failure.

### Deployment workflow

- Keep `install.sh` interactive by default and add a complete `--non-interactive` mode for automated installs.
- Validate Ubuntu 22.04 and the `amd64` or `arm64` architecture through `--check-platform`.
- Stop on failed downloads, builds, service startup, migrations, or configuration instead of reporting a false success.
- Start PostgreSQL and Redis and wait for both services before database setup.
- Use the Ubuntu FFmpeg package so the installed binary matches the host architecture.
- Build Bento4 from pinned commit `dc264854d1f76c370b65b18d9f303a95f7f21ab1`, smoke-test `mp4hls`, and install the SDK at `/opt/bento4`.
- Install the npm version declared by `frontend/package.json`.
- Save the domain, proxy, and observability choices in `/etc/cinematacms/deployment.env`.
- Add `deploy/apply-release-config.sh` so existing installations can apply release nginx, systemd, and observability configuration.
- Preserve existing nginx and Certbot changes, create backups, validate with `nginx -t`, and restore the previous files when validation fails.
- Add optional loopback-only Prometheus and OpenTelemetry Collector services.
- Read OpenTelemetry settings from `/etc/cinematacms/observability.env`.
- Document fresh installation, noninteractive installation, platform support, and release updates.

## Related issues

Follow-up to #811. This improves the metric and tracing work tracked in #579, #580, and #581 without closing those issues.

## How has this been tested?

The observability fixes and deployment workflow were developed with regression tests.

```text
uv run python -m unittest tests.test_deploy_scripts
```

Result: 32 tests passed. These tests cover interactive and noninteractive options, platform validation, PostgreSQL and Redis readiness, Bento4 architecture selection and failure cleanup, the pinned npm version, saved configuration, idempotent nginx updates, Certbot configuration retention, rollback, package installation, systemd environment files, and domain-change rejection.

```text
uv run python manage.py test cms.tests.test_observability files.tests.test_encoding --verbosity=1
```

Result: 36 tests passed.

```text
make agent-check
```

Result: all repository quality hooks passed.

```text
shellcheck install.sh deploy/apply-release-config.sh deploy/install-local-observability.sh
```

Result: passed.

Container validation also passed for:

- `nginx -t` with the generated site and metrics snippet.
- `promtool check config` with `deploy/prometheus-cinematacms.yml`.
- OpenTelemetry Collector `validate` with `deploy/otelcol-contrib-cinematacms.yml`.
- `systemd-analyze verify` for all seven application and observability units.

On 2026-08-31, commit `bd680f241223fd764f8d167ea7b8b2a0cb4b9928` completed a fresh noninteractive installation in a clean Ubuntu 22.04 ARM64 systemd container inside an OrbStack Linux VM. The run installed and started PostgreSQL, Redis, nginx, the application, all Celery workers, Prometheus, and the OpenTelemetry Collector.

Runtime checks confirmed:

- The application returned HTTP `200` through nginx.
- `/metrics` returned HTTP `200` on loopback and `403` through the non-loopback container address.
- Prometheus reported the `cinematacms` target as `UP` with no scrape error.
- The OpenTelemetry Collector exported application trace batches after real requests.
- Ubuntu FFmpeg and FFprobe ran on ARM64.
- Bento4 `mp4hls` and `mp4fragment` ran from `/opt/bento4`.
- Node.js `v22.23.2` used npm `11.19.0` without `EBADENGINE` warnings.
- Two consecutive `deploy/apply-release-config.sh` runs kept the nginx site SHA-256 unchanged and left all services active.

The full fresh-install test did not run on `amd64` because the local host is ARM64. Automated tests cover the `amd64` Bento4 build target and platform acceptance.

An earlier broad backend run executed 705 tests. No changed-area test failed. Two unrelated local environment failures remain:

- `files.tests.test_race_conditions.RaceConditionTest.test_concurrent_views_no_lost_counts` could not flush the shared PostgreSQL test database because the server preloads Apache AGE without an `ag_catalog` schema.
- `tests.test_ui_variant.UIVariantViewTests.test_upload_revamp_when_allowlisted` expected the Vite development path while the response used the built hashed asset.

The previous CI run also exposed a deployment test that imported production settings without CI's local-settings stub. Commit `bd680f241223fd764f8d167ea7b8b2a0cb4b9928` switches that test to `cms.ci_settings`; the focused regression test passes locally.

No user-interface checks apply.

### Review follow-up

Commit `577d252c5424259c5cf935f6dcd088338ad75b4b` addresses nine valid CodeRabbit findings. Regression tests cover both encoding safety breaks, invalid sampler input, rollback after a nested write failure, group and user provisioning, package-service shutdown, npm integrity suffixes, and executable shell fixtures.

The portal-name regex already rejects backslashes. `test_non_interactive_dry_run_rejects_portal_name_with_backslash` records that behavior, so production validation did not change.

## AI assistance

- [x] This contribution includes substantive AI assistance.
- [ ] This contribution does not include substantive AI assistance.

### AI tools and use

Codex `gpt-5.6-luna` implemented the initial test-first observability fixes. Codex `gpt-5.6-sol` reviewed those fixes, corrected retry outcome edge cases, implemented and hardened the deployment workflow, added regression tests, updated the documentation, ran the Ubuntu 22.04 ARM64 fresh-install test, verified metrics and trace collection, and addressed the follow-up review findings.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature which changes existing functionality)
- [x] Documentation update

## Checklist

- [x] The code follows the project style.
- [x] Tests cover the changed behavior.
- [x] Documentation covers the new installer and release-update commands.
- [ ] All existing local tests passed. See the two unrelated failures above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added interactive and non-interactive installation with dry-run checks, platform validation, and configurable domain, proxy, and observability settings.
  - Added automated release configuration with backups, rollback, and optional local Prometheus/OpenTelemetry setup.
  - Added secure, localhost-only metrics access and configurable observability settings.

- **Bug Fixes**
  - Improved media encoding outcome reporting across success, failure, and retry scenarios.
  - Prevented observability failures from interrupting media and encoding workflows.

- **Documentation**
  - Expanded installation, upgrade, Ubuntu deployment, and developer setup guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
