### PR TITLE
fix(profile): keep Similar Profiles cards inside their track (#850)

### DIFF
--- a/frontend/src/features/profile/components/SimilarProfiles.jsx
+++ b/frontend/src/features/profile/components/SimilarProfiles.jsx
@@ -25,7 +25,7 @@ export function SimilarProfiles({ author }) {
 				as="h2"
 				id="similar-profiles-heading"
 			/>
-			<div className="mt-4 grid grid-cols-1 gap-5 sm:ml-[57px] sm:grid-cols-2 xl:grid-cols-4">
+			<div className="mt-4 grid grid-cols-1 gap-5 sm:ml-[57px] sm:grid-cols-2 lg:grid-cols-3 xl:ml-0 xl:grid-cols-4">
 				{isLoading
 					? Array.from({ length: 4 }, (_, index) => (
 							<div
@@ -42,7 +42,7 @@ export function SimilarProfiles({ author }) {
 								<Card
 									key={profile.username}
 									variant="outlined"
-									className="flex min-h-[310px] flex-col items-center gap-4 bg-bg-surface-raised p-6 text-center"
+									className="flex min-h-[310px] min-w-0 flex-col items-center gap-4 bg-bg-surface-raised p-6 text-center"
 								>
 									<Avatar
 										name={name}
@@ -50,12 +50,16 @@ export function SimilarProfiles({ author }) {
 										alt={`${name}'s profile photo`}
 										style={{ width: 80, height: 80 }}
 									/>
-									<div className="min-w-0">
-										<Text as="h3" variant="h5-bold" className="m-0 text-text-primary">
+									<div className="w-full min-w-0">
+										<Text as="h3" variant="h5-bold" className="m-0 break-words text-text-primary">
 											{name}
 										</Text>
 										<div className="mt-1 flex items-center justify-center gap-1">
-											<Text as="span" variant="body-16-medium" className="text-text-accent">
+											<Text
+												as="span"
+												variant="body-16-medium"
+												className="min-w-0 break-all text-text-accent"
+											>
 												@{profile.username}
 											</Text>
 											{profile.is_trusted ? (
@@ -80,11 +84,11 @@ export function SimilarProfiles({ author }) {
 												{profile.location}
 											</Text>
 										) : null}
-										<div className="flex items-center gap-4">
+										<div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-1">
 											<Text
 												as="p"
 												variant="body-14"
-												className="m-0 inline-flex items-center gap-2 text-text-secondary"
+												className="m-0 inline-flex items-center gap-2 whitespace-nowrap text-text-secondary"
 											>
 												<Icon name="profileVideoCount" size="xs" decorative />
 												{mediaCount.toLocaleString()} {mediaCount === 1 ? 'video' : 'videos'}
@@ -93,7 +97,7 @@ export function SimilarProfiles({ author }) {
 												<Text
 													as="p"
 													variant="body-14"
-													className="m-0 inline-flex items-center gap-2 text-text-secondary"
+													className="m-0 inline-flex items-center gap-2 whitespace-nowrap text-text-secondary"
 												>
 													<Icon name="profileMemberSince" size="xs" decorative />
 													{joinedLabel}

--- a/frontend/src/features/profile/components/SimilarProfiles.test.jsx
+++ b/frontend/src/features/profile/components/SimilarProfiles.test.jsx
@@ -1,11 +1,39 @@
 import { render } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useSimilarProfiles } from '../hooks/useSimilarProfiles';
 import { SimilarProfiles } from './SimilarProfiles';
 
 vi.mock('../hooks/useSimilarProfiles', () => ({
 	useSimilarProfiles: vi.fn(),
 }));
+
+// UserRoleBadge reads window.matchMedia, which jsdom does not implement.
+const originalMatchMedia = window.matchMedia;
+
+beforeAll(() => {
+	Object.defineProperty(window, 'matchMedia', {
+		configurable: true,
+		writable: true,
+		value: vi.fn().mockImplementation((query) => ({
+			matches: false,
+			media: query,
+			onchange: null,
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
+			addListener: vi.fn(),
+			removeListener: vi.fn(),
+			dispatchEvent: vi.fn(),
+		})),
+	});
+});
+
+afterAll(() => {
+	Object.defineProperty(window, 'matchMedia', {
+		configurable: true,
+		writable: true,
+		value: originalMatchMedia,
+	});
+});
 
 describe('SimilarProfiles', () => {
 	beforeEach(() => {
@@ -43,5 +71,77 @@ describe('SimilarProfiles', () => {
 		);
 
 		expect(useSimilarProfiles).toHaveBeenCalledWith('jen', 'Philippines');
+	});
+
+	describe('narrow-column reflow guards', () => {
+		// jsdom does not lay out, so these assert the classes that carry the
+		// reflow behaviour rather than the rendered geometry. The visual proof
+		// is the manual screenshot pass recorded on the pull request.
+		const profile = {
+			username: 'ana',
+			name: 'Ana Reyes',
+			media_count: 489,
+			date_added: '2019-04-01T00:00:00Z',
+			is_trusted: false,
+			is_manager: false,
+		};
+
+		function renderProfiles(profiles) {
+			useSimilarProfiles.mockReturnValue({
+				data: { results: profiles },
+				isLoading: false,
+				isError: false,
+			});
+			return render(<SimilarProfiles author={{ username: 'jen', location_country: 'PH' }} />);
+		}
+
+		it('lets the stats row wrap so its two chunks stack instead of wrapping mid-chunk', () => {
+			const { container } = renderProfiles([profile]);
+
+			const statsRow = container.querySelector('.flex-wrap');
+			expect(statsRow).not.toBeNull();
+
+			const chunks = statsRow.querySelectorAll('.whitespace-nowrap');
+			expect(chunks).toHaveLength(2);
+		});
+
+		it('lets each card shrink to its grid track', () => {
+			const { container } = renderProfiles([profile]);
+
+			const card = container.querySelector('article');
+			expect(card.className).toContain('min-w-0');
+		});
+
+		it('keeps a long username inside its card', () => {
+			const longUsername = 'a'.repeat(40);
+			const { getByText } = renderProfiles([{ ...profile, username: longUsername }]);
+
+			// break-words only breaks between words, so it cannot split a single
+			// unbroken 40-character token. break-all is what keeps it in the card.
+			const username = getByText(`@${longUsername}`);
+			expect(username.className).toContain('break-all');
+			expect(username.className).toContain('min-w-0');
+		});
+
+		it('renders one card per similar profile', () => {
+			const { container } = renderProfiles(
+				Array.from({ length: 4 }, (_, index) => ({ ...profile, username: `member${index}` }))
+			);
+
+			expect(container.querySelectorAll('article')).toHaveLength(4);
+		});
+
+		it('renders nothing when there are no similar profiles', () => {
+			const { container } = renderProfiles([]);
+
+			expect(container).toBeEmptyDOMElement();
+		});
+
+		it('still renders four columns at the xl breakpoint', () => {
+			const { container } = renderProfiles([profile]);
+
+			const grid = container.querySelector('.grid');
+			expect(grid.className).toContain('xl:grid-cols-4');
+		});
 	});
 });


### PR DESCRIPTION
## Description

The Similar Profiles cards lost their layout at narrow column widths. The stats
row could not fit the video count and the joined date on one line, so each chunk
wrapped its own text.

Changes in `SimilarProfiles.jsx`:

- **Stats row** wraps, and each chunk carries `whitespace-nowrap`, so the video
  count and joined date **stack** instead of wrapping mid-chunk.
- **`<Card>`** gets `min-w-0`, since CSS grid items default to `min-width: auto`.
- **Name and `@username`** get overflow guards, and the wrapper gets `w-full`.
- **Grid** gains a `lg:grid-cols-3` step and reclaims the `57px` indent at `xl:`.

### One correction to the issue's proposed fix

The report proposed `break-words` for the username. That is not sufficient:
`overflow-wrap: break-word` only breaks *between* words, so it cannot split a
single unbroken 40-character token, which is exactly the case the issue's own
test table specifies. A long username still escaped the card at every width.
`break-all` is what keeps it in bounds.

Two related gaps the report did not name:

- The display name `<h3>` had no guard at all, and overflowed for a long name.
- The `min-w-0` wrapper is a flex child, so it also needed `w-full`.

These were only visible in the browser. The unit tests passed while the cards
were still visibly broken, which is what the issue predicted.

## Related Issue

Fixes #850

## Motivation and Context

At the four-column layout each track is ~200px. The stats row had no
`flex-wrap`, so its two `inline-flex` children were forced onto one line and
each wrapped its own text instead of the two stacking.

### Decisions on the two items the issue left open

The issue required both be decided rather than left as "optional".

**`lg:grid-cols-3` — adopted.** The layout jumped from two wide columns straight
to four narrow ones at 1280px. The `lg:` step removes that cliff and yields
~250px tracks at 1024px instead of the old 200px squeeze.

**`xl:ml-0` — adopted.** `sm:ml-[57px]` aligns the grid with the section
header's icon offset, but at `xl:` it is subtracted from the *narrowest* tracks,
precisely where the break occurs.

Neither changes the column count at `xl:`. This is a reflow fix, not a redesign.

## How Has This Been Tested?

Automated:

- `cd frontend && npm run test:run` — 614 passed, 111 files.
- `npm run lint:modern` — 0 errors (11 pre-existing warnings, none in these files).
- `make agent-check` — passed.

The three new behavioural tests were confirmed to fail against the pre-fix
component and pass after, so they are real regression guards rather than
assertions that merely restate the code.

Manual, on the About tab of a member profile with four similar profiles, one
with a 40-character username and a four-digit video count:

Rather than relying on reading images alone, I measured per-element overflow
against each card's bounding box across **81 widths from 320px to 1920px**:

| | Before | After |
| --- | --- | --- |
| Widths with overflow | **74 / 81** | **0 / 81** |
| Worst overflow | **118.3px** | **0px** |
| Horizontal document scroll | — | none |

Column progression after the change: 1 column (320-620), 2 (640-1020),
3 (1040-1260), 4 (1280-1920). Four columns at `xl:` preserved.

Environment: revamp variant (`cms/user_revamp.html`), Chrome 152, macOS,
Vite dev server.

## Screenshots (if appropriate):

### Before
<img width="279" height="1610" alt="before-375" src="https://github.com/user-attachments/assets/47994504-c774-4e24-ab92-1b62ccd9fbd5" />
<img width="624" height="858" alt="before-768" src="https://github.com/user-attachments/assets/f787fba9-3530-425d-9aa6-abf4fe884f04" />
<img width="640" height="858" alt="before-1024" src="https://github.com/user-attachments/assets/9ea92f71-2164-4a21-a76b-e5a4f5f37971" />
<img width="896" height="511" alt="before-1280" src="https://github.com/user-attachments/assets/661720c9-a2d5-436f-b538-b87f3f53e2a1" />

### After
<img width="279" height="1680" alt="after-375" src="https://github.com/user-attachments/assets/f6747801-aa79-4e5b-85ed-213c830774c0" />
<img width="624" height="890" alt="after-768" src="https://github.com/user-attachments/assets/0ca6d1c4-aa3a-417e-b391-37df8d53b5ff" />
<img width="640" height="1050" alt="after-1024" src="https://github.com/user-attachments/assets/d5c23db1-d95b-42ed-86f4-b5d1e6bd75da" />
<img width="896" height="573" alt="after-1280" src="https://github.com/user-attachments/assets/266bbe7e-a2f3-4c7a-8826-0eb681c8cf5c" />


## AI assistance

- [x] This contribution includes substantive AI assistance.
- [ ] This contribution does not include substantive AI assistance.

### AI tools and use

Claude Code (claude-opus-5) implemented the component and test changes from the
issue's acceptance criteria, drove the browser to capture the before/after
screenshots, and ran the overflow measurement sweep. It identified that the
issue's proposed `break-words` guard was insufficient for an unbroken token and
substituted `break-all`, and found the two unguarded elements the report did not
name. I reviewed every changed line and the resulting screenshots.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):

- [x] I have not imported `flux` in a new component
- [x] If adding a new feature, I used Modern Track patterns
- [x] New features do not create new SCSS files (use Tailwind instead)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved similar-profile cards for responsive layouts and long profile names or usernames.
  - Metadata now wraps cleanly while preserving individual values.
  - Updated grid behavior for larger screen sizes.
- **Tests**
  - Added coverage for narrow-column reflow, long usernames, empty results, and one-card-per-profile rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->