### PR TITLE
fix: restart services after release configuration

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -71,7 +71,13 @@ The updater performs these actions:
 3. Installs the application and observability systemd units.
 4. Runs `nginx -t`.
 5. Restores the backup if nginx rejects the configuration.
-6. Restarts the affected services and reloads nginx.
+6. Restarts the application and Celery services, updates the selected
+   observability services, and reloads nginx.
+
+Use `--no-restart` to install and validate the files without changing any
+service state. Run the updater without that option during a maintenance window
+because the application restart briefly interrupts requests and background
+tasks.
 
 Pass new proxy or observability values to change the saved deployment settings:
 

--- a/deploy/apply-release-config.sh
+++ b/deploy/apply-release-config.sh
@@ -295,7 +295,8 @@ trap - ERR
 
 systemctl daemon-reload
 if [ "$NO_RESTART" = false ]; then
-    systemctl enable --now mediacms celery_long celery_short celery_whisper celery_beat
+    systemctl enable mediacms celery_long celery_short celery_whisper celery_beat
+    systemctl restart mediacms celery_long celery_short celery_whisper celery_beat
     if [ "$OBSERVABILITY_MODE" = "local" ]; then
         systemctl enable --now cinematacms-prometheus cinematacms-otelcol
     else

--- a/deploy/mediacms.service
+++ b/deploy/mediacms.service
@@ -6,9 +6,7 @@ EnvironmentFile=-/etc/cinematacms/observability.env
 Environment=PROMETHEUS_MULTIPROC_DIR="/tmp/prometheus_multiproc"
 ExecStartPre=/bin/bash -c "mkdir -p /tmp/prometheus_multiproc && chown www-data:www-data /tmp/prometheus_multiproc"
 ExecStart=/home/cinemata/bin/uwsgi --ini /home/cinemata/cinematacms/uwsgi.ini
-ExecStop=/usr/bin/killall -9 uwsgi
 RestartSec=3
-#ExecRestart=killall -9 uwsgi; sleep 5; /home/sss/bin/uwsgi --ini /home/sss/wordgames/uwsgi.ini
 Restart=always
 
 

--- a/tests/test_deploy_scripts.py
+++ b/tests/test_deploy_scripts.py
@@ -684,6 +684,86 @@ class ApplyReleaseConfigTests(unittest.TestCase):
         self.assertIn("nginx -t", self.command_log.read_text())
         self.assertNotIn("systemctl enable --now", self.command_log.read_text())
 
+    def test_apply_restarts_active_application_services(self):
+        result = self.run_updater(
+            "--domain",
+            "video.example.org",
+            "--proxy",
+            "none",
+            "--observability",
+            "none",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        commands = self.command_log.read_text().splitlines()
+        application_services = "mediacms celery_long celery_short celery_whisper celery_beat"
+        self.assertIn(f"systemctl enable {application_services}", commands)
+        self.assertIn(f"systemctl restart {application_services}", commands)
+        self.assertNotIn(f"systemctl enable --now {application_services}", commands)
+
+    def test_application_service_restart_failure_aborts_apply(self):
+        self._write_fake_command(
+            "systemctl",
+            """
+            if [ "$1" = "restart" ]; then
+                exit 23
+            fi
+            """,
+        )
+
+        result = self.run_updater(
+            "--domain",
+            "video.example.org",
+            "--proxy",
+            "none",
+            "--observability",
+            "none",
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        commands = self.command_log.read_text().splitlines()
+        self.assertIn(
+            "systemctl restart mediacms celery_long celery_short celery_whisper celery_beat",
+            commands,
+        )
+        self.assertNotIn("systemctl reload-or-restart nginx", commands)
+
+    def test_no_restart_performs_no_service_lifecycle_actions(self):
+        result = self.run_updater(
+            "--domain",
+            "video.example.org",
+            "--proxy",
+            "none",
+            "--observability",
+            "none",
+            "--no-restart",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        lifecycle_actions = {"enable", "disable", "start", "stop", "restart", "reload-or-restart"}
+        systemctl_commands = (
+            command.split()[1]
+            for command in self.command_log.read_text().splitlines()
+            if command.startswith("systemctl ")
+        )
+        self.assertTrue(lifecycle_actions.isdisjoint(systemctl_commands))
+
+    def test_installed_mediacms_unit_uses_systemd_process_shutdown(self):
+        result = self.run_updater(
+            "--domain",
+            "video.example.org",
+            "--proxy",
+            "none",
+            "--observability",
+            "none",
+            "--no-restart",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        unit = (self.deploy_root / "etc/systemd/system/mediacms.service").read_text()
+        self.assertNotIn("ExecStop=", unit)
+        self.assertNotIn("killall", unit)
+
     def test_second_apply_reuses_saved_config_without_duplicate_nginx_include(self):
         first = self.run_updater(
             "--domain",


### PR DESCRIPTION
## Description

- Enable and restart the application and Celery services as separate operations so active processes load updated unit files and environment variables.
- Remove the `killall` `ExecStop` command from `mediacms.service`. Systemd now stops the tracked uWSGI control group without an undeclared `psmisc` dependency.
- Add regression coverage for active-service restarts, restart failures, `--no-restart`, and the installed uWSGI unit.
- Document the service interruption and the non-disruptive `--no-restart` option.

## Related Issue

Fixes #900

## Motivation and Context

The release updater wrote `OTEL_ENABLED=true` on `cinemata-dev` but left the active Django and Celery processes unchanged. `systemctl enable --now` starts inactive services but does not restart active services.

The subsequent manual uWSGI restart also failed its stop command because `/usr/bin/killall` was absent. Systemd waited for the 90-second stop timeout before the service recovered. The managed service does not need that command because systemd already tracks and stops the full service control group.

## How Has This Been Tested?

```text
uv run python -m unittest tests.test_deploy_scripts
```

Result: 36 tests passed.

```text
bash -n deploy/apply-release-config.sh
shellcheck deploy/apply-release-config.sh deploy/install-local-observability.sh install.sh
```

Result: passed.

```text
make agent-check
```

Result: all repository quality hooks passed.

The seven application and observability units also passed `systemd-analyze verify` inside an Ubuntu 22.04 container. Inert executables were installed at the production command paths so the validation covered the unit definitions without installing CinemataCMS in the container.

A read-only check on `cinemata-dev` confirmed the service defaults that replace `ExecStop`: `KillMode=control-group`, `KillSignal=15`, and `SendSIGKILL=yes`.

The branch has not been deployed to dev. Runtime verification on dev remains a post-merge check.

## Screenshots

Not applicable.

## AI assistance

- [x] This contribution includes substantive AI assistance.
- [ ] This contribution does not include substantive AI assistance.

### AI tools and use

Codex `gpt-5.6-sol` reproduced and diagnosed the dev deployment failure, drafted issue #900, implemented the test-first fix, updated the deployment guide, and ran the local and dev verification commands.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed. The deployment suite and repository quality gates passed. The unrelated Django and frontend suites were not run.

## Modern Track Checklist

- [x] I have not imported `flux` in a new component.
- [ ] If adding a new feature, I used Modern Track patterns.
- [x] New features do not create new SCSS files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--no-restart` option to apply release configuration without changing service state.
  * Standard updates now restart application and background services, refresh selected observability services, and reload nginx.
* **Bug Fixes**
  * Improved service restart handling to prevent nginx reloading when an application restart fails.
  * Removed forced process termination during service shutdown for safer restarts.
* **Documentation**
  * Documented restart behavior, maintenance-window guidance, and the `--no-restart` option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->