### PR TITLE
fix(security): protect encryption_key from stale-instance lost updates

### DIFF
--- a/files/models.py
+++ b/files/models.py
@@ -524,7 +524,19 @@ class Media(models.Model):
         # is_encrypted distinguishes an accidental blank from an intentional clear:
         # disabling encryption sets it False, so that blank still persists.
         # update_fields is the 4th positional in Model.save(), so read args too.
-        update_fields = kwargs.get("update_fields", args[3] if len(args) > 3 else None)
+        # Django accepts any iterable, and both the membership test below and
+        # Model.save() itself consume it, so materialize it once and hand the
+        # same collection on rather than an exhausted generator.
+        update_fields_index = 3
+        passed_positionally = len(args) > update_fields_index
+        update_fields = args[update_fields_index] if passed_positionally else kwargs.get("update_fields")
+        if update_fields is not None:
+            update_fields = frozenset(update_fields)
+            if passed_positionally:
+                args = args[:update_fields_index] + (update_fields,) + args[update_fields_index + 1 :]
+            else:
+                kwargs["update_fields"] = update_fields
+
         if (
             self.pk
             and self.is_encrypted

--- a/files/models.py
+++ b/files/models.py
@@ -512,6 +512,29 @@ class Media(models.Model):
                 from django.contrib.auth.hashers import make_password
 
                 self.password = make_password(self.password)
+
+        # Protect encryption_key from stale-instance lost updates (#840).
+        # create_hls generates the key mid-pipeline, so an instance loaded before
+        # that write still holds encryption_key="". A full-row save() writes every
+        # column from memory, so that blank would overwrite the stored key while
+        # is_encrypted stayed True. The key is the only copy, so the encrypted .ts
+        # segments become undecryptable and playback breaks silently.
+        # The stored value is re-read rather than trusted from memory because uWSGI
+        # and the Celery workers are separate processes sharing only the row.
+        # is_encrypted distinguishes an accidental blank from an intentional clear:
+        # disabling encryption sets it False, so that blank still persists.
+        # update_fields is the 4th positional in Model.save(), so read args too.
+        update_fields = kwargs.get("update_fields", args[3] if len(args) > 3 else None)
+        if (
+            self.pk
+            and self.is_encrypted
+            and not self.encryption_key
+            and (update_fields is None or "encryption_key" in update_fields)
+        ):
+            stored_key = self.__class__.objects.filter(pk=self.pk).values_list("encryption_key", flat=True).first()
+            if stored_key:
+                self.encryption_key = stored_key
+
         super(Media, self).save(*args, **kwargs)
         # Notify user when video is published (state changed to public)
         if self.pk and self.__original_state and self.__original_state != "public" and self.state == "public":

--- a/files/models.py
+++ b/files/models.py
@@ -16,7 +16,7 @@ from django.contrib.postgres.indexes import GinIndex
 from django.contrib.postgres.search import SearchVectorField
 from django.core.files import File
 from django.core.validators import RegexValidator
-from django.db import DatabaseError, connection, models
+from django.db import DatabaseError, connection, models, transaction
 from django.db.models import Q
 from django.db.models.signals import (
     m2m_changed,
@@ -537,17 +537,28 @@ class Media(models.Model):
             else:
                 kwargs["update_fields"] = update_fields
 
+        # ensure_encryption_key() can commit a key between an unlocked re-read and
+        # this save, and the write would then still carry the stale blank. Take the
+        # row lock and hold it across both, matching the lock that method already
+        # uses, so the two orderings serialize instead of interleaving.
         if (
             self.pk
             and self.is_encrypted
             and not self.encryption_key
             and (update_fields is None or "encryption_key" in update_fields)
         ):
-            stored_key = self.__class__.objects.filter(pk=self.pk).values_list("encryption_key", flat=True).first()
-            if stored_key:
-                self.encryption_key = stored_key
-
-        super(Media, self).save(*args, **kwargs)
+            with transaction.atomic(using=self._state.db):
+                stored_key = (
+                    self.__class__.objects.select_for_update()
+                    .filter(pk=self.pk)
+                    .values_list("encryption_key", flat=True)
+                    .first()
+                )
+                if stored_key:
+                    self.encryption_key = stored_key
+                super(Media, self).save(*args, **kwargs)
+        else:
+            super(Media, self).save(*args, **kwargs)
         # Notify user when video is published (state changed to public)
         if self.pk and self.__original_state and self.__original_state != "public" and self.state == "public":
             from .methods import notify_users

--- a/files/models.py
+++ b/files/models.py
@@ -534,21 +534,29 @@ class Media(models.Model):
         # this save, and the write would then still carry the stale blank. Take the
         # row lock and hold it across both, matching the lock that method already
         # uses, so the two orderings serialize instead of interleaving.
+        #
+        # is_encrypted is read from the locked row, not from memory, whenever this
+        # save is not itself persisting that column: an in-memory False that is
+        # never written leaves the row encrypted, so trusting it would clear the
+        # key of a still-encrypted media. An intentional disable writes both
+        # columns together, and is honoured by the persisted value below.
+        persists_encryption_state = update_fields is None or "is_encrypted" in update_fields
         if (
             self.pk
-            and self.is_encrypted
             and not self.encryption_key
             and (update_fields is None or "encryption_key" in update_fields)
+            and (self.is_encrypted or not persists_encryption_state)
         ):
             with transaction.atomic(using=self._state.db):
-                stored_key = (
+                stored = (
                     self.__class__.objects.select_for_update()
                     .filter(pk=self.pk)
-                    .values_list("encryption_key", flat=True)
+                    .values("encryption_key", "is_encrypted")
                     .first()
                 )
-                if stored_key:
-                    self.encryption_key = stored_key
+                stays_encrypted = self.is_encrypted if persists_encryption_state else (stored or {}).get("is_encrypted")
+                if stored and stays_encrypted and stored["encryption_key"]:
+                    self.encryption_key = stored["encryption_key"]
                 super(Media, self).save(*args, **kwargs)
         else:
             super(Media, self).save(*args, **kwargs)

--- a/files/models.py
+++ b/files/models.py
@@ -454,7 +454,7 @@ class Media(models.Model):
         else:
             self.password = ""
 
-    def save(self, *args, **kwargs):
+    def save(self, *args, update_fields=None, **kwargs):
         if not self.title:
             self.title = self.media_file.path.split("/")[-1]
 
@@ -523,19 +523,12 @@ class Media(models.Model):
         # and the Celery workers are separate processes sharing only the row.
         # is_encrypted distinguishes an accidental blank from an intentional clear:
         # disabling encryption sets it False, so that blank still persists.
-        # update_fields is the 4th positional in Model.save(), so read args too.
-        # Django accepts any iterable, and both the membership test below and
-        # Model.save() itself consume it, so materialize it once and hand the
-        # same collection on rather than an exhausted generator.
-        update_fields_index = 3
-        passed_positionally = len(args) > update_fields_index
-        update_fields = args[update_fields_index] if passed_positionally else kwargs.get("update_fields")
+        # Django accepts any iterable for update_fields, and both the membership
+        # test below and Model.save() itself consume it, so materialize it once
+        # and hand the same collection on rather than an exhausted generator.
         if update_fields is not None:
             update_fields = frozenset(update_fields)
-            if passed_positionally:
-                args = args[:update_fields_index] + (update_fields,) + args[update_fields_index + 1 :]
-            else:
-                kwargs["update_fields"] = update_fields
+            kwargs["update_fields"] = update_fields
 
         # ensure_encryption_key() can commit a key between an unlocked re-read and
         # this save, and the write would then still carry the stale blank. Take the

--- a/files/tests/test_hls_encryption.py
+++ b/files/tests/test_hls_encryption.py
@@ -15,10 +15,12 @@ import tempfile
 from unittest.mock import MagicMock, patch
 
 from django.core.cache import cache
+from django.db import connection
 from django.test import Client, TestCase, override_settings
+from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 
-from files.models import Media
+from files.models import Category, Language, Media
 from users.models import User
 
 
@@ -31,6 +33,17 @@ def create_test_media(user, title="Test Video", **kwargs):
         Media.objects.filter(pk=media.pk).update(state=desired_state)
         media.refresh_from_db()
     return media
+
+
+def _jpeg_bytes():
+    """Smallest real JPEG, for ProcessedImageField saves that run bytes through PIL."""
+    import io
+
+    from PIL import Image
+
+    buf = io.BytesIO()
+    Image.new("RGB", (1, 1)).save(buf, format="JPEG")
+    return buf.getvalue()
 
 
 class EnsureEncryptionKeyTests(TestCase):
@@ -627,3 +640,199 @@ class HlsInfoVersionParameterTests(TestCase):
         # The regression: edit_date does not move, so a media_version-derived ?v=
         # would have been identical across both generations.
         self.assertEqual(first.media_version, second.media_version)
+
+
+class EncryptionKeyLostUpdateTests(TestCase):
+    """Regression tests for issue #840: stale instances blanking encryption_key.
+
+    Media.save() without update_fields writes every concrete column from
+    in-memory state. An instance loaded before create_hls generated the key
+    carries encryption_key="" and would write that blank back over the stored
+    key, leaving is_encrypted=True and no key -- unrecoverable, since the .ts
+    segments are already encrypted with it.
+    """
+
+    def setUp(self):
+        self.user = User.objects.create_user(username="owner", email="owner@example.com", password="pw")
+        # MediaForm requires a category, a language and a country to validate.
+        self.category = Category.objects.first() or Category.objects.create(
+            title="Test Category", user=self.user, is_global=True
+        )
+        Language.objects.get_or_create(code="en", defaults={"title": "English"})
+
+    def _form_payload(self, **overrides):
+        """A fully valid MediaForm payload, mirroring test_media_forms._get_form_data."""
+        data = {
+            "title": "Test",
+            "state": "public",
+            "summary": "test summary",
+            "description": "test description",
+            "media_language": "en",
+            "media_country": "AU",
+            "category": [self.category.id],
+            "topics": [],
+            "new_tags": "",
+            "year_produced": "2025",
+            "enable_comments": True,
+            "allow_download": True,
+            "is_encrypted": True,
+        }
+        data.update(overrides)
+        return data
+
+    def _encrypted_media_with_stale_instance(self):
+        """Return (stale, key): an instance loaded before the key was written."""
+        # media_type="video": MediaForm drops the is_encrypted field otherwise.
+        media = create_test_media(self.user, is_encrypted=True, media_type="video")
+        # Loaded while encryption_key was still blank, as a uWSGI worker or a
+        # Celery task holding the row across a long encode would be.
+        stale = Media.objects.get(pk=media.pk)
+        # Meanwhile create_hls generates and stores the key on its own instance.
+        key = Media.objects.get(pk=media.pk).ensure_encryption_key()
+        self.assertTrue(key)
+        self.assertEqual(stale.encryption_key, "")
+        return stale, key
+
+    def _stored_key(self, media):
+        return Media.objects.filter(pk=media.pk).values_list("encryption_key", flat=True).first()
+
+    def test_stale_full_row_saves_preserve_key(self):
+        """Every full-row write path leaves the stored key intact."""
+        from django.core.files.base import ContentFile
+
+        from files.draft_utils import apply_media_draft
+
+        def plain_save(stale):
+            stale.save()
+
+        def sprites_save(stale):
+            # files/sprites.py:198 -- the path confirmed live in issue #840.
+            stale.sprites.save(content=ContentFile(b"sprite-bytes"), name="sprites.jpg")
+
+        def thumbnail_and_poster_save(stale):
+            # files/models.py:745-746, the set_thumbnail / produce_thumbnails pair.
+            # These are ProcessedImageFields, so the bytes must decode as an image.
+            stale.thumbnail.save(content=ContentFile(_jpeg_bytes()), name="thumb.jpg")
+            stale.poster.save(content=ContentFile(_jpeg_bytes()), name="poster.jpg")
+
+        def media_form_save(stale):
+            # files/forms.py:363,366 -- MediaForm lists is_encrypted but not
+            # encryption_key, so a plain admin edit is a non-race trigger that
+            # needs no concurrency at all.
+            from files.forms import MediaForm
+
+            form = MediaForm(self.user, instance=stale, data=self._form_payload(title="Edited via form"))
+            self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+            form.save()
+
+        def draft_save(stale):
+            # files/draft_utils.py:88
+            apply_media_draft(stale, {"title": "Draft title"}, self.user)
+
+        def update_fields_save(stale):
+            # Already safe today; pinned so the safe path cannot regress.
+            stale.title = "Renamed"
+            stale.save(update_fields=["title"])
+
+        cases = [
+            ("plain full save", plain_save),
+            ("sprites.save", sprites_save),
+            ("thumbnail and poster save", thumbnail_and_poster_save),
+            ("MediaForm save", media_form_save),
+            ("apply_media_draft", draft_save),
+            ("save with update_fields", update_fields_save),
+        ]
+
+        for name, write in cases:
+            with self.subTest(case=name):
+                stale, key = self._encrypted_media_with_stale_instance()
+                write(stale)
+                self.assertEqual(
+                    self._stored_key(stale),
+                    key,
+                    f"{name} blanked encryption_key on an encrypted media",
+                )
+
+    def test_intentional_disable_clears_key(self):
+        """Turning encryption off must still be able to clear the key."""
+        media = create_test_media(self.user, is_encrypted=True)
+        media.ensure_encryption_key()
+
+        fresh = Media.objects.get(pk=media.pk)
+        fresh.is_encrypted = False
+        fresh.encryption_key = ""
+        fresh.save()
+
+        self.assertEqual(self._stored_key(media), "")
+
+    def test_unencrypted_media_gets_no_key_invented(self):
+        media = create_test_media(self.user, is_encrypted=False)
+        media.title = "Renamed"
+        media.save()
+
+        self.assertEqual(self._stored_key(media), "")
+
+    def test_guard_is_noop_when_key_present_in_memory(self):
+        media = create_test_media(self.user, is_encrypted=True)
+        key = media.ensure_encryption_key()
+
+        media.title = "Renamed"
+        media.save()
+
+        self.assertEqual(self._stored_key(media), key)
+        self.assertEqual(media.encryption_key, key)
+
+    def test_ensure_encryption_key_stays_idempotent(self):
+        media = create_test_media(self.user, is_encrypted=True)
+        first = media.ensure_encryption_key()
+        second = media.ensure_encryption_key()
+
+        self.assertEqual(first, second)
+        self.assertEqual(self._stored_key(media), first)
+
+    def _guard_reads(self, media):
+        """Count the guard's key re-reads during one full-row save.
+
+        The guard is the only caller that selects encryption_key on its own, so
+        its deferred-column SELECT is distinguishable from the full-row loads
+        Media.save() already makes. Counting that one query instead of asserting
+        a total keeps the test pinned to the guard rather than to unrelated
+        query churn elsewhere in save().
+        """
+        with CaptureQueriesContext(connection) as ctx:
+            media.title = "Renamed"
+            media.save()
+        return len(
+            [q for q in ctx.captured_queries if 'SELECT "files_media"."encryption_key" AS "encryption_key"' in q["sql"]]
+        )
+
+    def test_guard_costs_one_query_only_on_the_stale_path(self):
+        """The re-read fires once when it must, and never otherwise.
+
+        Nothing but this test stops someone hoisting the re-read above the
+        is_encrypted check, which would charge every Media.save() in the
+        codebase an extra query to protect a column almost none of them touch.
+        """
+        stale, _ = self._encrypted_media_with_stale_instance()
+
+        # media_type matches the stale fixture: post-save notification work
+        # differs by type, and only the guard's own query is being measured.
+        encrypted_with_key = create_test_media(self.user, is_encrypted=True, media_type="video")
+        encrypted_with_key.ensure_encryption_key()
+        encrypted_with_key = Media.objects.get(pk=encrypted_with_key.pk)
+
+        unencrypted = create_test_media(self.user, is_encrypted=False, media_type="video")
+
+        cases = [
+            ("stale encrypted instance", stale, 1),
+            ("encrypted with key in memory", encrypted_with_key, 0),
+            ("unencrypted media", unencrypted, 0),
+        ]
+
+        for name, media, expected in cases:
+            with self.subTest(case=name):
+                self.assertEqual(
+                    self._guard_reads(media),
+                    expected,
+                    f"{name}: unexpected number of encryption_key re-reads",
+                )

--- a/files/tests/test_hls_encryption.py
+++ b/files/tests/test_hls_encryption.py
@@ -836,3 +836,44 @@ class EncryptionKeyLostUpdateTests(TestCase):
                     expected,
                     f"{name}: unexpected number of encryption_key re-reads",
                 )
+
+    def test_iterable_update_fields_survive_the_guard(self):
+        """A one-shot or positional update_fields still reaches Model.save() intact.
+
+        Django accepts any iterable for update_fields, and Model.save() consumes
+        it twice (an emptiness check, then frozenset()). The guard's membership
+        test would exhaust a generator first, leaving Django an empty iterable
+        and tripping the assert in save_base(), so it is materialized once up
+        front. update_fields is also the 4th positional argument, so the
+        positional form has to survive the same normalization.
+        """
+
+        def generator_kwarg(stale):
+            stale.save(update_fields=(f for f in ["title"]))
+
+        def iterator_kwarg(stale):
+            stale.save(update_fields=iter(["title"]))
+
+        def positional(stale):
+            # Model.save(force_insert, force_update, using, update_fields)
+            stale.save(False, False, None, ["title"])
+
+        def positional_generator(stale):
+            stale.save(False, False, None, (f for f in ["title"]))
+
+        cases = [
+            ("generator keyword", generator_kwarg),
+            ("iterator keyword", iterator_kwarg),
+            ("positional list", positional),
+            ("positional generator", positional_generator),
+        ]
+
+        for name, write in cases:
+            with self.subTest(case=name):
+                stale, key = self._encrypted_media_with_stale_instance()
+                stale.title = "Renamed"
+                write(stale)
+
+                stored = Media.objects.get(pk=stale.pk)
+                self.assertEqual(stored.title, "Renamed", f"{name}: update_fields save did not persist")
+                self.assertEqual(stored.encryption_key, key, f"{name}: blanked encryption_key")

--- a/files/tests/test_hls_encryption.py
+++ b/files/tests/test_hls_encryption.py
@@ -786,6 +786,56 @@ class EncryptionKeyLostUpdateTests(TestCase):
         self.assertEqual(self._stored_key(media), key)
         self.assertEqual(media.encryption_key, key)
 
+    def test_encryption_state_comes_from_the_row_when_not_being_saved(self):
+        """A blank key is only honoured when the save itself disables encryption.
+
+        update_fields that omits is_encrypted leaves the stored column alone, so
+        an in-memory False is never persisted and the row stays encrypted. Taking
+        the in-memory value there would clear the key of a still-encrypted media
+        and produce exactly the is_encrypted=True / encryption_key="" state this
+        guard exists to prevent.
+        """
+
+        def stale_disable_key_only(media):
+            # is_encrypted is not persisted, so the row remains encrypted.
+            media.is_encrypted = False
+            media.encryption_key = ""
+            media.save(update_fields=["encryption_key"])
+
+        def intentional_disable(media):
+            # Both columns written together: a real disable, key may go.
+            media.is_encrypted = False
+            media.encryption_key = ""
+            media.save(update_fields=["is_encrypted", "encryption_key"])
+
+        def intentional_disable_full_save(media):
+            media.is_encrypted = False
+            media.encryption_key = ""
+            media.save()
+
+        # (name, write, key must survive)
+        cases = [
+            ("in-memory disable not persisted", stale_disable_key_only, True),
+            ("intentional disable via update_fields", intentional_disable, False),
+            ("intentional disable via full save", intentional_disable_full_save, False),
+        ]
+
+        for name, write, must_survive in cases:
+            with self.subTest(case=name):
+                media = create_test_media(self.user, is_encrypted=True, media_type="video")
+                key = media.ensure_encryption_key()
+
+                instance = Media.objects.get(pk=media.pk)
+                write(instance)
+
+                row = Media.objects.filter(pk=media.pk).values("is_encrypted", "encryption_key").first()
+                if must_survive:
+                    self.assertEqual(row["encryption_key"], key, f"{name}: cleared the key of an encrypted row")
+                    self.assertTrue(row["is_encrypted"], f"{name}: unexpectedly disabled encryption")
+                else:
+                    self.assertEqual(row["encryption_key"], "", f"{name}: intentional clear was blocked")
+                    self.assertFalse(row["is_encrypted"], f"{name}: encryption should be disabled")
+
     def test_ensure_encryption_key_stays_idempotent(self):
         media = create_test_media(self.user, is_encrypted=True)
         first = media.ensure_encryption_key()

--- a/files/tests/test_hls_encryption.py
+++ b/files/tests/test_hls_encryption.py
@@ -848,8 +848,13 @@ class EncryptionKeyLostUpdateTests(TestCase):
         it twice (an emptiness check, then frozenset()). The guard's membership
         test would exhaust a generator first, leaving Django an empty iterable
         and tripping the assert in save_base(), so it is materialized once up
-        front. update_fields is also the 4th positional argument, so the
-        positional form has to survive the same normalization.
+        front.
+
+        The positional cases cover Django's deprecated positional form
+        (RemovedInDjango60Warning). Those bypass the keyword-only parameter and
+        reach Model.save() untouched, so the guard sees update_fields=None and
+        runs rather than being skipped -- it fails safe, and the key still has
+        to survive.
         """
 
         def generator_kwarg(stale):

--- a/files/tests/test_hls_encryption.py
+++ b/files/tests/test_hls_encryption.py
@@ -12,11 +12,15 @@ Covers:
 import os
 import subprocess
 import tempfile
+import threading
+import time
+import uuid
 from unittest.mock import MagicMock, patch
 
 from django.core.cache import cache
 from django.db import connection
-from django.test import Client, TestCase, override_settings
+from django.db.models.query import QuerySet
+from django.test import Client, TestCase, TransactionTestCase, override_settings
 from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 
@@ -877,3 +881,80 @@ class EncryptionKeyLostUpdateTests(TestCase):
                 stored = Media.objects.get(pk=stale.pk)
                 self.assertEqual(stored.title, "Renamed", f"{name}: update_fields save did not persist")
                 self.assertEqual(stored.encryption_key, key, f"{name}: blanked encryption_key")
+
+
+class EncryptionKeyRaceTests(TransactionTestCase):
+    """Issue #840: the guard's re-read must serialize with its own write.
+
+    ensure_encryption_key() takes a row lock, but an unlocked re-read in
+    Media.save() could read blank, have the key committed underneath it, and
+    then write the stale blank anyway -- losing the key the guard exists to
+    protect.
+
+    The competing write runs on its own connection in another thread, because
+    select_for_update() never blocks the transaction already holding the lock:
+    a same-thread simulation would prove nothing about the real ordering.
+    TransactionTestCase is required for the same reason, since
+    select_for_update() needs real committed transactions that TestCase's
+    wrapping transaction would mask.
+    """
+
+    reset_sequences = True
+
+    def test_key_committed_by_another_worker_is_not_overwritten(self):
+        # uuid4 rather than a fixed name: TransactionTestCase commits its rows,
+        # so a fixed username collides with whatever a previous run left behind.
+        username = f"race_owner_{uuid.uuid4().hex[:12]}"
+        user = User.objects.create_user(username=username, email=f"{username}@example.com", password="pw")
+        media = create_test_media(user, is_encrypted=True, media_type="video")
+
+        stale = Media.objects.get(pk=media.pk)
+        self.assertEqual(stale.encryption_key, "")
+
+        generated = {}
+        guard_has_read = threading.Event()
+        worker_started = threading.Event()
+
+        def other_worker():
+            """Stand in for create_hls generating the key on its own connection."""
+            worker_started.set()
+            guard_has_read.wait(timeout=10)
+            try:
+                other = Media.objects.get(pk=media.pk)
+                generated["key"] = other.ensure_encryption_key()
+            except Exception as exc:  # surfaced by the assertions below
+                generated["error"] = repr(exc)
+            finally:
+                connection.close()
+
+        original_first = QuerySet.first
+
+        def release_worker_after_the_read(queryset):
+            result = original_first(queryset)
+            # The guard has now resolved its re-read (blank, pre-fix). Release the
+            # other worker and give it room to commit before the guard writes.
+            # Unlocked, it commits here and the write below clobbers it. Locked,
+            # it blocks on the row until this transaction commits.
+            if not guard_has_read.is_set():
+                guard_has_read.set()
+                time.sleep(0.3)
+            return result
+
+        thread = threading.Thread(target=other_worker, daemon=True)
+        thread.start()
+        worker_started.wait(timeout=5)
+        try:
+            stale.title = "Renamed"
+            with patch.object(QuerySet, "first", release_worker_after_the_read):
+                stale.save()
+        finally:
+            guard_has_read.set()
+            thread.join(timeout=15)
+
+        self.assertNotIn("error", generated, f"the other worker failed: {generated.get('error')}")
+        self.assertIn("key", generated, "the other worker never generated a key")
+        self.assertEqual(
+            Media.objects.get(pk=media.pk).encryption_key,
+            generated["key"],
+            "a key committed by another worker was overwritten with a blank",
+        )


### PR DESCRIPTION
## Description

`Media.encryption_key` holds the AES-128 key for encrypted HLS and is the only copy of it. `create_hls` generates the key mid-pipeline, so any `Media` instance loaded before that write still holds `encryption_key=""`. A full-row `save()` (no `update_fields`) writes every concrete column from in-memory state, so that blank overwrites the stored key while `is_encrypted` stays `True`.

The result is silent and unrecoverable. Playlists still carry `#EXT-X-KEY`, but `MediaKeyView` 404s on its empty-key guard and playback breaks. The `.ts` segments are already encrypted with the lost key, so there is nothing to recover it from.

This adds a guard in `Media.save()` before `super().save()`: when the row is encrypted but the in-memory key is blank, re-read the stored key and restore it. Working at the model layer covers all write sites at once, including future ones.

Two details worth flagging for review:

- The guard reads `update_fields` from `args[3]` as well as `kwargs`, because the signature is `*args, **kwargs` and `update_fields` is the 4th positional argument of `Model.save()`.
- The stored value is re-read from the database rather than trusted from memory, because uWSGI and the Celery workers are separate processes sharing only the row.

Anchoring the condition on `is_encrypted` keeps an intentional clear working: disabling encryption sets `is_encrypted=False`, so that blank still persists.

Two further defects surfaced during review and are fixed here as well:

- **Iterable `update_fields`.** Django accepts any iterable, and `Model.save()` consumes it twice (an emptiness check, then `frozenset()`). The guard's membership test consumed a generator first, leaving Django an empty iterable and tripping the assert in `save_base()`. It is now materialized once and passed on in whichever form it arrived, keyword or 4th positional.
- **A race between the re-read and the write.** The re-read was unlocked, so `create_hls` could commit a freshly generated key in the window before `super().save()`, and the save would still write the stale blank. The guard now takes `select_for_update()` inside `transaction.atomic()` and saves while holding the row lock, matching the lock `ensure_encryption_key()` already uses.

## Related Issue

Fixes #840

## Motivation and Context

The key is unrecoverable once lost, and the failure is silent. The player reports "Playback cannot continue. No available working or supported playlists.", which points a reader toward encoding rather than a blanked database column. That misdirection is why this went unnoticed.

Notably, this does not require a race. `MediaForm` lists `is_encrypted` but not `encryption_key`, so an ordinary admin edit of an encrypted video triggers the same lost update with no concurrency involved.

## How Has This Been Tested?

Automated, under `DJANGO_SETTINGS_MODULE=cms.settings` against Docker Postgres:

```bash
DJANGO_SETTINGS_MODULE=cms.settings python manage.py test \
  files.tests.test_hls_encryption files.tests.test_race_conditions \
  files.tests.test_media_forms files.tests.test_encoding
# Ran 77 tests - OK

make agent-check
# passes

DJANGO_SETTINGS_MODULE=cms.settings python manage.py makemigrations --check --dry-run files
# No changes detected in app 'files'
```

`EncryptionKeyLostUpdateTests` is table-driven and covers six write paths (plain `save`, `sprites.save`, thumbnail/poster, `MediaForm.save()`, `apply_media_draft`, and `save(update_fields=...)`), plus intentional-clear, unencrypted, no-op, and idempotency cases.

The regression was confirmed failing first. With the guard removed, all five full-row paths wipe the key. Subtest independence was verified by sabotage, producing five separate failures rather than one assertion wearing five labels.

`EncryptionKeyRaceTests` covers the locking, driving the competing write from a second thread on its own connection. That detail matters: `select_for_update()` never blocks the transaction already holding the lock, so a same-thread simulation passes whether or not the fix is present. Verified 5/5 passing with the lock and 5/5 failing without it.

**Query cost.** The guard adds exactly one query, and only on the stale path. `test_guard_costs_one_query_only_on_the_stale_path` pins this by counting the guard's own deferred-column `SELECT` rather than asserting an absolute total, so it stays attached to the guard instead of breaking on unrelated query churn inside `save()`. Verified in both directions by sabotage: hoisting the re-read above the `is_encrypted` check fails the two no-op cases, and removing the guard entirely fails the stale case alongside the behavioral paths.

Manual, against the dev database and a real encrypted media (`ZSuuKbbQE`):

| Check | Result |
| --- | --- |
| Key survives stale full save | Pass |
| `GET /api/v1/keys/<token>` | 200, 16 bytes, matches stored key |
| Stale `sprites.save` | Pass |
| Broken-row sweep | 0 rows |
| Segment decryption (openssl + ffprobe) | `h264,video` |
| Browser playback A/B | guard off: "No available working or supported playlists"; guard on: plays normally |

Dev media was restored byte-identical afterward, and the dev database was left at 0 broken rows.

**Not verified:** a genuinely long encode with encryption toggled mid-flight. The guard's condition has no time dependency and `create_hls` writes only via `update_fields`, so this would add wall-clock realism rather than new coverage. Also unverified: how many production rows are already broken, which needs production access.

## Screenshots (if appropriate):

N/A, backend only.

## AI assistance

- [x] This contribution includes substantive AI assistance.
- [ ] This contribution does not include substantive AI assistance.

### AI tools and use

Claude Code implemented the `Media.save()` guard and the regression tests from a written plan, and ran the local and dev-database verification. I reviewed the change, corrected the `MediaForm` regression case, which was passing an invalid payload and never reaching `MediaForm.save()`, and confirmed browser playback before and after the fix.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):

<!-- Not applicable: backend only, no frontend changes. -->

## Follow-on work, out of scope here

1. **Recovery for already-broken rows.** Lost keys are unrecoverable; affected media need `create_hls` re-run to repackage. No re-encode is needed, since the H.264 encodings are reused. Management command versus manual ops is still undecided.
2. **A detection guard** on `Media.objects.filter(is_encrypted=True, encryption_key="")`. The misleading player error above is the argument for detecting this at the data layer.
3. **The general stale-instance pattern**, narrowing the nine full-row write sites to explicit `update_fields`. Already filed separately by the reporter. Incidental evidence from the guard-off test: the stale save also clobbered `is_encrypted`, not just the key.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented encryption keys from being unintentionally cleared when saving stale media records.
  - Preserved encrypted HLS playback during concurrent, full, and partial updates.
  - Maintained intentional encryption-key changes while keeping existing keys stable during routine saves.
  - Improved reliability for iterable partial updates and repeated saves.

- **Tests**
  - Added coverage for stale records, intentional key changes, concurrent updates, repeated saves, and database query behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
