### PR TITLE
fix: deploy dev through authorized restart script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,10 +311,11 @@ jobs:
       - name: Deploy via SSH
         run: |
           ssh ${{ secrets.DEPLOY_DEV_USER }}@${{ secrets.DEPLOY_DEV_HOST }} \
-            'previous_sha=$(sudo git -C /home/cinemata/cinematacms rev-parse HEAD) &&
-             sudo git -C /home/cinemata/cinematacms fetch origin ${{ github.sha }} &&
-             sudo git -C /home/cinemata/cinematacms merge --ff-only ${{ github.sha }} &&
-             sudo env CINEMATA_PREV_SHA="$previous_sha" /home/cinemata/cinematacms/restart_script.sh --no-pull'
+            'if grep -q -- "--revision" /home/cinemata/cinematacms/restart_script.sh; then
+               sudo /home/cinemata/cinematacms/restart_script.sh --revision ${{ github.sha }};
+             else
+               sudo /home/cinemata/cinematacms/restart_script.sh;
+             fi'
 
       - name: Set deployment success
         if: success()

--- a/restart_script.sh
+++ b/restart_script.sh
@@ -5,12 +5,26 @@ set -e
 # Run as root
 
 PULL_LATEST=true
-if [ "${1:-}" = "--no-pull" ]; then
-  PULL_LATEST=false
-elif [ "$#" -gt 0 ]; then
-  echo "Usage: $0 [--no-pull]" >&2
-  exit 2
-fi
+DEPLOY_REVISION=""
+case "${1:-}" in
+  --no-pull)
+    PULL_LATEST=false
+    ;;
+  --revision)
+    if [[ "${2:-}" =~ ^[0-9a-f]{40}$ ]] && [ "$#" -eq 2 ]; then
+      DEPLOY_REVISION="$2"
+    else
+      echo "--revision requires a full 40-character lowercase commit SHA" >&2
+      exit 2
+    fi
+    ;;
+  "")
+    ;;
+  *)
+    echo "Usage: $0 [--no-pull | --revision COMMIT_SHA]" >&2
+    exit 2
+    ;;
+esac
 
 if [ `id -u` -ne 0 ]
   then echo "Please run as root"
@@ -34,7 +48,11 @@ mkdir -p "$(dirname "$DEPLOY_LOG")"
 PREV_SHA="${CINEMATA_PREV_SHA:-$(git rev-parse HEAD)}"
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
-if [ "$PULL_LATEST" = true ]; then
+if [ -n "$DEPLOY_REVISION" ]; then
+  echo "Deploying requested commit $DEPLOY_REVISION..."
+  git fetch origin "$DEPLOY_REVISION"
+  git merge --ff-only "$DEPLOY_REVISION"
+elif [ "$PULL_LATEST" = true ]; then
   echo "Pulling latest changes from git repository..."
   git pull --ff-only
 fi

--- a/restart_script.sh
+++ b/restart_script.sh
@@ -4,27 +4,47 @@ set -e
 # Cinemata restart script after code changes
 # Run as root
 
-PULL_LATEST=true
-DEPLOY_REVISION=""
-case "${1:-}" in
-  --no-pull)
-    PULL_LATEST=false
-    ;;
-  --revision)
-    if [[ "${2:-}" =~ ^[0-9a-f]{40}$ ]] && [ "$#" -eq 2 ]; then
-      DEPLOY_REVISION="$2"
-    else
-      echo "--revision requires a full 40-character lowercase commit SHA" >&2
-      exit 2
-    fi
-    ;;
-  "")
-    ;;
-  *)
-    echo "Usage: $0 [--no-pull | --revision COMMIT_SHA]" >&2
-    exit 2
-    ;;
-esac
+parse_restart_args() {
+  PULL_LATEST=true
+  DEPLOY_REVISION=""
+  case "${1:-}" in
+    --no-pull)
+      if [ "$#" -ne 1 ]; then
+        echo "Usage: $0 [--no-pull | --revision COMMIT_SHA]" >&2
+        return 2
+      fi
+      PULL_LATEST=false
+      ;;
+    --revision)
+      if [[ "${2:-}" =~ ^[0-9a-f]{40}$ ]] && [ "$#" -eq 2 ]; then
+        DEPLOY_REVISION="$2"
+      else
+        echo "--revision requires a full 40-character lowercase commit SHA" >&2
+        return 2
+      fi
+      ;;
+    "")
+      ;;
+    *)
+      echo "Usage: $0 [--no-pull | --revision COMMIT_SHA]" >&2
+      return 2
+      ;;
+  esac
+}
+
+select_release() {
+  if [ -n "$DEPLOY_REVISION" ]; then
+    echo "Deploying requested commit $DEPLOY_REVISION..."
+    git fetch origin "$DEPLOY_REVISION"
+    git merge --ff-only "$DEPLOY_REVISION"
+  elif [ "$PULL_LATEST" = true ]; then
+    echo "Pulling latest changes from git repository..."
+    git pull --ff-only
+  fi
+}
+
+main() {
+parse_restart_args "$@"
 
 if [ `id -u` -ne 0 ]
   then echo "Please run as root"
@@ -48,14 +68,7 @@ mkdir -p "$(dirname "$DEPLOY_LOG")"
 PREV_SHA="${CINEMATA_PREV_SHA:-$(git rev-parse HEAD)}"
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
-if [ -n "$DEPLOY_REVISION" ]; then
-  echo "Deploying requested commit $DEPLOY_REVISION..."
-  git fetch origin "$DEPLOY_REVISION"
-  git merge --ff-only "$DEPLOY_REVISION"
-elif [ "$PULL_LATEST" = true ]; then
-  echo "Pulling latest changes from git repository..."
-  git pull --ff-only
-fi
+select_release
 
 # Append a deploy-log entry only when the pull actually advanced HEAD.
 NEW_SHA=$(git rev-parse HEAD)
@@ -109,3 +122,8 @@ systemctl restart mediacms celery_long celery_short celery_whisper celery_email 
 systemctl restart nginx
 
 echo "Cinemata restart completed successfully!"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/tests/test_deploy_scripts.py
+++ b/tests/test_deploy_scripts.py
@@ -1038,15 +1038,21 @@ class RestartScriptTests(unittest.TestCase):
         self.assertIn(f"systemctl enable {units}", script)
         self.assertIn(f"systemctl restart {units}", script)
 
-    def test_deployer_bootstraps_runtime_config_before_running_restart_script(self):
-        workflow = CI_WORKFLOW.read_text()
-        fetch = "sudo git -C /home/cinemata/cinematacms fetch origin ${{ github.sha }}"
-        merge = "sudo git -C /home/cinemata/cinematacms merge --ff-only ${{ github.sha }}"
-        restart = "/home/cinemata/cinematacms/restart_script.sh --no-pull"
+    def test_restart_can_deploy_an_exact_revision(self):
+        script = RESTART_SCRIPT.read_text()
 
-        self.assertLess(workflow.index(fetch), workflow.index(merge))
-        self.assertLess(workflow.index(merge), workflow.index(restart))
-        self.assertIn('CINEMATA_PREV_SHA="$previous_sha"', workflow)
+        self.assertIn("--revision requires a full 40-character lowercase commit SHA", script)
+        self.assertIn('git fetch origin "$DEPLOY_REVISION"', script)
+        self.assertIn('git merge --ff-only "$DEPLOY_REVISION"', script)
+
+    def test_deployer_uses_the_authorized_restart_boundary(self):
+        workflow = CI_WORKFLOW.read_text()
+        restart = "sudo /home/cinemata/cinematacms/restart_script.sh"
+
+        self.assertEqual(workflow.count(restart), 2)
+        self.assertIn(f"{restart} --revision ${{{{ github.sha }}}}", workflow)
+        self.assertNotIn("sudo git", workflow)
+        self.assertNotIn("sudo env", workflow)
         self.assertNotIn("local_settings_example.py", workflow)
         self.assertNotIn("Materialize CI local_settings", workflow)
 

--- a/tests/test_deploy_scripts.py
+++ b/tests/test_deploy_scripts.py
@@ -1022,6 +1022,39 @@ class ApplyReleaseConfigTests(unittest.TestCase):
 
 
 class RestartScriptTests(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.test_root = Path(self.temp_dir.name)
+
+    def run_restart_functions(self, arguments, *, run_selection=False):
+        fake_bin = self.test_root / "bin"
+        fake_bin.mkdir(exist_ok=True)
+        command_log = self.test_root / "commands.log"
+        git = fake_bin / "git"
+        git.write_text('#!/bin/sh\nprintf \'%s\\n\' "git $*" >> "$FAKE_COMMAND_LOG"\n')
+        git.chmod(git.stat().st_mode | stat.S_IXUSR)
+        env = os.environ.copy()
+        env.update(
+            {
+                "FAKE_COMMAND_LOG": str(command_log),
+                "PATH": f"{fake_bin}:{env['PATH']}",
+            }
+        )
+        command = 'source "$1"; shift; parse_restart_args "$@"'
+        if run_selection:
+            command += "; select_release"
+        result = subprocess.run(
+            ["bash", "-c", command, "restart-test", str(RESTART_SCRIPT), *arguments],
+            cwd=PROJECT_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        commands = command_log.read_text().splitlines() if command_log.exists() else []
+        return result, commands
+
     def test_restart_installs_and_starts_every_application_unit(self):
         script = RESTART_SCRIPT.read_text()
         units = "mediacms celery_long celery_short celery_whisper celery_email celery_beat"
@@ -1039,11 +1072,29 @@ class RestartScriptTests(unittest.TestCase):
         self.assertIn(f"systemctl restart {units}", script)
 
     def test_restart_can_deploy_an_exact_revision(self):
-        script = RESTART_SCRIPT.read_text()
+        revision = "a" * 40
 
-        self.assertIn("--revision requires a full 40-character lowercase commit SHA", script)
-        self.assertIn('git fetch origin "$DEPLOY_REVISION"', script)
-        self.assertIn('git merge --ff-only "$DEPLOY_REVISION"', script)
+        result, commands = self.run_restart_functions(["--revision", revision], run_selection=True)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(commands, [f"git fetch origin {revision}", f"git merge --ff-only {revision}"])
+
+    def test_restart_rejects_invalid_revision(self):
+        result, commands = self.run_restart_functions(["--revision", "not-a-commit"])
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("full 40-character lowercase commit SHA", result.stderr)
+        self.assertEqual(commands, [])
+
+    def test_restart_rejects_trailing_arguments_for_each_mode(self):
+        revision = "a" * 40
+
+        for arguments in (["--no-pull", "extra"], ["--revision", revision, "extra"]):
+            with self.subTest(arguments=arguments):
+                result, commands = self.run_restart_functions(arguments)
+
+                self.assertEqual(result.returncode, 2)
+                self.assertEqual(commands, [])
 
     def test_deployer_uses_the_authorized_restart_boundary(self):
         workflow = CI_WORKFLOW.read_text()


### PR DESCRIPTION
## Description

Fix the development deployment job after the runtime environment migration in #911.

The job used `sudo git` and `sudo env`, but the `github-deploy` account only has passwordless sudo access to `/home/cinemata/cinematacms/restart_script.sh`. The job now delegates the deployment to that authorized script.

`restart_script.sh --revision COMMIT_SHA` fetches and fast-forwards to the exact GitHub commit before it applies the runtime configuration, builds assets, runs migrations, and restarts services. The workflow falls back to the existing no-argument script once so the development server can install this hotfix. Later deployments use the revision argument.

## Related Issue

Follow-up to #580 and #911.

## Motivation and Context

The first deployment after #911 updated the development checkout but failed before it created `/etc/cinematacms/app.env`. Sudo requested a password for a command outside the account's allowlist.

The environment migration was run manually on the development server. Both health endpoints now return HTTP 200, and the application services load `/etc/cinematacms/app.env`.

## How Has This Been Tested?

- `bash -n restart_script.sh`
- `uv run python -m unittest tests.test_deploy_scripts.RestartScriptTests`
- `make agent-check`
- Confirmed on `cinemata-dev` that `github-deploy` has passwordless sudo access only to `restart_script.sh`.
- Confirmed `/etc/cinematacms/app.env` is owned by `root:root`, has mode `640`, and contains no duplicate keys.
- Confirmed `mediacms`, `celery_long`, `celery_short`, `celery_beat`, and `celery_email` are active.
- Confirmed `/health/live` and `/health/ready` return HTTP 200 over the configured HTTPS host.
- Confirmed `python manage.py check` reports no issues.

## Screenshots (if appropriate):

Not applicable.

## AI assistance

- [x] This contribution includes substantive AI assistance.
- [ ] This contribution does not include substantive AI assistance.

### AI tools and use

Codex diagnosed the failed deployment, checked the development server's sudo policy, implemented the workflow and script changes, added regression coverage, and ran the verification commands.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Modern Track Checklist (for new features):

- [ ] I have not imported `flux` in a new component
- [ ] If adding a new feature, I used Modern Track patterns
- [ ] New features do not create new SCSS files (use Tailwind instead)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Deployments can target an exact code revision for more predictable releases.
  * Revision values and unsupported deployment options are now validated before deployment proceeds.
  * Deployment now consistently uses the approved restart process, with fallback support for environments that do not support revision targeting.
  * Automated checks were expanded to verify revision-based deployments and prevent unintended server-side update commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->