### PR TITLE
docs: add the clone step to the fork setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,13 +5,19 @@ local setup, follow the [developer onboarding guide](docs/setup/Developer-Onboar
 
 ## Start from `upstream/main`
 
-Fork the repository, add the upstream remote, and create a focused branch:
+Fork the repository, clone your fork, add the upstream remote, and create a
+focused branch:
 
 ```bash
+git clone https://github.com/<your-username>/cinematacms.git
+cd cinematacms
 git remote add upstream https://github.com/EngageMedia-video/cinematacms.git
 git fetch upstream
 git switch -c fix/private-media-access upstream/main
 ```
+
+`origin` is your fork and receives every push. `upstream` is the EngageMedia
+repository and is only a source to fetch from. You never push to `upstream`.
 
 Use a short branch type such as `feat`, `fix`, `docs`, `refactor`, `test`, or
 `chore`.


### PR DESCRIPTION
## Description

The fork setup block in `CONTRIBUTING.md` started at `git remote add upstream`,
so it read as if the contributor clones the EngageMedia repository and then adds
a remote to that clone. This adds the missing `git clone` of the fork and names
the role of each remote.

## Related Issue

None.

## Motivation and Context

A contributor following the block literally ends up with `origin` pointing at
the EngageMedia repository, which then fails on the first push. Two sentences
after the block state that `origin` is the fork and receives every push, and
that `upstream` is fetch-only.

## How Has This Been Tested?

- `git diff --check`
- `uv run pre-commit run --files CONTRIBUTING.md` — passed (trailing whitespace,
  end of file, merge conflicts, large files, private key; language-specific
  hooks skipped, no matching files)

Documentation-only change; no backend, frontend, or migration check applies.

## Screenshots (if appropriate):

Not applicable.

## AI assistance

- [x] This contribution includes substantive AI assistance.
- [ ] This contribution does not include substantive AI assistance.

### AI tools and use

Claude Code (claude-opus-5) found the missing clone step while I asked why the
guide adds an upstream remote, and wrote the added lines. I reviewed and kept
the wording.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Modern Track Checklist (for new features):

- [ ] I have not imported `flux` in a new component
- [ ] If adding a new feature, I used Modern Track patterns
- [ ] New features do not create new SCSS files (use Tailwind instead)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified contribution setup instructions, including repository forking, cloning, and configuring remote repositories.
  * Documented that `origin` is used for pushing changes, while `upstream` is used for fetching updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->