### PR TITLE
Fix development email worker deployment

### DIFF
--- a/cms/celery.py
+++ b/cms/celery.py
@@ -28,7 +28,7 @@ def debug_task(self):
     print(f"Request: {self.request!r}")
 
 
-@app.task(name="record_beat_freshness", queue="default")
+@app.task(name="record_beat_freshness", queue="short_tasks")
 def record_beat_freshness():
     import time
 

--- a/cms/tests/test_scheduled_jobs.py
+++ b/cms/tests/test_scheduled_jobs.py
@@ -6,6 +6,11 @@ from cms.scheduled_jobs import SCHEDULED_JOBS, record_scheduled_outcome
 
 
 class ScheduledJobContractTests(SimpleTestCase):
+    def test_beat_freshness_runs_on_a_consumed_queue(self):
+        from cms.celery import record_beat_freshness
+
+        self.assertEqual(record_beat_freshness.queue, "short_tasks")
+
     def test_registry_matches_the_production_beat_schedule(self):
         from django.conf import settings
 

--- a/restart_script.sh
+++ b/restart_script.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
+set -e
+
 # Cinemata restart script after code changes
 # Run as root
 
 if [ `id -u` -ne 0 ]
   then echo "Please run as root"
-  exit
+  exit 1
 fi
 
 echo "Starting Cinemata restart process..."
@@ -61,15 +63,15 @@ chown -R www-data. /home/cinemata/
 
 # Reload systemd unit files in case service definitions changed
 echo "Reloading systemd daemon..."
+for unit in mediacms celery_long celery_short celery_whisper celery_email celery_beat; do
+  install -m 0644 "deploy/$unit.service" "/etc/systemd/system/$unit.service"
+done
 systemctl daemon-reload
 
 # Restart services
 echo "Restarting services..."
-systemctl restart celery_long
-systemctl restart celery_short
-systemctl restart celery_beat
-systemctl restart mediacms.service
-systemctl restart celery_whisper.service
+systemctl enable mediacms celery_long celery_short celery_whisper celery_email celery_beat
+systemctl restart mediacms celery_long celery_short celery_whisper celery_email celery_beat
 systemctl restart nginx
 
 echo "Cinemata restart completed successfully!"

--- a/tests/test_deploy_scripts.py
+++ b/tests/test_deploy_scripts.py
@@ -11,6 +11,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 INSTALLER = PROJECT_ROOT / "install.sh"
 UPDATER = PROJECT_ROOT / "deploy" / "apply-release-config.sh"
 LOCAL_OBSERVABILITY_INSTALLER = PROJECT_ROOT / "deploy" / "install-local-observability.sh"
+RESTART_SCRIPT = PROJECT_ROOT / "restart_script.sh"
 
 
 class InstallScriptTests(unittest.TestCase):
@@ -864,6 +865,18 @@ class ApplyReleaseConfigTests(unittest.TestCase):
 
         self.assertNotEqual(second.returncode, 0)
         self.assertIn("Certbot and nginx", second.stderr)
+
+
+class RestartScriptTests(unittest.TestCase):
+    def test_restart_installs_and_starts_every_application_unit(self):
+        script = RESTART_SCRIPT.read_text()
+        units = "mediacms celery_long celery_short celery_whisper celery_email celery_beat"
+
+        self.assertIn("set -e", script)
+        self.assertIn(f"for unit in {units}; do", script)
+        self.assertIn('install -m 0644 "deploy/$unit.service" "/etc/systemd/system/$unit.service"', script)
+        self.assertIn(f"systemctl enable {units}", script)
+        self.assertIn(f"systemctl restart {units}", script)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

This hotfix makes the normal development deployment install and restart the email worker introduced by #904.

- install every repository-managed application unit before `systemctl daemon-reload`
- enable and restart `celery_email` with the existing application services
- stop the deployment script when a command or service restart fails
- route `record_beat_freshness` to `short_tasks`, which has an active worker

## Related issue

Follow-up to #904.

## Motivation and context

The deployment for merge commit `e25aee33f790a0d81cfce1dad8c88a414a5c0550` succeeded on 2026-09-01, but `cinemata-dev` had no installed `celery_email.service`. The deployment workflow calls `restart_script.sh`; that script reloaded systemd without copying the repository unit files and restarted only the older workers.

Live inspection also found 27 `record_beat_freshness` tasks in the unconsumed `default` queue. No deployed worker subscribes to that queue.

## How has this been tested?

Passed locally:

- `make agent-check`
- `uv run python manage.py makemigrations --check`
- `uv run python manage.py test --noinput cms.tests.test_scheduled_jobs tests.test_deploy_scripts` (41 tests)

The regression tests failed against the pre-fix code because `record_beat_freshness.queue` was `default` and `restart_script.sh` did not install or start the email unit. The same tests pass with this patch.

The broad command `uv run python manage.py test --noinput --verbosity=2 --exclude-tag=requires-whisper` reported the same two local-environment failures documented in #904:

- `files.tests.test_race_conditions.RaceConditionTest.test_concurrent_views_no_lost_counts` cannot flush PostgreSQL because the local server lacks the `ag_catalog` schema.
- `tests.test_ui_variant.UIVariantViewTests.test_upload_revamp_when_allowlisted` expects the development entry path, but the configured production manifest renders the hashed asset path.

## Live development verification

On `cinemata-dev`, I installed and enabled `celery_email.service` from merge commit `e25aee33f790a0d81cfce1dad8c88a414a5c0550` as an immediate recovery step.

- the service is `active` and `enabled`
- `email@dev.cinemata.org` subscribes to `email_tasks`
- `email_tasks` drained from 5 to 0
- a real broker-to-worker smoke task completed with result `0`, and its Celery result was removed
- the 27 queued `record_beat_freshness` tasks were inspected by name and processed by a temporary `default` worker

Beat continues to publish one task per minute to `default` until this patch is merged and deployed. After deployment, `short@dev.cinemata.org` will consume the freshness task.

## Screenshots

Not applicable.

## AI assistance

- [x] This contribution includes substantive AI assistance.
- [ ] This contribution does not include substantive AI assistance.

### AI tools and use

Codex GPT-5.6 diagnosed the live deployment gap, implemented the tests and hotfix, ran the verification commands, and performed the documented development-host recovery. I requested and reviewed this work.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Modern Track Checklist

- [x] I have not imported `flux` in a new component.
- [x] If adding a new feature, I used Modern Track patterns.
- [x] New features do not create new SCSS files.
